### PR TITLE
Don't overescape

### DIFF
--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -20,6 +20,10 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-storage</artifactId>
     </dependency>
@@ -74,10 +78,6 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
     </dependency>
     <dependency>
       <groupId>org.threeten</groupId>

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/SignatureInfo.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/SignatureInfo.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.storage;
 
-import static com.google.cloud.storage.SignedUrlEncodingHelper.Rfc3986UriEncode;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.collect.ImmutableList;
@@ -191,7 +190,8 @@ public class SignatureInfo {
       if (!RESERVED_PARAMS_LOWER.contains(entry.getKey().toLowerCase())) {
         // URI encode user-supplied parameter, both the name and the value.
         sortedParamMap.put(
-            Rfc3986UriEncode(entry.getKey(), true), Rfc3986UriEncode(entry.getValue(), true));
+            SignedUrlEncodingHelper.encodeForQueryString(entry.getKey(), true),
+            SignedUrlEncodingHelper.encodeForQueryString(entry.getValue(), true));
       }
     }
 
@@ -237,16 +237,21 @@ public class SignatureInfo {
     TreeMap<String, String> sortedParamMap = getNonReservedUserQueryParams();
 
     // Add in the reserved auth-specific query params.
-    sortedParamMap.put("X-Goog-Algorithm", Rfc3986UriEncode(GOOG4_RSA_SHA256, true));
+    sortedParamMap.put("X-Goog-Algorithm",
+        SignedUrlEncodingHelper.encodeForQueryString(GOOG4_RSA_SHA256, true));
     sortedParamMap.put(
-        "X-Goog-Credential", Rfc3986UriEncode(accountEmail + "/" + yearMonthDay + SCOPE, true));
-    sortedParamMap.put("X-Goog-Date", Rfc3986UriEncode(exactDate, true));
-    sortedParamMap.put("X-Goog-Expires", Rfc3986UriEncode(Long.toString(expiration), true));
+        "X-Goog-Credential", 
+        SignedUrlEncodingHelper.encodeForQueryString(accountEmail + "/" + yearMonthDay + SCOPE, true));
+    sortedParamMap.put(
+        "X-Goog-Date", SignedUrlEncodingHelper.encodeForQueryString(exactDate, true));
+    sortedParamMap.put(
+        "X-Goog-Expires",
+        SignedUrlEncodingHelper.encodeForQueryString(Long.toString(expiration), true));
     StringBuilder signedHeadersBuilder =
         new CanonicalExtensionHeadersSerializer(Storage.SignUrlOption.SignatureVersion.V4)
             .serializeHeaderNames(canonicalizedExtensionHeaders);
-    sortedParamMap.put(
-        "X-Goog-SignedHeaders", Rfc3986UriEncode(signedHeadersBuilder.toString(), true));
+    sortedParamMap.put("X-Goog-SignedHeaders",
+        SignedUrlEncodingHelper.encodeForQueryString(signedHeadersBuilder.toString(), true));
 
     // The "X-Goog-Signature" param is not included here.
     return queryStringFromParamMap(sortedParamMap);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/SignatureInfo.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/SignatureInfo.java
@@ -238,20 +238,20 @@ public class SignatureInfo {
 
     // Add in the reserved auth-specific query params.
     sortedParamMap.put("X-Goog-Algorithm",
-        SignedUrlEncodingHelper.encodeForQueryString(GOOG4_RSA_SHA256, true));
+        SignedUrlEncodingHelper.Rfc3986UriEncode(GOOG4_RSA_SHA256, true));
     sortedParamMap.put(
         "X-Goog-Credential", 
-        SignedUrlEncodingHelper.encodeForQueryString(accountEmail + "/" + yearMonthDay + SCOPE, true));
+        SignedUrlEncodingHelper.Rfc3986UriEncode(accountEmail + "/" + yearMonthDay + SCOPE, true));
     sortedParamMap.put(
-        "X-Goog-Date", SignedUrlEncodingHelper.encodeForQueryString(exactDate, true));
+        "X-Goog-Date", SignedUrlEncodingHelper.Rfc3986UriEncode(exactDate, true));
     sortedParamMap.put(
         "X-Goog-Expires",
-        SignedUrlEncodingHelper.encodeForQueryString(Long.toString(expiration), true));
+        SignedUrlEncodingHelper.Rfc3986UriEncode(Long.toString(expiration), true));
     StringBuilder signedHeadersBuilder =
         new CanonicalExtensionHeadersSerializer(Storage.SignUrlOption.SignatureVersion.V4)
             .serializeHeaderNames(canonicalizedExtensionHeaders);
     sortedParamMap.put("X-Goog-SignedHeaders",
-        SignedUrlEncodingHelper.encodeForQueryString(signedHeadersBuilder.toString(), true));
+        SignedUrlEncodingHelper.Rfc3986UriEncode(signedHeadersBuilder.toString(), true));
 
     // The "X-Goog-Signature" param is not included here.
     return queryStringFromParamMap(sortedParamMap);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/SignatureInfo.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/SignatureInfo.java
@@ -187,6 +187,7 @@ public class SignatureInfo {
       // Convert to (and check for the existence of) lowercase keys to prevent cases like a user
       // supplying "x-goog-algorithm", in order to prevent the resulting query string from
       // containing "x-goog-algorithm" and "X-Goog-Algorithm".
+      // todo this is broken. It depends on locale.
       if (!RESERVED_PARAMS_LOWER.contains(entry.getKey().toLowerCase())) {
         // URI encode user-supplied parameter, both the name and the value.
         sortedParamMap.put(

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/SignedUrlEncodingHelper.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/SignedUrlEncodingHelper.java
@@ -16,28 +16,27 @@
 
 package com.google.cloud.storage;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
+import com.google.api.client.util.escape.PercentEscaper;
 
 /** Helper for encoding URI segments appropriately when creating a Signed URL. */
 class SignedUrlEncodingHelper {
 
-  static String Rfc3986UriEncode(final String segment, final boolean encodeForwardSlash) {
-    String encodedSegment;
-    try {
-      encodedSegment = URLEncoder.encode(segment, "UTF-8");
-    } catch (UnsupportedEncodingException exception) {
-      throw new RuntimeException(exception);
+  private static final PercentEscaper PATH_ENCODER =
+      new PercentEscaper(PercentEscaper.SAFEPATHCHARS_URLENCODER, false);
+
+  private static final PercentEscaper QUERY_ENCODER =
+      new PercentEscaper(PercentEscaper.SAFEQUERYSTRINGCHARS_URLENCODER, false);
+
+  static String encodeForPath(String segment, boolean encodeForwardSlash) {
+    String encodedSegment = PATH_ENCODER.escape(segment);
+    if (!encodeForwardSlash) {
+      encodedSegment = encodedSegment.replace("%2F", "/");
     }
-    // URLEncoder.encode() does mostly what we want, with the exception of a few characters that
-    // we fix in a second phase:
-    encodedSegment =
-        encodedSegment
-            .replace("*", "%2A") // Asterisks should be encoded.
-            .replace("+", "%20") // Spaces should be encoded as %20 instead of a plus sign.
-            .replace("%7E", "~"); // Tildes should not be encoded.
-    // Forward slashes should NOT be encoded in the segment of the URI that represents the
-    // object's name, but should be encoded for all other segments.
+    return encodedSegment;
+  }
+  
+  static String encodeForQueryString(String segment, boolean encodeForwardSlash) {
+    String encodedSegment = QUERY_ENCODER.escape(segment);
     if (!encodeForwardSlash) {
       encodedSegment = encodedSegment.replace("%2F", "/");
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/SignedUrlEncodingHelper.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/SignedUrlEncodingHelper.java
@@ -25,7 +25,8 @@ class SignedUrlEncodingHelper {
 
   /**
    * @deprecated use the escaper designed for the specific part of the URL you're
-   *     escaping. 
+   *     escaping. Different parts of the URL have different reserved and unreserved
+   *     characters.
    */
   @Deprecated
   static String Rfc3986UriEncode(String segment, boolean encodeForwardSlash) {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
@@ -19,7 +19,7 @@ package com.google.cloud.storage;
 import static com.google.cloud.RetryHelper.runWithRetries;
 import static com.google.cloud.storage.PolicyHelper.convertFromApiPolicy;
 import static com.google.cloud.storage.PolicyHelper.convertToApiPolicy;
-import static com.google.cloud.storage.SignedUrlEncodingHelper.Rfc3986UriEncode;
+import static com.google.cloud.storage.SignedUrlEncodingHelper.encodeForPath;
 import static com.google.cloud.storage.spi.v1.StorageRpc.Option.DELIMITER;
 import static com.google.cloud.storage.spi.v1.StorageRpc.Option.IF_GENERATION_MATCH;
 import static com.google.cloud.storage.spi.v1.StorageRpc.Option.IF_GENERATION_NOT_MATCH;
@@ -666,7 +666,7 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
     String bucketName = slashlessBucketNameFromBlobInfo(blobInfo);
     String escapedBlobName = "";
     if (!Strings.isNullOrEmpty(blobInfo.getName())) {
-      escapedBlobName = Rfc3986UriEncode(blobInfo.getName(), false);
+      escapedBlobName = encodeForPath(blobInfo.getName(), false);
     }
 
     boolean usePathStyle = shouldUsePathStyleForSignedUrl(optionMap);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
@@ -19,7 +19,6 @@ package com.google.cloud.storage;
 import static com.google.cloud.RetryHelper.runWithRetries;
 import static com.google.cloud.storage.PolicyHelper.convertFromApiPolicy;
 import static com.google.cloud.storage.PolicyHelper.convertToApiPolicy;
-import static com.google.cloud.storage.SignedUrlEncodingHelper.encodeForPath;
 import static com.google.cloud.storage.spi.v1.StorageRpc.Option.DELIMITER;
 import static com.google.cloud.storage.spi.v1.StorageRpc.Option.IF_GENERATION_MATCH;
 import static com.google.cloud.storage.spi.v1.StorageRpc.Option.IF_GENERATION_NOT_MATCH;
@@ -91,14 +90,6 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
   private static final String STORAGE_XML_URI_SCHEME = "https";
 
   private static final String STORAGE_XML_URI_HOST_NAME = "storage.googleapis.com";
-
-  private static final Function<Tuple<Storage, Boolean>, Boolean> DELETE_FUNCTION =
-      new Function<Tuple<Storage, Boolean>, Boolean>() {
-        @Override
-        public Boolean apply(Tuple<Storage, Boolean> tuple) {
-          return tuple.y();
-        }
-      };
 
   private final StorageRpc storageRpc;
 
@@ -666,7 +657,7 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
     String bucketName = slashlessBucketNameFromBlobInfo(blobInfo);
     String escapedBlobName = "";
     if (!Strings.isNullOrEmpty(blobInfo.getName())) {
-      escapedBlobName = encodeForPath(blobInfo.getName(), false);
+      escapedBlobName = SignedUrlEncodingHelper.Rfc3986UriEncode(blobInfo.getName(), false);
     }
 
     boolean usePathStyle = shouldUsePathStyleForSignedUrl(optionMap);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/SignatureInfoTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/SignatureInfoTest.java
@@ -94,8 +94,8 @@ public class SignatureInfoTest {
 
     String queryString = builder.build().constructV4QueryString();
     assertEquals(
-        "X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=me%40google.com%2F20010909%2F"
-            + "auto%2Fstorage%2Fgoog4_request&X-Goog-Date=20010909T014640Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host",
+        "X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=me@google.com/20010909/"
+            + "auto/storage/goog4_request&X-Goog-Date=20010909T014640Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host",
         queryString);
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/SignatureInfoTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/SignatureInfoTest.java
@@ -94,8 +94,8 @@ public class SignatureInfoTest {
 
     String queryString = builder.build().constructV4QueryString();
     assertEquals(
-        "X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=me@google.com/20010909/"
-            + "auto/storage/goog4_request&X-Goog-Date=20010909T014640Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host",
+        "X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=me%40google.com%2F20010909%2F"
+            + "auto%2Fstorage%2Fgoog4_request&X-Goog-Date=20010909T014640Z&X-Goog-Expires=10&X-Goog-SignedHeaders=host",
         queryString);
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageImplTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageImplTest.java
@@ -86,6 +86,7 @@ import javax.crypto.spec.SecretKeySpec;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -381,7 +382,7 @@ public class StorageImplTest {
   private StorageRpc storageRpcMock;
   private Storage storage;
 
-  private Blob expectedBlob1, expectedBlob2, expectedBlob3;
+  private Blob expectedBlob1, expectedBlob2;
   private Bucket expectedBucket1, expectedBucket2, expectedBucket3;
 
   @Rule public ExpectedException thrown = ExpectedException.none();
@@ -426,7 +427,6 @@ public class StorageImplTest {
   private void initializeServiceDependentObjects() {
     expectedBlob1 = new Blob(storage, new BlobInfo.BuilderImpl(BLOB_INFO1));
     expectedBlob2 = new Blob(storage, new BlobInfo.BuilderImpl(BLOB_INFO2));
-    expectedBlob3 = new Blob(storage, new BlobInfo.BuilderImpl(BLOB_INFO3));
     expectedBucket1 = new Bucket(storage, new BucketInfo.BuilderImpl(BUCKET_INFO1));
     expectedBucket2 = new Bucket(storage, new BucketInfo.BuilderImpl(BUCKET_INFO2));
     expectedBucket3 = new Bucket(storage, new BucketInfo.BuilderImpl(BUCKET_INFO3));
@@ -2332,7 +2332,7 @@ public class StorageImplTest {
     storage = options.toBuilder().setCredentials(credentials).build().getService();
 
     String dispositionNotEncoded = "attachment; filename=\"" + BLOB_NAME1 + "\"";
-    String dispositionEncoded = "attachment%3B%20filename%3D%22" + BLOB_NAME1 + "%22";
+    String dispositionEncoded = "attachment;%20filename%3D%22" + BLOB_NAME1 + "%22";
     URL url =
         storage.signUrl(
             BLOB_INFO1,
@@ -2361,7 +2361,8 @@ public class StorageImplTest {
             .append(42L + 1209600)
             .append("&Signature=")
             .toString();
-    assertTrue(stringUrl.startsWith(expectedPrefix));
+    assertTrue(stringUrl + "does not start with " + expectedPrefix,
+        stringUrl.startsWith(expectedPrefix));
     String signature = stringUrl.substring(expectedPrefix.length());
 
     StringBuilder signedMessageBuilder = new StringBuilder();
@@ -2400,7 +2401,7 @@ public class StorageImplTest {
     storage = options.toBuilder().setCredentials(credentials).build().getService();
 
     String dispositionNotEncoded = "attachment; filename=\"" + BLOB_NAME1 + "\"";
-    String dispositionEncoded = "attachment%3B%20filename%3D%22" + BLOB_NAME1 + "%22";
+    String dispositionEncoded = "attachment;%20filename%3D%22" + BLOB_NAME1 + "%22";
     URL url =
         storage.signUrl(
             BLOB_INFO1,
@@ -2442,7 +2443,9 @@ public class StorageImplTest {
     assertTrue(restOfUrl, matcher.matches());
 
     // Make sure query param was encoded properly.
-    assertNotEquals(-1, restOfUrl.indexOf("&response-content-disposition=" + dispositionEncoded));
+    String expected = "&response-content-disposition=" + dispositionEncoded;
+    Assert.assertTrue(restOfUrl + " does not contain " + expected,
+        restOfUrl.contains(expected));
   }
 
   @Test

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageImplTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageImplTest.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.storage;
 
-import static com.google.cloud.storage.SignedUrlEncodingHelper.Rfc3986UriEncode;
+import static com.google.cloud.storage.SignedUrlEncodingHelper.encodeForPath;
 import static com.google.cloud.storage.testing.ApiPolicyMatcher.eqApiPolicy;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertArrayEquals;
@@ -1852,7 +1852,7 @@ public class StorageImplTest {
             14,
             TimeUnit.DAYS,
             Storage.SignUrlOption.withHostName("https://example.com"));
-    String escapedBlobName = Rfc3986UriEncode(blobName, false);
+    String escapedBlobName = encodeForPath(blobName, false);
     String stringUrl = url.toString();
     String expectedUrl =
         new StringBuilder("https://example.com/")
@@ -2238,7 +2238,7 @@ public class StorageImplTest {
     String blobName = "/foo/bar/baz #%20other cool stuff.txt";
     URL url =
         storage.signUrl(BlobInfo.newBuilder(BUCKET_NAME1, blobName).build(), 14, TimeUnit.DAYS);
-    String escapedBlobName = Rfc3986UriEncode(blobName, false);
+    String escapedBlobName = encodeForPath(blobName, false);
     String stringUrl = url.toString();
     String expectedUrl =
         new StringBuilder("https://storage.googleapis.com/")
@@ -2288,7 +2288,7 @@ public class StorageImplTest {
             14,
             TimeUnit.DAYS,
             Storage.SignUrlOption.withHostName("https://example.com"));
-    String escapedBlobName = Rfc3986UriEncode(blobName, false);
+    String escapedBlobName = encodeForPath(blobName, false);
     String stringUrl = url.toString();
     String expectedUrl =
         new StringBuilder("https://example.com/")

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/V4SigningTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/V4SigningTest.java
@@ -126,7 +126,7 @@ public class V4SigningTest {
             .toString();
     assertEquals(new URL(testData.getExpectedUrl()), new URL(signedUrl));
     // If the previous assert passed and this one fails, then the URLs are
-    // not properly caonicalized.
+    // not properly canonicalized.
     assertEquals("URLs are not strings and should not be compared as such",
         testData.getExpectedUrl(), signedUrl);
   }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/V4SigningTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/V4SigningTest.java
@@ -56,17 +56,19 @@ public class V4SigningTest {
   private static class FakeClock implements ApiClock {
     private final AtomicLong currentNanoTime;
 
-    public FakeClock(Timestamp timestamp) {
+    FakeClock(Timestamp timestamp) {
       this.currentNanoTime =
           new AtomicLong(
               TimeUnit.NANOSECONDS.convert(timestamp.getSeconds(), TimeUnit.SECONDS)
                   + timestamp.getNanos());
     }
 
+    @Override
     public long nanoTime() {
       return this.currentNanoTime.get();
     }
 
+    @Override
     public long millisTime() {
       return TimeUnit.MILLISECONDS.convert(this.nanoTime(), TimeUnit.NANOSECONDS);
     }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/V4SigningTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/V4SigningTest.java
@@ -34,6 +34,8 @@ import com.google.protobuf.util.JsonFormat;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -95,7 +97,7 @@ public class V4SigningTest {
   }
 
   @Test
-  public void test() {
+  public void test() throws MalformedURLException {
     assumeThat(
         "Test skipped until b/136171758 is resolved",
         testName.getMethodName(),
@@ -122,7 +124,11 @@ public class V4SigningTest {
                 SignUrlOption.withExtHeaders(testData.getHeadersMap()),
                 SignUrlOption.withV4Signature())
             .toString();
-    assertEquals(testData.getExpectedUrl(), signedUrl);
+    assertEquals(new URL(testData.getExpectedUrl()), new URL(signedUrl));
+    // If the previous assert passed and this one fails, then the URLs are
+    // not properly caonicalized.
+    assertEquals("URLs are not strings and should not be compared as such",
+        testData.getExpectedUrl(), signedUrl);
   }
 
   /**

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/V4SigningTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/V4SigningTest.java
@@ -109,7 +109,7 @@ public class V4SigningTest {
 
     BlobInfo blob = BlobInfo.newBuilder(testData.getBucket(), testData.getObject()).build();
 
-    final String signedUrl =
+    String signedUrl =
         storage
             .signUrl(
                 blob,

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>28.2-android</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-bom</artifactId>
         <version>1.34.0</version>
@@ -112,7 +117,7 @@
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-bom</artifactId>
-        <version>1.52.0</version>
+        <version>1.53.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -127,11 +132,6 @@
         <groupId>com.google.apis</groupId>
         <artifactId>google-api-services-storage</artifactId>
         <version>v1-rev20191011-1.30.3</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>28.1-android</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-conformance-tests</artifactId>
-        <version>0.0.3</version>
+        <version>0.0.4</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
Fixes #57 To the extent the conformance tests allow, don't escape characters that don't need to be escaped. Deprecate the method that overescapes.

This should produce spec-compliant, canonically equivalent URLs. However do consider whether there's something on the server side or elsewhere that might cause signatures to no longer match. It depends on when, why, and how the signatures are calculated. 

It might be worthwhile to break this PR up into smaller steps, but this is where we're heading.

@frankyn 