### PR TITLE
add disableGzipContent option for create from InputStream

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
@@ -567,7 +567,8 @@ public interface Storage extends Service<StorageOptions> {
       IF_CRC32C_MATCH,
       CUSTOMER_SUPPLIED_KEY,
       KMS_KEY_NAME,
-      USER_PROJECT;
+      USER_PROJECT,
+      IF_DISABLE_GZIP_CONTENT;
 
       StorageRpc.Option toRpcOption() {
         return StorageRpc.Option.valueOf(this.name());
@@ -698,6 +699,14 @@ public interface Storage extends Service<StorageOptions> {
      */
     public static BlobWriteOption userProject(String userProject) {
       return new BlobWriteOption(Option.USER_PROJECT, userProject);
+    }
+
+    /**
+     * Returns an option that signals automatic gzip compression should not be performed en route to
+     * the bucket.
+     */
+    public static BlobWriteOption disableGzipContent() {
+      return new BlobWriteOption(Option.IF_DISABLE_GZIP_CONTENT, true);
     }
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageImplTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageImplTest.java
@@ -742,6 +742,33 @@ public class StorageImplTest {
   }
 
   @Test
+  public void testCreateBlobFromStreamDisableGzipContent() throws IOException {
+    Capture<ByteArrayInputStream> capturedStream = Capture.newInstance();
+
+    ByteArrayInputStream fileStream = new ByteArrayInputStream(BLOB_CONTENT);
+    BlobInfo.Builder infoBuilder = BLOB_INFO1.toBuilder();
+    BlobInfo infoWithHashes = infoBuilder.setMd5(CONTENT_MD5).setCrc32c(CONTENT_CRC32C).build();
+    BlobInfo infoWithoutHashes = infoBuilder.setMd5(null).setCrc32c(null).build();
+    EasyMock.expect(
+            storageRpcMock.create(
+                EasyMock.eq(infoWithoutHashes.toPb()),
+                EasyMock.capture(capturedStream),
+                EasyMock.eq(BLOB_TARGET_OPTIONS_CREATE_DISABLE_GZIP_CONTENT)))
+        .andReturn(BLOB_INFO1.toPb());
+    EasyMock.replay(storageRpcMock);
+    initializeService();
+
+    Blob blob = storage.create(infoWithHashes, fileStream, BlobWriteOption.disableGzipContent());
+
+    assertEquals(expectedBlob1, blob);
+    ByteArrayInputStream byteStream = capturedStream.getValue();
+    byte[] streamBytes = new byte[BLOB_CONTENT.length];
+    assertEquals(BLOB_CONTENT.length, byteStream.read(streamBytes));
+    assertArrayEquals(BLOB_CONTENT, streamBytes);
+    assertEquals(-1, byteStream.read(streamBytes));
+  }
+
+  @Test
   public void testCreateBlobFromStreamWithEncryptionKey() throws IOException {
     ByteArrayInputStream fileStream = new ByteArrayInputStream(BLOB_CONTENT);
     BlobInfo.Builder infoBuilder = BLOB_INFO1.toBuilder();

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageTest.java
@@ -69,6 +69,7 @@ import com.google.cloud.storage.HttpMethod;
 import com.google.cloud.storage.ServiceAccount;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BlobField;
+import com.google.cloud.storage.Storage.BlobWriteOption;
 import com.google.cloud.storage.Storage.BucketField;
 import com.google.cloud.storage.StorageBatch;
 import com.google.cloud.storage.StorageBatchResult;
@@ -589,6 +590,20 @@ public class ITStorageTest {
     BlobInfo blob = BlobInfo.newBuilder(BUCKET, blobName).setContentType(CONTENT_TYPE).build();
     ByteArrayInputStream stream = new ByteArrayInputStream(BLOB_STRING_CONTENT.getBytes(UTF_8));
     Blob remoteBlob = storage.create(blob, stream);
+    assertNotNull(remoteBlob);
+    assertEquals(blob.getBucket(), remoteBlob.getBucket());
+    assertEquals(blob.getName(), remoteBlob.getName());
+    assertEquals(blob.getContentType(), remoteBlob.getContentType());
+    byte[] readBytes = storage.readAllBytes(BUCKET, blobName);
+    assertEquals(BLOB_STRING_CONTENT, new String(readBytes, UTF_8));
+  }
+
+  @Test
+  public void testCreateBlobStreamDisableGzipContent() {
+    String blobName = "test-create-blob-stream-disable-gzip-compression";
+    BlobInfo blob = BlobInfo.newBuilder(BUCKET, blobName).setContentType(CONTENT_TYPE).build();
+    ByteArrayInputStream stream = new ByteArrayInputStream(BLOB_STRING_CONTENT.getBytes(UTF_8));
+    Blob remoteBlob = storage.create(blob, stream, BlobWriteOption.disableGzipContent());
     assertNotNull(remoteBlob);
     assertEquals(blob.getBucket(), remoteBlob.getBucket());
     assertEquals(blob.getName(), remoteBlob.getName());


### PR DESCRIPTION
 **Is your feature request related to a problem? Please describe.**

I have a use case that necessitates using the Storage/Bucket write method variants with InputStream arguments. The inputs for my use case to store in Cloud Storage are:

* predominantly already compressed,
* have a wide range of file sizes, from a few KB to GB+,
* we don't always know the size in advance.

 **Describe the solution you'd like**

Given that our content is already compressed, I would prefer to avoid spending the CPU time on compressing the content again en route to the Bucket.

 **Describe alternatives you've considered**

We have used the `byte[]` variants, with `BlobTargetOption.disableGzipContent` and the Compose request. This is suitable but leaves us with a tuning challenge:

* Buffering these streams into memory (`byte[]` chunks) requires additional heap space be available
* Compose is limited to only 32 chunks. If the file content we intend to store is far larger than `32 * bufferSize`, we will upload 31 small sized chunks and 1 large chunk that we have to use the `InputStream` variant for anyways, and pay the additional overhead of gzip compression.

 **Additional context**

I have done some exploration and it appears that the values on the BlobWriteOption (used on `InputStream` variants) and BlobTargetOption (used on `byte[]` variants) enums both are translated into `StorageRpc.Option`. I have a small contribution to offer in the form of a pull request to follow.

Fixes #36; ported from https://github.com/googleapis/google-cloud-java/pull/7057