### PR TITLE
Update HTTP client

### DIFF
--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -24,8 +24,17 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
+      <version>1.30.7</version>
     </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>
@@ -42,14 +51,6 @@
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client-jackson2</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>

--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -20,6 +20,10 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-storage</artifactId>
     </dependency>
@@ -74,10 +78,6 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
     </dependency>
     <dependency>
       <groupId>org.threeten</groupId>

--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -165,11 +165,6 @@
       <artifactId>google-cloud-conformance-tests</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -166,6 +166,12 @@
       <artifactId>google-cloud-conformance-tests</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.11</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-bom</artifactId>
-        <version>1.52.0</version>
+        <version>1.53.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -131,7 +131,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>28.1-android</version>
+        <version>28.2-android</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -87,13 +87,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>com.google.api-client</groupId>
-        <artifactId>google-api-client</artifactId>
-        <version>1.30.7</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-core-bom</artifactId>
         <version>${google.core.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-bom</artifactId>
-        <version>1.34.0</version>
+        <version>1.34.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -132,11 +132,6 @@
         <groupId>com.google.apis</groupId>
         <artifactId>google-api-services-storage</artifactId>
         <version>v1-rev20191011-1.30.3</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>28.2-android</version>
       </dependency>
       <dependency>
         <groupId>org.checkerframework</groupId>


### PR DESCRIPTION
@suztomo

[WARNING] Rule 2: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for org.apache.httpcomponents:httpclient:4.5.10 paths to dependency are:
+-com.google.cloud:google-cloud-storage:1.103.1
  +-com.google.http-client:google-http-client:1.34.1
    +-org.apache.httpcomponents:httpclient:4.5.10 (managed) <-- org.apache.httpcomponents:httpclient:4.5.11
]
