### PR TITLE
fix: mismatch chunksize

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BlobWriteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BlobWriteChannelTest.java
@@ -59,7 +59,7 @@ public class BlobWriteChannelTest {
   private static final BlobInfo BLOB_INFO = BlobInfo.newBuilder(BUCKET_NAME, BLOB_NAME).build();
   private static final Map<StorageRpc.Option, ?> EMPTY_RPC_OPTIONS = ImmutableMap.of();
   private static final int MIN_CHUNK_SIZE = 256 * 1024;
-  private static final int DEFAULT_CHUNK_SIZE = 8 * MIN_CHUNK_SIZE;
+  private static final int DEFAULT_CHUNK_SIZE = 60 * MIN_CHUNK_SIZE; // 15MiB
   private static final int CUSTOM_CHUNK_SIZE = 4 * MIN_CHUNK_SIZE;
   private static final Random RANDOM = new Random();
   private static final String SIGNED_URL =

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <github.global.server>github</github.global.server>
     <site.installationModule>google-cloud-storage-parent</site.installationModule>
-    <google.core.version>1.91.3</google.core.version>
+    <google.core.version>1.92.5</google.core.version>
     <google.api-common.version>1.8.1</google.api-common.version>
     <junit.version>4.13</junit.version>
     <threeten.version>1.4.1</threeten.version>
@@ -103,7 +103,7 @@
       <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-bom</artifactId>
-        <version>1.27.0</version>
+        <version>1.27.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
The default chunk size was increased in https://github.com/googleapis/java-core/pull/87 and was not updated in java-storage unit tests.

This is a quick patch to unblock releasing changes needed to fix: #57 

@elharo, thank you for your patience.