### PR TITLE
docs: clarify documentation on date formats.

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobInfo.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobInfo.java
@@ -795,17 +795,26 @@ public class BlobInfo implements Serializable {
     return metageneration;
   }
 
-  /** Returns the deletion time of the blob. */
+  /**
+   * Returns the deletion time of the blob expressed as the number of milliseconds since the Unix
+   * epoch.
+   */
   public Long getDeleteTime() {
     return deleteTime;
   }
 
-  /** Returns the last modification time of the blob's metadata. */
+  /**
+   * Returns the last modification time of the blob's metadata expressed as the number of
+   * milliseconds since the Unix epoch.
+   */
   public Long getUpdateTime() {
     return updateTime;
   }
 
-  /** Returns the creation time of the blob. */
+  /**
+   * Returns the creation time of the blob expressed as the number of milliseconds since the Unix
+   * epoch.
+   */
   public Long getCreateTime() {
     return createTime;
   }


### PR DESCRIPTION
I added the following code:

System.out.printf("Blob updatetime: %s", blob.getUpdateTime());

The output was

Blob updatetime: 1582157090238

I verified that this was ms after epoch:

$ date -d @1582157090
Wed 19 Feb 2020 04:04:50 PM PST

I also traced the code to this function:

https://github.com/googleapis/google-http-java-client/blob/master/google-http-client/src/main/java/com/google/api/client/util/DateTime.java#L53

I assumed that create and delete times used the same format.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️
