### PR TITLE
fix: storage-client-lib-docs to right location

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,4 +245,4 @@ Apache 2.0 - See [LICENSE] for more information.
 [cloud-storage-create-bucket]: https://cloud.google.com/storage/docs/cloud-console#_creatingbuckets
 [cloud-storage-activation]:https://cloud.google.com/storage/docs/signup?hl=en
 [storage-product-docs]: https://cloud.google.com/storage/docs/
-[storage-client-lib-docs]: https://googleapis.dev/java/google-cloud-clients/latest/index.html?com/google/cloud/storage/package-summary.html
+[storage-client-lib-docs]: https://googleapis.dev/java/google-cloud-storage/latest/index.html


### PR DESCRIPTION
Fixes: #212 