### PR TITLE
chore: generate README from templates

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -1,0 +1,114 @@
+custom_content: |
+  #### Creating an authorized service object
+
+  To make authenticated requests to Google Cloud Storage, you must create a service object with credentials. You can
+  then make API calls by calling methods on the Storage service object. The simplest way to authenticate is to use
+  [Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials).
+  These credentials are automatically inferred from your environment, so you only need the following code to create your
+  service object:
+
+  ```java
+  import com.google.cloud.storage.Storage;
+  import com.google.cloud.storage.StorageOptions;
+
+  Storage storage = StorageOptions.getDefaultInstance().getService();
+  ```
+
+  For other authentication options, see the [Authentication](https://github.com/googleapis/google-cloud-java#authentication) page.
+
+  #### Storing data
+  Stored objects are called "blobs" in `google-cloud` and are organized into containers called "buckets".  `Blob`, a
+  subclass of `BlobInfo`, adds a layer of service-related functionality over `BlobInfo`.  Similarly, `Bucket` adds a
+  layer of service-related functionality over `BucketInfo`.  In this code snippet, we will create a new bucket and
+  upload a blob to that bucket.
+
+  Add the following imports at the top of your file:
+
+  ```java
+  import static java.nio.charset.StandardCharsets.UTF_8;
+
+  import com.google.cloud.storage.Blob;
+  import com.google.cloud.storage.Bucket;
+  import com.google.cloud.storage.BucketInfo;
+  ```
+
+  Then add the following code to create a bucket and upload a simple blob.
+
+  *Important: Bucket names have to be globally unique (among all users of Cloud Storage). If you choose a bucket name
+  that already exists, you'll get a helpful error message telling you to choose another name. In the code below, replace
+  "my_unique_bucket" with a unique bucket name. See more about naming rules
+  [here](https://cloud.google.com/storage/docs/bucket-naming?hl=en#requirements).*
+
+  ```java
+  // Create a bucket
+  String bucketName = "my_unique_bucket"; // Change this to something unique
+  Bucket bucket = storage.create(BucketInfo.of(bucketName));
+
+  // Upload a blob to the newly created bucket
+  BlobId blobId = BlobId.of(bucketName, "my_blob_name");
+  BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("text/plain").build();
+  Blob blob = storage.create(blobInfo, "a simple blob".getBytes(UTF_8));
+  ```
+
+  A complete example for creating a blob can be found at
+  [CreateBlob.java](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/storage/snippets/CreateBlob.java).
+
+  At this point, you will be able to see your newly created bucket and blob on the Google Developers Console.
+
+  #### Retrieving data
+  Now that we have content uploaded to the server, we can see how to read data from the server.  Add the following line
+  to your program to get back the blob we uploaded.
+
+  ```java
+  BlobId blobId = BlobId.of(bucketName, "my_blob_name");
+  byte[] content = storage.readAllBytes(blobId);
+  String contentString = new String(content, UTF_8);
+  ```
+
+  A complete example for accessing blobs can be found at
+  [CreateBlob.java](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/storage/snippets/CreateBlob.java).
+
+  #### Updating data
+  Another thing we may want to do is update a blob. The following snippet shows how to update a Storage blob if it exists.
+
+  ``` java
+  BlobId blobId = BlobId.of(bucketName, "my_blob_name");
+  Blob blob = storage.get(blobId);
+  if (blob != null) {
+    byte[] prevContent = blob.getContent();
+    System.out.println(new String(prevContent, UTF_8));
+    WritableByteChannel channel = blob.writer();
+    channel.write(ByteBuffer.wrap("Updated content".getBytes(UTF_8)));
+    channel.close();
+  }
+  ```
+
+  The complete source code can be found at
+  [UpdateBlob.java](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/storage/snippets/UpdateBlob.java).
+
+  #### Listing buckets and contents of buckets
+  Suppose that you've added more buckets and blobs, and now you want to see the names of your buckets and the contents
+  of each one. Add the following code to list all your buckets and all the blobs inside each bucket.
+
+  ```java
+  // List all your buckets
+  System.out.println("My buckets:");
+  for (Bucket bucket : storage.list().iterateAll()) {
+    System.out.println(bucket);
+
+    // List all blobs in the bucket
+    System.out.println("Blobs in the bucket:");
+    for (Blob blob : bucket.list().iterateAll()) {
+      System.out.println(blob);
+    }
+  }
+  ```
+
+  #### Complete source code
+
+  In
+  [CreateAndListBucketsAndBlobs.java](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/storage/snippets/CreateAndListBucketsAndBlobs.java)
+  we put together examples creating and listing buckets and blobs into one program. The program assumes that you are
+  running on Compute Engine or from your own desktop. To run the example on App Engine, simply move
+  the code from the main method to your application's servlet class and change the print statements to
+  display on your webpage.

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -112,3 +112,10 @@ custom_content: |
   running on Compute Engine or from your own desktop. To run the example on App Engine, simply move
   the code from the main method to your application's servlet class and change the print statements to
   display on your webpage.
+
+  ### Example Applications
+
+  - [`StorageExample`](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/storage/StorageExample.java) is a simple command line interface that provides some of Cloud Storage's functionality.  Read more about using the application on the [`StorageExample` docs page](https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-examples/README.md).
+  - [`Bookshelf`](https://github.com/GoogleCloudPlatform/getting-started-java/tree/master/bookshelf) - An App Engine application that manages a virtual bookshelf.
+    - This app uses `google-cloud` to interface with Cloud Datastore and Cloud Storage. It also uses Cloud SQL, another Google Cloud Platform service.
+  - [`Flexible Environment/Storage example`](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/flexible/cloudstorage) - An app that uploads files to a public Cloud Storage bucket on the App Engine Flexible Environment runtime.

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "storage",
-  "name_pretty": "Google Cloud Storage",
+  "name_pretty": "Cloud Storage",
   "product_documentation": "https://cloud.google.com/storage",
   "client_documentation": "https://googleapis.dev/java/java-storage/latest/",
   "api_description": "is a durable and highly available object storage service. Google Cloud Storage is almost infinitely scalable and guarantees consistency: when a write succeeds, the latest copy of the object will be returned to any GET, globally.",

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -3,11 +3,13 @@
   "name_pretty": "Google Cloud Storage",
   "product_documentation": "https://cloud.google.com/storage",
   "client_documentation": "https://googleapis.dev/java/java-storage/latest/",
+  "api_description": "is a durable and highly available object storage service. Google Cloud Storage is almost infinitely scalable and guarantees consistency: when a write succeeds, the latest copy of the object will be returned to any GET, globally.",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559782",
   "release_level": "ga",
   "language": "java",
   "repo": "googleapis/java-storage",
   "repo_short": "java-storage",
   "distribution_name": "com.google.cloud:google-cloud-storage",
-  "api_id": "storage.googleapis.com"
+  "api_id": "storage.googleapis.com",
+  "requires_billing": true
 }

--- a/README.md
+++ b/README.md
@@ -1,53 +1,52 @@
-Google Cloud Java Client for Storage
-====================================
+# Google Google Cloud Storage Client for Java
 
-Java idiomatic client for [Google Cloud Storage][cloud-storage].
+Java idiomatic client for [Google Cloud Storage][product-docs].
 
-[![Kokoro CI](http://storage.googleapis.com/cloud-devrel-public/java/badges/google-cloud-java/master.svg)](http://storage.googleapis.com/cloud-devrel-public/java/badges/google-cloud-java/master.html)
-[![Maven](https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-storage.svg)]( https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-storage.svg)
-[![Codacy Badge](https://api.codacy.com/project/badge/grade/9da006ad7c3a4fe1abd142e77c003917)](https://www.codacy.com/app/mziccard/google-cloud-java)
+[![Maven][maven-version-image]][maven-version-link]
+![Stability][stability-image]
 
-- [Product Documentation][storage-product-docs]
-- [Client Library Documentation][storage-client-lib-docs]
+- [Product Documentation][product-docs]
+- [Client Library Documentation][javadocs]
 
-Quickstart
-----------
-If you are using Maven with Bom, Add this to your pom.xml file.
+## Quickstart
+
+If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file
 ```xml
 <dependencyManagement>
- <dependencies>
-  <dependency>
-    <groupId>com.google.cloud</groupId>
-    <artifactId>libraries-bom</artifactId>
-    <version>3.2.0</version>
-    <type>pom</type>
-    <scope>import</scope>
-   </dependency>
- </dependencies>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>libraries-bom</artifactId>
+      <version>4.4.1</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
 </dependencyManagement>
 
-<dependency>
-  <groupId>com.google.cloud</groupId>
-  <artifactId>google-cloud-storage</artifactId>
-</dependency>
+<dependencies>
+  <dependency>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-storage</artifactId>
+  </dependency>
+
 ```
-[//]: # ({x-version-update-start:google-cloud-storage:released})
-If you are using Maven without Bom, Add this to your dependencies.
+
+If you are using Maven without BOM, add this to your dependencies:
+
 ```xml
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-storage</artifactId>
   <version>1.106.0</version>
 </dependency>
+
 ```
+
+[//]: # ({x-version-update-start:google-cloud-storage:released})
+
 If you are using Gradle, add this to your dependencies
 ```Groovy
-repositories {
-        google()
-	 central()
-        //other repositories
-        }
-
 compile 'com.google.cloud:google-cloud-storage:1.106.0'
 ```
 If you are using SBT, add this to your dependencies
@@ -56,43 +55,41 @@ libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "1.106.0"
 ```
 [//]: # ({x-version-update-end})
 
-Example Applications
--------------------
+## Authentication
 
-- [`StorageExample`](../../google-cloud-examples/src/main/java/com/google/cloud/examples/storage/StorageExample.java) is a simple command line interface that provides some of Cloud Storage's functionality.  Read more about using the application on the [`StorageExample` docs page](https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-examples/README.md).
-- [`Bookshelf`](https://github.com/GoogleCloudPlatform/getting-started-java/tree/master/bookshelf) - An App Engine application that manages a virtual bookshelf.
-  - This app uses `google-cloud` to interface with Cloud Datastore and Cloud Storage. It also uses Cloud SQL, another Google Cloud Platform service.
-- [`Flexible Environment/Storage example`](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/flexible/cloudstorage) - An app that uploads files to a public Cloud Storage bucket on the App Engine Flexible Environment runtime.
+See the [Authentication][authentication] section in the base directory's README.
 
-Authentication
---------------
+## Getting Started
 
-See the [Authentication](https://github.com/googleapis/google-cloud-java#authentication) section in the base directory's README.
+### Prerequisites
 
-About Google Cloud Storage
---------------------------
+You will need a [Google Cloud Platform Console][developer-console] project with the Google Cloud Storage [API enabled][enable-api].
+You will need to [enable billing][enable-billing] to use Google Google Cloud Storage.
+[Follow these instructions][create-project] to get your project set up. You will also need to set up the local development environment by
+[installing the Google Cloud SDK][cloud-sdk] and running the following commands in command line:
+`gcloud auth login` and `gcloud config set project [YOUR PROJECT ID]`.
 
-[Google Cloud Storage][cloud-storage] is a durable and highly available
-object storage service. Google Cloud Storage is almost infinitely scalable
-and guarantees consistency: when a write succeeds, the latest copy of the
-object will be returned to any GET, globally.
+### Installation and setup
 
-See the [Google Cloud Storage docs][cloud-storage-activation] for more details on how to activate
-Cloud Storage for your project.
+You'll need to obtain the `google-cloud-storage` library.  See the [Quickstart](#quickstart) section
+to add `google-cloud-storage` as a dependency in your code.
 
-See the [Storage client library docs][storage-client-lib-docs] to learn how to interact
-with the Cloud Storage using this Client Library.
+## About Google Cloud Storage
 
-Getting Started
----------------
-#### Prerequisites
-For this tutorial, you will need a [Google Developers Console](https://console.developers.google.com/) project with "Google Cloud Storage" and "Google Cloud Storage JSON API" enabled via the console's API Manager. You will need to [enable billing](https://support.google.com/cloud/answer/6158867?hl=en) to use Google Cloud Storage. [Follow these instructions](https://cloud.google.com/resource-manager/docs/creating-managing-projects) to get your project set up. You will also need to set up the local development environment by [installing the Google Cloud SDK](https://cloud.google.com/sdk/) and running the following commands in command line: `gcloud auth login` and `gcloud config set project [YOUR PROJECT ID]`.
 
-#### Installation and setup
-You'll need to obtain the `google-cloud-storage` library.  See the [Quickstart](#quickstart) section to add `google-cloud-storage` as a dependency in your code.
+[Google Cloud Storage][product-docs] is a durable and highly available object storage service. Google Cloud Storage is almost infinitely scalable and guarantees consistency: when a write succeeds, the latest copy of the object will be returned to any GET, globally.
+
+See the [Google Cloud Storage client library docs][javadocs] to learn how to
+use this Google Cloud Storage Client Library.
+
 
 #### Creating an authorized service object
-To make authenticated requests to Google Cloud Storage, you must create a service object with credentials. You can then make API calls by calling methods on the Storage service object. The simplest way to authenticate is to use [Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials). These credentials are automatically inferred from your environment, so you only need the following code to create your service object:
+
+To make authenticated requests to Google Cloud Storage, you must create a service object with credentials. You can
+then make API calls by calling methods on the Storage service object. The simplest way to authenticate is to use
+[Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials).
+These credentials are automatically inferred from your environment, so you only need the following code to create your
+service object:
 
 ```java
 import com.google.cloud.storage.Storage;
@@ -104,7 +101,10 @@ Storage storage = StorageOptions.getDefaultInstance().getService();
 For other authentication options, see the [Authentication](https://github.com/googleapis/google-cloud-java#authentication) page.
 
 #### Storing data
-Stored objects are called "blobs" in `google-cloud` and are organized into containers called "buckets".  `Blob`, a subclass of `BlobInfo`, adds a layer of service-related functionality over `BlobInfo`.  Similarly, `Bucket` adds a layer of service-related functionality over `BucketInfo`.  In this code snippet, we will create a new bucket and upload a blob to that bucket.
+Stored objects are called "blobs" in `google-cloud` and are organized into containers called "buckets".  `Blob`, a
+subclass of `BlobInfo`, adds a layer of service-related functionality over `BlobInfo`.  Similarly, `Bucket` adds a
+layer of service-related functionality over `BucketInfo`.  In this code snippet, we will create a new bucket and
+upload a blob to that bucket.
 
 Add the following imports at the top of your file:
 
@@ -118,7 +118,10 @@ import com.google.cloud.storage.BucketInfo;
 
 Then add the following code to create a bucket and upload a simple blob.
 
-*Important: Bucket names have to be globally unique (among all users of Cloud Storage). If you choose a bucket name that already exists, you'll get a helpful error message telling you to choose another name. In the code below, replace "my_unique_bucket" with a unique bucket name. See more about naming rules [here](https://cloud.google.com/storage/docs/bucket-naming?hl=en#requirements).*
+*Important: Bucket names have to be globally unique (among all users of Cloud Storage). If you choose a bucket name
+that already exists, you'll get a helpful error message telling you to choose another name. In the code below, replace
+"my_unique_bucket" with a unique bucket name. See more about naming rules
+[here](https://cloud.google.com/storage/docs/bucket-naming?hl=en#requirements).*
 
 ```java
 // Create a bucket
@@ -132,12 +135,13 @@ Blob blob = storage.create(blobInfo, "a simple blob".getBytes(UTF_8));
 ```
 
 A complete example for creating a blob can be found at
-[CreateBlob.java](../../google-cloud-examples/src/main/java/com/google/cloud/examples/storage/snippets/CreateBlob.java).
+[CreateBlob.java](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/storage/snippets/CreateBlob.java).
 
 At this point, you will be able to see your newly created bucket and blob on the Google Developers Console.
 
 #### Retrieving data
-Now that we have content uploaded to the server, we can see how to read data from the server.  Add the following line to your program to get back the blob we uploaded.
+Now that we have content uploaded to the server, we can see how to read data from the server.  Add the following line
+to your program to get back the blob we uploaded.
 
 ```java
 BlobId blobId = BlobId.of(bucketName, "my_blob_name");
@@ -146,10 +150,10 @@ String contentString = new String(content, UTF_8);
 ```
 
 A complete example for accessing blobs can be found at
-[CreateBlob.java](../../google-cloud-examples/src/main/java/com/google/cloud/examples/storage/snippets/CreateBlob.java).
+[CreateBlob.java](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/storage/snippets/CreateBlob.java).
 
 #### Updating data
-Another thing we may want to do is update a blob. The following snippet shows how to update a Storage blob if it exists. 
+Another thing we may want to do is update a blob. The following snippet shows how to update a Storage blob if it exists.
 
 ``` java
 BlobId blobId = BlobId.of(bucketName, "my_blob_name");
@@ -164,17 +168,18 @@ if (blob != null) {
 ```
 
 The complete source code can be found at
-[UpdateBlob.java](../../google-cloud-examples/src/main/java/com/google/cloud/examples/storage/snippets/UpdateBlob.java).
+[UpdateBlob.java](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/storage/snippets/UpdateBlob.java).
 
 #### Listing buckets and contents of buckets
-Suppose that you've added more buckets and blobs, and now you want to see the names of your buckets and the contents of each one. Add the following code to list all your buckets and all the blobs inside each bucket.
+Suppose that you've added more buckets and blobs, and now you want to see the names of your buckets and the contents
+of each one. Add the following code to list all your buckets and all the blobs inside each bucket.
 
 ```java
 // List all your buckets
 System.out.println("My buckets:");
 for (Bucket bucket : storage.list().iterateAll()) {
   System.out.println(bucket);
-  
+
   // List all blobs in the bucket
   System.out.println("Blobs in the bucket:");
   for (Blob blob : bucket.list().iterateAll()) {
@@ -186,63 +191,78 @@ for (Bucket bucket : storage.list().iterateAll()) {
 #### Complete source code
 
 In
-[CreateAndListBucketsAndBlobs.java](../../google-cloud-examples/src/main/java/com/google/cloud/examples/storage/snippets/CreateAndListBucketsAndBlobs.java)
+[CreateAndListBucketsAndBlobs.java](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/storage/snippets/CreateAndListBucketsAndBlobs.java)
 we put together examples creating and listing buckets and blobs into one program. The program assumes that you are
 running on Compute Engine or from your own desktop. To run the example on App Engine, simply move
 the code from the main method to your application's servlet class and change the print statements to
 display on your webpage.
 
-Troubleshooting
----------------
 
-To get help, follow the instructions in the [shared Troubleshooting document](https://github.com/googleapis/google-cloud-common/blob/master/troubleshooting/readme.md#troubleshooting).
 
-Transport
----------
-Storage uses HTTP for the transport layer.
 
-Java Versions
--------------
+## Troubleshooting
+
+To get help, follow the instructions in the [shared Troubleshooting document][troubleshooting].
+
+## Java Versions
 
 Java 7 or above is required for using this client.
 
-Testing
--------
-
-This library has tools to help make tests for code using Cloud Storage.
-
-See [TESTING] to read more about testing.
-
-Versioning
-----------
+## Versioning
 
 This library follows [Semantic Versioning](http://semver.org/).
 
-It is currently in major version one (``1.y.z``), which means that the public API should be considered stable.
 
-Contributing
-------------
+
+## Contributing
+
 
 Contributions to this library are always welcome and highly encouraged.
 
-See `google-cloud`'s [CONTRIBUTING] documentation and the [shared documentation](https://github.com/googleapis/google-cloud-common/blob/master/contributing/readme.md#how-to-contribute-to-gcloud) for more information on how to get started.
+See [CONTRIBUTING][contributing] for more information how to get started.
 
-Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms. See [Code of Conduct][code-of-conduct] for more information.
+Please note that this project is released with a Contributor Code of Conduct. By participating in
+this project you agree to abide by its terms. See [Code of Conduct][code-of-conduct] for more
+information.
 
-License
--------
+## License
 
-Apache 2.0 - See [LICENSE] for more information.
+Apache 2.0 - See [LICENSE][license] for more information.
 
+## CI Status
 
-[CONTRIBUTING]:https://github.com/googleapis/google-cloud-java/blob/master/CONTRIBUTING.md
-[code-of-conduct]:https://github.com/googleapis/google-cloud-java/blob/master/CODE_OF_CONDUCT.md#contributor-code-of-conduct
-[LICENSE]: https://github.com/googleapis/google-cloud-java/blob/master/LICENSE
-[TESTING]: https://github.com/googleapis/google-cloud-java/blob/master/TESTING.md#testing-code-that-uses-storage
-[cloud-platform]: https://cloud.google.com/
+Java Version | Status
+------------ | ------
+Java 7 | [![Kokoro CI][kokoro-badge-image-1]][kokoro-badge-link-1]
+Java 8 | [![Kokoro CI][kokoro-badge-image-2]][kokoro-badge-link-2]
+Java 8 OSX | [![Kokoro CI][kokoro-badge-image-3]][kokoro-badge-link-3]
+Java 8 Windows | [![Kokoro CI][kokoro-badge-image-4]][kokoro-badge-link-4]
+Java 11 | [![Kokoro CI][kokoro-badge-image-5]][kokoro-badge-link-5]
 
-[cloud-storage]: https://cloud.google.com/storage/
-[cloud-storage-create-bucket]: https://cloud.google.com/storage/docs/cloud-console#_creatingbuckets
-[cloud-storage-activation]:https://cloud.google.com/storage/docs/signup?hl=en
-[storage-product-docs]: https://cloud.google.com/storage/docs/
-[storage-client-lib-docs]: https://googleapis.dev/java/google-cloud-storage/latest/index.html
+[product-docs]: https://cloud.google.com/storage
+[javadocs]: https://googleapis.dev/java/java-storage/latest/
+[kokoro-badge-image-1]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java7.svg
+[kokoro-badge-link-1]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java7.html
+[kokoro-badge-image-2]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java8.svg
+[kokoro-badge-link-2]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java8.html
+[kokoro-badge-image-3]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java8-osx.svg
+[kokoro-badge-link-3]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java8-osx.html
+[kokoro-badge-image-4]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java8-win.svg
+[kokoro-badge-link-4]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java8-win.html
+[kokoro-badge-image-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java11.svg
+[kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java11.html
+[stability-image]: https://img.shields.io/badge/stability-ga-green
+[maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-storage.svg
+[maven-version-link]: https://search.maven.org/search?q=g:com.google.cloud%20AND%20a:google-cloud-storage&core=gav
+[authentication]: https://github.com/googleapis/google-cloud-java#authentication
+[developer-console]: https://console.developers.google.com/
+[create-project]: https://cloud.google.com/resource-manager/docs/creating-managing-projects
+[cloud-sdk]: https://cloud.google.com/sdk/
+[troubleshooting]: https://github.com/googleapis/google-cloud-common/blob/master/troubleshooting/readme.md#troubleshooting
+[contributing]: https://github.com/googleapis/java-storage/blob/master/CONTRIBUTING.md
+[code-of-conduct]: https://github.com/googleapis/java-storage/blob/master/CODE_OF_CONDUCT.md#contributor-code-of-conduct
+[license]: https://github.com/googleapis/java-storage/blob/master/LICENSE
+[enable-billing]: https://cloud.google.com/apis/docs/getting-started#enabling_billing
+[enable-api]: https://console.cloud.google.com/flows/enableapi?apiid=storage.googleapis.com
+[libraries-bom]: https://github.com/GoogleCloudPlatform/cloud-opensource-java/wiki/The-Google-Cloud-Platform-Libraries-BOM
+[shell_img]: https://gstatic.com/cloudssh/images/open-btn.png

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Google Google Cloud Storage Client for Java
+# Google Cloud Storage Client for Java
 
-Java idiomatic client for [Google Cloud Storage][product-docs].
+Java idiomatic client for [Cloud Storage][product-docs].
 
 [![Maven][maven-version-image]][maven-version-link]
 ![Stability][stability-image]
@@ -63,8 +63,8 @@ See the [Authentication][authentication] section in the base directory's README.
 
 ### Prerequisites
 
-You will need a [Google Cloud Platform Console][developer-console] project with the Google Cloud Storage [API enabled][enable-api].
-You will need to [enable billing][enable-billing] to use Google Google Cloud Storage.
+You will need a [Google Cloud Platform Console][developer-console] project with the Cloud Storage [API enabled][enable-api].
+You will need to [enable billing][enable-billing] to use Google Cloud Storage.
 [Follow these instructions][create-project] to get your project set up. You will also need to set up the local development environment by
 [installing the Google Cloud SDK][cloud-sdk] and running the following commands in command line:
 `gcloud auth login` and `gcloud config set project [YOUR PROJECT ID]`.
@@ -74,13 +74,13 @@ You will need to [enable billing][enable-billing] to use Google Google Cloud Sto
 You'll need to obtain the `google-cloud-storage` library.  See the [Quickstart](#quickstart) section
 to add `google-cloud-storage` as a dependency in your code.
 
-## About Google Cloud Storage
+## About Cloud Storage
 
 
-[Google Cloud Storage][product-docs] is a durable and highly available object storage service. Google Cloud Storage is almost infinitely scalable and guarantees consistency: when a write succeeds, the latest copy of the object will be returned to any GET, globally.
+[Cloud Storage][product-docs] is a durable and highly available object storage service. Google Cloud Storage is almost infinitely scalable and guarantees consistency: when a write succeeds, the latest copy of the object will be returned to any GET, globally.
 
-See the [Google Cloud Storage client library docs][javadocs] to learn how to
-use this Google Cloud Storage Client Library.
+See the [Cloud Storage client library docs][javadocs] to learn how to
+use this Cloud Storage Client Library.
 
 
 #### Creating an authorized service object

--- a/README.md
+++ b/README.md
@@ -197,6 +197,13 @@ running on Compute Engine or from your own desktop. To run the example on App En
 the code from the main method to your application's servlet class and change the print statements to
 display on your webpage.
 
+### Example Applications
+
+- [`StorageExample`](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/storage/StorageExample.java) is a simple command line interface that provides some of Cloud Storage's functionality.  Read more about using the application on the [`StorageExample` docs page](https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-examples/README.md).
+- [`Bookshelf`](https://github.com/GoogleCloudPlatform/getting-started-java/tree/master/bookshelf) - An App Engine application that manages a virtual bookshelf.
+  - This app uses `google-cloud` to interface with Cloud Datastore and Cloud Storage. It also uses Cloud SQL, another Google Cloud Platform service.
+- [`Flexible Environment/Storage example`](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/flexible/cloudstorage) - An app that uploads files to a public Cloud Storage bucket on the App Engine Flexible Environment runtime.
+
 
 
 

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,19 +1,17 @@
 {
-  "updateTime": "2020-04-09T11:28:44.677622Z",
   "sources": [
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/java-storage.git",
-        "sha": "397fcd981848ec5e02d7686b41050a4715aa90c3"
+        "remote": "git@github.com:googleapis/java-storage.git",
+        "sha": "15cb2678276ec20f8b650ac0f352e1a22b0ff8bb"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "c7e0e517d7f46f77bebd27da2e5afcaa6eee7e25",
-        "log": "c7e0e517d7f46f77bebd27da2e5afcaa6eee7e25\nbuild(java): fix nightly integration test config to run integrations (#465)\n\nThis was only running the units.\nbd69a2aa7b70875f3c988e269706b22fefbef40e\nbuild(java): fix retry_with_backoff when -e option set (#475)\n\n\nd9b173c427bfa0c6cca818233562e7e8841a357c\nfix: record version of working repo in synth.metadata (#473)\n\nPartial revert of b37cf74d12e9a42b9de9e61a4f26133d7cd9c168.\nf73a541770d95a609e5be6bf6b3b220d17cefcbe\nfeat(discogapic): allow local discovery-artifact-manager (#474)\n\n\n8cf0f5d93a70c3dcb0b4999d3152c46d4d9264bf\ndoc: describe the Autosynth & Synthtool protocol (#472)\n\n* doc: describe the Autosynth & Synthtool protocol\n\n* Accommodate review comments.\n980baaa738a1ad8fa02b4fdbd56be075ee77ece5\nfix: pin sphinx to <3.0.0 as new version causes new error (#471)\n\nThe error `toctree contains reference to document changlelog that doesn't have a title: no link will be generated` occurs as of 3.0.0. Pinning to 2.x until we address the docs build issue.\n\nTowards #470\n\nI did this manually for python-datastore https://github.com/googleapis/python-datastore/pull/22\n928b2998ac5023e7c7e254ab935f9ef022455aad\nchore(deps): update dependency com.google.cloud.samples:shared-configuration to v1.0.15 (#466)\n\nCo-authored-by: Jeffrey Rennie <rennie@google.com>\n188f1b1d53181f739b98f8aa5d40cfe99eb90c47\nfix: allow local and external deps to be specified (#469)\n\nModify noxfile.py to allow local and external dependencies for\nsystem tests to be specified.\n1df68ed6735ddce6797d0f83641a731c3c3f75b4\nfix: apache license URL (#468)\n\n\nf4a59efa54808c4b958263de87bc666ce41e415f\nfeat: Add discogapic support for GAPICBazel generation (#459)\n\n* feat: Add discogapic support for GAPICBazel generation\n\n* reformat with black\n\n* Rename source repository variable\n\nCo-authored-by: Jeffrey Rennie <rennie@google.com>\n99820243d348191bc9c634f2b48ddf65096285ed\nfix: update template files for Node.js libraries (#463)\n\n\n3cbe6bcd5623139ac9834c43818424ddca5430cb\nfix(ruby): remove dead troubleshooting link from generated auth guide (#462)\n\n\n"
+        "sha": "8eff3790f88b50706a0c4b6a20b385f24e9ac4e7"
       }
     }
   ]

--- a/synth.metadata
+++ b/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": ".",
         "remote": "git@github.com:googleapis/java-storage.git",
-        "sha": "ccc4dce8d3b33afa46c57ca5956b71bb535b1008"
+        "sha": "b5441df8d27ea8c77621da575decbf127f281897"
       }
     },
     {

--- a/synth.metadata
+++ b/synth.metadata
@@ -4,7 +4,7 @@
       "git": {
         "name": ".",
         "remote": "git@github.com:googleapis/java-storage.git",
-        "sha": "15cb2678276ec20f8b650ac0f352e1a22b0ff8bb"
+        "sha": "ccc4dce8d3b33afa46c57ca5956b71bb535b1008"
       }
     },
     {

--- a/synth.py
+++ b/synth.py
@@ -19,7 +19,6 @@ import synthtool.languages.java as java
 AUTOSYNTH_MULTIPLE_COMMITS = True
 
 java.common_templates(excludes=[
-  'README.md',
   '.kokoro/presubmit/integration.cfg'
 ])
 


### PR DESCRIPTION
Custom content is now in `.readme-partials.yaml` so any updates need to go there for now. This will allow automatic updates to the install sections for the latest libraries-bom versions and keep our README format in sync with the other client libraries.

Also fixes a few broken links to the google-cloud-examples that still live in the monorepo.