### PR TITLE
chore: override the versioning section in the README

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -119,3 +119,8 @@ custom_content: |
   - [`Bookshelf`](https://github.com/GoogleCloudPlatform/getting-started-java/tree/master/bookshelf) - An App Engine application that manages a virtual bookshelf.
     - This app uses `google-cloud` to interface with Cloud Datastore and Cloud Storage. It also uses Cloud SQL, another Google Cloud Platform service.
   - [`Flexible Environment/Storage example`](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/flexible/cloudstorage) - An app that uploads files to a public Cloud Storage bucket on the App Engine Flexible Environment runtime.
+
+versioning: |
+  This library follows [Semantic Versioning](http://semver.org/), but does update [Storage interface](src/main/java/com.google.cloud.storage/Storage.java)
+  to introduce new methods which can break your implementations if you implement this interface for testing purposes.
+


### PR DESCRIPTION
In conjunction with https://github.com/googleapis/synthtool/pull/495, this will allow the README generation to keep the customized versioning section.