### PR TITLE
feat: moving a testing class from java-storage-nio to java-storage

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/testing/FakeStorageRpc.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/testing/FakeStorageRpc.java
@@ -41,7 +41,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * A bare-bones in-memory implementation of StorageRpc, meant for testing.
@@ -74,7 +73,6 @@ import javax.annotation.concurrent.NotThreadSafe;
  *       </ul>
  * </ul>
  */
-@NotThreadSafe
 public class FakeStorageRpc implements StorageRpc {
 
   // fullname -> metadata

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/testing/FakeStorageRpc.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/testing/FakeStorageRpc.java
@@ -1,0 +1,660 @@
+/*
+ * Copyright 2016 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.testing;
+
+import com.google.api.services.storage.model.Bucket;
+import com.google.api.services.storage.model.BucketAccessControl;
+import com.google.api.services.storage.model.HmacKey;
+import com.google.api.services.storage.model.HmacKeyMetadata;
+import com.google.api.services.storage.model.Notification;
+import com.google.api.services.storage.model.ObjectAccessControl;
+import com.google.api.services.storage.model.Policy;
+import com.google.api.services.storage.model.ServiceAccount;
+import com.google.api.services.storage.model.StorageObject;
+import com.google.api.services.storage.model.TestIamPermissionsResponse;
+import com.google.cloud.Tuple;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.spi.v1.RpcBatch;
+import com.google.cloud.storage.spi.v1.StorageRpc;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.concurrent.NotThreadSafe;
+
+/**
+ * A bare-bones in-memory implementation of StorageRpc, meant for testing.
+ *
+ * <p>This class is <i>not</i> thread-safe. It's also (currently) limited in the following ways:
+ *
+ * <ul>
+ *   <li>Supported
+ *       <ul>
+ *         <li>object create
+ *         <li>object get
+ *         <li>object delete
+ *         <li>list the contents of a bucket
+ *         <li>generations
+ *       </ul>
+ *   <li>Unsupported
+ *       <ul>
+ *         <li>bucket create
+ *         <li>bucket get
+ *         <li>bucket delete
+ *         <li>list all buckets
+ *         <li>file attributes
+ *         <li>patch
+ *         <li>continueRewrite
+ *         <li>createBatch
+ *         <li>checksums, etags
+ *         <li>IAM operations
+ *         <li>BucketLock operations
+ *         <li>HMAC key operations
+ *       </ul>
+ * </ul>
+ */
+@NotThreadSafe
+public class FakeStorageRpc implements StorageRpc {
+
+  // fullname -> metadata
+  Map<String, StorageObject> metadata = new HashMap<>();
+  // fullname -> contents
+  Map<String, byte[]> contents = new HashMap<>();
+  // fullname -> future contents that will be visible on close.
+  Map<String, byte[]> futureContents = new HashMap<>();
+
+  private final boolean throwIfOption;
+
+  /**
+   * Initializes a newly created {@code FakeStorageRpc} object.
+   *
+   * @param throwIfOption if true, we throw {@code UnsupportedOperationException} when given any
+   *     option
+   */
+  public FakeStorageRpc(boolean throwIfOption) {
+    this.throwIfOption = throwIfOption;
+  }
+
+  // remove all files
+  public void reset() {
+    metadata = new HashMap<>();
+    contents = new HashMap<>();
+  }
+
+  @Override
+  public Bucket create(Bucket bucket, Map<Option, ?> options) throws StorageException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public StorageObject create(StorageObject object, InputStream content, Map<Option, ?> options)
+      throws StorageException {
+    potentiallyThrow(options);
+    String key = fullname(object);
+    metadata.put(key, object);
+    try {
+      contents.put(key, com.google.common.io.ByteStreams.toByteArray(content));
+    } catch (IOException e) {
+      throw new StorageException(e);
+    }
+    // TODO: crc, etc
+    return object;
+  }
+
+  @Override
+  public Tuple<String, Iterable<Bucket>> list(Map<Option, ?> options) throws StorageException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Tuple<String, Iterable<StorageObject>> list(String bucket, Map<Option, ?> options)
+      throws StorageException {
+    String delimiter = null;
+    String preprefix = "";
+    String pageToken = null;
+    long maxResults = Long.MAX_VALUE;
+    for (Map.Entry<Option, ?> e : options.entrySet()) {
+      switch (e.getKey()) {
+        case PAGE_TOKEN:
+          pageToken = (String) e.getValue();
+          break;
+        case PREFIX:
+          preprefix = (String) e.getValue();
+          if (preprefix.startsWith("/")) {
+            preprefix = preprefix.substring(1);
+          }
+          break;
+        case DELIMITER:
+          delimiter = (String) e.getValue();
+          break;
+        case FIELDS:
+          // ignore and return all the fields
+          break;
+        case MAX_RESULTS:
+          maxResults = (Long) e.getValue();
+          break;
+        case USER_PROJECT:
+          // prevent unsupported operation
+          break;
+        default:
+          throw new UnsupportedOperationException("Unknown option: " + e.getKey());
+      }
+    }
+    final String prefix = preprefix;
+
+    List<StorageObject> values = new ArrayList<>();
+    Map<String, StorageObject> folders = new HashMap<>();
+    for (StorageObject so : metadata.values()) {
+      if (!so.getName().startsWith(prefix)) {
+        continue;
+      }
+      if (processedAsFolder(so, delimiter, prefix, folders)) {
+        continue;
+      }
+      so.setSize(size(so));
+      values.add(so);
+    }
+    values.addAll(folders.values());
+
+    // truncate to max allowed length
+    if (values.size() > maxResults) {
+      List<StorageObject> newValues = new ArrayList<>();
+      for (int i = 0; i < maxResults; i++) {
+        newValues.add(values.get(i));
+      }
+      values = newValues;
+    }
+
+    // null cursor to indicate there is no more data (empty string would cause us to be called
+    // again).
+    // The type cast seems to be necessary to help Java's typesystem remember that collections are
+    // iterable.
+    return Tuple.of(pageToken, (Iterable<StorageObject>) values);
+  }
+
+  /** Returns the requested bucket or {@code null} if not found. */
+  @Override
+  public Bucket get(Bucket bucket, Map<Option, ?> options) throws StorageException {
+    potentiallyThrow(options);
+    return null;
+  }
+
+  /** Returns the requested storage object or {@code null} if not found. */
+  @Override
+  public StorageObject get(StorageObject object, Map<Option, ?> options) throws StorageException {
+    // we allow the "ID" option because we need to, but then we give a whole answer anyways
+    // because the caller won't mind the extra fields.
+    if (throwIfOption
+        && !options.isEmpty()
+        && options.size() > 1
+        && options.keySet().toArray()[0] != Storage.BlobGetOption.fields(Storage.BlobField.ID)) {
+      throw new UnsupportedOperationException();
+    }
+
+    String key = fullname(object);
+    if (metadata.containsKey(key)) {
+      StorageObject ret = metadata.get(key);
+      ret.setSize(size(ret));
+      ret.setId(key);
+
+      return ret;
+    }
+    return null;
+  }
+
+  @Override
+  public Bucket patch(Bucket bucket, Map<Option, ?> options) throws StorageException {
+    potentiallyThrow(options);
+    return null;
+  }
+
+  @Override
+  public StorageObject patch(StorageObject storageObject, Map<Option, ?> options)
+      throws StorageException {
+    potentiallyThrow(options);
+    return null;
+  }
+
+  @Override
+  public boolean delete(Bucket bucket, Map<Option, ?> options) throws StorageException {
+    return false;
+  }
+
+  @Override
+  public boolean delete(StorageObject object, Map<Option, ?> options) throws StorageException {
+    String key = fullname(object);
+    contents.remove(key);
+    return null != metadata.remove(key);
+  }
+
+  @Override
+  public RpcBatch createBatch() {
+    // return new DefaultRpcBatch(storage);
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public StorageObject compose(
+      Iterable<StorageObject> sources, StorageObject target, Map<Option, ?> targetOptions)
+      throws StorageException {
+    return null;
+  }
+
+  @Override
+  public byte[] load(StorageObject storageObject, Map<Option, ?> options) throws StorageException {
+    String key = fullname(storageObject);
+    if (!contents.containsKey(key)) {
+      throw new StorageException(404, "File not found: " + key);
+    }
+    return contents.get(key);
+  }
+
+  @Override
+  public Tuple<String, byte[]> read(
+      StorageObject from, Map<Option, ?> options, long zposition, int zbytes)
+      throws StorageException {
+    // if non-null, then we check the file's at that generation.
+    Long generationMatch = null;
+    for (Option op : options.keySet()) {
+      if (op.equals(StorageRpc.Option.IF_GENERATION_MATCH)) {
+        generationMatch = (Long) options.get(op);
+      } else {
+        throw new UnsupportedOperationException("Unknown option: " + op);
+      }
+    }
+    String key = fullname(from);
+    if (!contents.containsKey(key)) {
+      throw new StorageException(404, "File not found: " + key);
+    }
+    checkGeneration(key, generationMatch);
+    long position = zposition;
+    int bytes = zbytes;
+    if (position < 0) {
+      position = 0;
+    }
+    byte[] full = contents.get(key);
+    if ((int) position + bytes > full.length) {
+      bytes = full.length - (int) position;
+    }
+    if (bytes <= 0) {
+      // special case: you're trying to read past the end
+      return Tuple.of("etag-goes-here", new byte[0]);
+    }
+    byte[] ret = new byte[bytes];
+    System.arraycopy(full, (int) position, ret, 0, bytes);
+    return Tuple.of("etag-goes-here", ret);
+  }
+
+  @Override
+  public long read(
+      StorageObject from, Map<Option, ?> options, long position, OutputStream outputStream) {
+    // if non-null, then we check the file's at that generation.
+    Long generationMatch = null;
+    for (Option op : options.keySet()) {
+      if (op.equals(StorageRpc.Option.IF_GENERATION_MATCH)) {
+        generationMatch = (Long) options.get(op);
+      } else {
+        throw new UnsupportedOperationException("Unknown option: " + op);
+      }
+    }
+    String key = fullname(from);
+    if (!contents.containsKey(key)) {
+      throw new StorageException(404, "File not found: " + key);
+    }
+    checkGeneration(key, generationMatch);
+    if (position < 0) {
+      position = 0;
+    }
+    byte[] full = contents.get(key);
+    int bytes = (int) (full.length - position);
+    if (bytes <= 0) {
+      // special case: you're trying to read past the end
+      return 0;
+    }
+    try {
+      outputStream.write(full, (int) position, bytes);
+    } catch (IOException e) {
+      throw new StorageException(500, "Failed to write to file", e);
+    }
+    return bytes;
+  }
+
+  @Override
+  public String open(StorageObject object, Map<Option, ?> options) throws StorageException {
+    String key = fullname(object);
+    // if non-null, then we check the file's at that generation.
+    Long generationMatch = null;
+    for (Option option : options.keySet()) {
+      // this is a bit of a hack, since we don't implement generations.
+      if (option == Option.IF_GENERATION_MATCH) {
+        generationMatch = (Long) options.get(option);
+      }
+    }
+    checkGeneration(key, generationMatch);
+    metadata.put(key, object);
+
+    return fullname(object);
+  }
+
+  @Override
+  public String open(String signedURL) {
+    return null;
+  }
+
+  @Override
+  public void write(
+      String uploadId, byte[] toWrite, int toWriteOffset, long destOffset, int length, boolean last)
+      throws StorageException {
+    // this may have a lot more allocations than ideal, but it'll work.
+    byte[] bytes;
+    if (futureContents.containsKey(uploadId)) {
+      bytes = futureContents.get(uploadId);
+      if (bytes.length < length + destOffset) {
+        byte[] newBytes = new byte[(int) (length + destOffset)];
+        System.arraycopy(bytes, 0, newBytes, (int) 0, bytes.length);
+        bytes = newBytes;
+      }
+    } else {
+      bytes = new byte[(int) (length + destOffset)];
+    }
+    System.arraycopy(toWrite, toWriteOffset, bytes, (int) destOffset, length);
+    // we want to mimic the GCS behavior that file contents are only visible on close.
+    if (last) {
+      contents.put(uploadId, bytes);
+      futureContents.remove(uploadId);
+      if (metadata.containsKey(uploadId)) {
+        StorageObject storageObject = metadata.get(uploadId);
+        Long generation = storageObject.getGeneration();
+        if (null == generation) {
+          generation = Long.valueOf(0);
+        }
+        storageObject.setGeneration(++generation);
+        metadata.put(uploadId, storageObject);
+      }
+    } else {
+      futureContents.put(uploadId, bytes);
+    }
+  }
+
+  @Override
+  public RewriteResponse openRewrite(RewriteRequest rewriteRequest) throws StorageException {
+    String sourceKey = fullname(rewriteRequest.source);
+
+    // a little hackish, just good enough for the tests to work.
+    if (!contents.containsKey(sourceKey)) {
+      throw new StorageException(404, "File not found: " + sourceKey);
+    }
+
+    // if non-null, then we check the file's at that generation.
+    Long generationMatch = null;
+    for (Option option : rewriteRequest.targetOptions.keySet()) {
+      // this is a bit of a hack, since we don't implement generations.
+      if (option == Option.IF_GENERATION_MATCH) {
+        generationMatch = (Long) rewriteRequest.targetOptions.get(option);
+      }
+    }
+
+    String destKey = fullname(rewriteRequest.target);
+
+    // if this is a new file, set generation to 1, else increment the existing generation
+    long generation = 1;
+    if (metadata.containsKey(destKey)) {
+      generation = metadata.get(destKey).getGeneration() + 1;
+    }
+
+    checkGeneration(destKey, generationMatch);
+
+    byte[] data = contents.get(sourceKey);
+
+    rewriteRequest.target.setGeneration(generation);
+    rewriteRequest.target.setSize(BigInteger.valueOf(data.length));
+
+    metadata.put(destKey, rewriteRequest.target);
+
+    contents.put(destKey, Arrays.copyOf(data, data.length));
+    return new RewriteResponse(
+        rewriteRequest,
+        rewriteRequest.target,
+        data.length,
+        true,
+        "rewriteToken goes here",
+        data.length);
+  }
+
+  @Override
+  public RewriteResponse continueRewrite(RewriteResponse previousResponse) throws StorageException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BucketAccessControl getAcl(String bucket, String entity, Map<Option, ?> options) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean deleteAcl(String bucket, String entity, Map<Option, ?> options) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BucketAccessControl createAcl(BucketAccessControl acl, Map<Option, ?> options) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BucketAccessControl patchAcl(BucketAccessControl acl, Map<Option, ?> options) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<BucketAccessControl> listAcls(String bucket, Map<Option, ?> options) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public HmacKey createHmacKey(String serviceAccountEmail, Map<Option, ?> options) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Tuple<String, Iterable<HmacKeyMetadata>> listHmacKeys(Map<Option, ?> options) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public HmacKeyMetadata updateHmacKey(HmacKeyMetadata hmacKeyMetadata, Map<Option, ?> options) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public HmacKeyMetadata getHmacKey(String accessId, Map<Option, ?> options) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void deleteHmacKey(HmacKeyMetadata hmacKeyMetadata, Map<Option, ?> options) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ObjectAccessControl getDefaultAcl(String bucket, String entity) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean deleteDefaultAcl(String bucket, String entity) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ObjectAccessControl createDefaultAcl(ObjectAccessControl acl) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ObjectAccessControl patchDefaultAcl(ObjectAccessControl acl) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<ObjectAccessControl> listDefaultAcls(String bucket) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ObjectAccessControl getAcl(String bucket, String object, Long generation, String entity) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean deleteAcl(String bucket, String object, Long generation, String entity) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ObjectAccessControl createAcl(ObjectAccessControl acl) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ObjectAccessControl patchAcl(ObjectAccessControl acl) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<ObjectAccessControl> listAcls(String bucket, String object, Long generation) {
+    throw new UnsupportedOperationException();
+  }
+
+  private String fullname(StorageObject so) {
+    return (so.getBucket() + "/" + so.getName());
+  }
+
+  private BigInteger size(StorageObject so) {
+    String key = fullname(so);
+
+    if (contents.containsKey(key)) {
+      return BigInteger.valueOf(contents.get(key).length);
+    }
+
+    return null;
+  }
+
+  private void potentiallyThrow(Map<Option, ?> options) throws UnsupportedOperationException {
+    if (throwIfOption && !options.isEmpty()) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  /**
+   * Throw if we're asking for generation 0 and the file exists, or if the requested generation
+   * number doesn't match what is asked.
+   *
+   * @param key
+   * @param generationMatch
+   */
+  private void checkGeneration(String key, Long generationMatch) {
+    if (null == generationMatch) {
+      return;
+    }
+    if (generationMatch == 0 && metadata.containsKey(key)) {
+      throw new StorageException(new FileAlreadyExistsException(key));
+    }
+    if (generationMatch != 0) {
+      Long generation = metadata.get(key).getGeneration();
+      if (!generationMatch.equals(generation)) {
+        throw new StorageException(
+            404, "Generation mismatch. Requested " + generationMatch + " but got " + generation);
+      }
+    }
+  }
+
+  // Returns true if this is a folder. Adds it to folders if it isn't already there.
+  private static boolean processedAsFolder(
+      StorageObject so,
+      String delimiter,
+      String prefix, /* inout */
+      Map<String, StorageObject> folders) {
+    if (delimiter == null) {
+      return false;
+    }
+    int nextSlash = so.getName().indexOf(delimiter, prefix.length());
+    if (nextSlash < 0) {
+      return false;
+    }
+    String folderName = so.getName().substring(0, nextSlash + 1);
+    if (folders.containsKey(folderName)) {
+      return true;
+    }
+    StorageObject fakeFolder = new StorageObject();
+    fakeFolder.setName(folderName);
+    fakeFolder.setBucket(so.getBucket());
+    fakeFolder.setGeneration(so.getGeneration());
+    fakeFolder.set("isDirectory", true);
+    fakeFolder.setSize(BigInteger.ZERO);
+    folders.put(folderName, fakeFolder);
+    return true;
+  }
+
+  @Override
+  public Policy getIamPolicy(String bucket, Map<Option, ?> options) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Policy setIamPolicy(String bucket, Policy policy, Map<Option, ?> options) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public TestIamPermissionsResponse testIamPermissions(
+      String bucket, List<String> permissions, Map<Option, ?> options) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean deleteNotification(String bucket, String notification) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<Notification> listNotifications(String bucket) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Notification createNotification(String bucket, Notification notification) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Bucket lockRetentionPolicy(Bucket bucket, Map<Option, ?> options) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ServiceAccount getServiceAccount(String projectId) {
+    return null;
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/testing/FakeStorageRpcTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/testing/FakeStorageRpcTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.api.services.storage.model.Bucket;
@@ -30,9 +31,11 @@ import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.spi.v1.StorageRpc;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
@@ -147,10 +150,13 @@ public class FakeStorageRpcTest {
 
     tuple = instance.list(null, options);
     assertEquals("abc", tuple.x());
-    Iterator<StorageObject> it = tuple.y().iterator();
-    assertSame(OBJECT, it.next());
-    assertSame(anotherObject, it.next());
-    assertFalse(it.hasNext());
+    List<StorageObject> objectList = new ArrayList<>();
+    for (Iterator<StorageObject> it = tuple.y().iterator(); it.hasNext(); ) {
+      objectList.add(it.next());
+    }
+    assertEquals(2, objectList.size());
+    assertTrue(objectList.contains(OBJECT));
+    assertTrue(objectList.contains(anotherObject));
   }
 
   @Test

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/testing/FakeStorageRpcTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/testing/FakeStorageRpcTest.java
@@ -1,0 +1,670 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.testing;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+import com.google.api.services.storage.model.Bucket;
+import com.google.api.services.storage.model.StorageObject;
+import com.google.cloud.Tuple;
+import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.spi.v1.StorageRpc;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FakeStorageRpcTest {
+
+  private FakeStorageRpc instance;
+  private Map<StorageRpc.Option, Object> options;
+  private static final String BUCKET_NAME = "fake-bucket";
+  private static final String OBJECT_NAME = "fake-obj";
+  private static final long GENERATION = 12345L;
+  private static final Bucket BUCKET = new Bucket().setName("fake-bucket");
+  private static final byte[] BYTES = {0, 1, 2, 3, 4, 5, 6, 7};
+
+  private static final StorageObject OBJECT =
+      new StorageObject().setName(OBJECT_NAME).setBucket(BUCKET_NAME).setGeneration(GENERATION);
+  private static final String FULLNAME = fullname(OBJECT);
+
+  private static final String fullname(StorageObject object) {
+    return object.getBucket() + "/" + object.getName();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    instance = new FakeStorageRpc(true);
+    options = new HashMap<>();
+  }
+
+  @After
+  public void tearDown() throws Exception {}
+
+  // Using Callable would require to return null each time
+  interface FakeCall {
+    void call();
+  }
+
+  private void verifyUnsupported(FakeCall fakeCall) {
+    try {
+      fakeCall.call();
+      fail("UnsupportedOperationException expected");
+    } catch (UnsupportedOperationException e) {
+      // expected
+    }
+  }
+
+  private void verifyNotFoundStorageException(String name, FakeCall fakeCall) {
+    try {
+      fakeCall.call();
+      fail("StorageException expected");
+    } catch (StorageException expected) {
+      assertEquals(404, expected.getCode());
+      assertEquals("File not found: " + name, expected.getMessage());
+    }
+  }
+
+  private void verifyFields(int metadataSize, int contentsSize, int futureContentsSize) {
+    assertEquals(metadataSize, instance.metadata.size());
+    assertEquals(contentsSize, instance.contents.size());
+    assertEquals(futureContentsSize, instance.futureContents.size());
+  }
+
+  @Test
+  public void testReset() {
+    instance.metadata.put("x", OBJECT);
+    instance.contents.put("y", new byte[1]);
+    instance.futureContents.put("z", new byte[2]);
+    instance.reset();
+    verifyFields(0, 0, 1);
+  }
+
+  @Test
+  public void testCreateBucket() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.create(BUCKET, options);
+          }
+        });
+  }
+
+  @Test
+  public void testCreateObject() {
+    instance.create(OBJECT, new ByteArrayInputStream(BYTES), options);
+    verifyFields(1, 1, 0);
+    assertSame(OBJECT, instance.metadata.get(FULLNAME));
+    assertArrayEquals(BYTES, instance.contents.get(FULLNAME));
+  }
+
+  @Test
+  public void testList() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.list(options);
+          }
+        });
+  }
+
+  @Test
+  public void testListBucket() {
+    Tuple<String, Iterable<StorageObject>> tuple = instance.list(BUCKET.getName(), options);
+    assertNull(tuple.x());
+    assertFalse(tuple.y().iterator().hasNext());
+
+    instance.create(OBJECT, new ByteArrayInputStream(new byte[1]), options);
+    StorageObject anotherObject = new StorageObject().setBucket("x2").setName("y2");
+    instance.create(anotherObject, new ByteArrayInputStream(new byte[2]), options);
+    options.put(StorageRpc.Option.PAGE_TOKEN, "abc");
+
+    tuple = instance.list(null, options);
+    assertEquals("abc", tuple.x());
+    Iterator<StorageObject> it = tuple.y().iterator();
+    assertSame(OBJECT, it.next());
+    assertSame(anotherObject, it.next());
+    assertFalse(it.hasNext());
+  }
+
+  @Test
+  public void testGetBucket() {
+    assertNull(instance.get(BUCKET, options));
+    options.put(StorageRpc.Option.USER_PROJECT, "what ever");
+
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.get(BUCKET, options);
+          }
+        });
+  }
+
+  @Test
+  public void testGetObject() {
+    assertNull(instance.get(OBJECT, options));
+
+    instance.metadata.put("x", OBJECT);
+    assertNull(instance.get(OBJECT, options));
+
+    instance.metadata.put(FULLNAME, OBJECT);
+    assertSame(OBJECT, instance.get(OBJECT, options));
+  }
+
+  @Test
+  public void testPatchBucket() {
+    assertNull(instance.patch(BUCKET, options));
+
+    options.put(StorageRpc.Option.CUSTOMER_SUPPLIED_KEY, "some");
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.patch(BUCKET, options);
+          }
+        });
+  }
+
+  @Test
+  public void testPatchObject() {
+    assertNull(instance.patch(OBJECT, options));
+
+    options.put(StorageRpc.Option.CUSTOMER_SUPPLIED_KEY, "some");
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.patch(OBJECT, options);
+          }
+        });
+  }
+
+  @Test
+  public void testDeleteBucket() {
+    assertFalse(instance.delete(BUCKET, options));
+    options.put(StorageRpc.Option.CUSTOMER_SUPPLIED_KEY, "some");
+    assertFalse(instance.delete(BUCKET, options));
+  }
+
+  @Test
+  public void testDeleteObject() {
+    assertFalse(instance.delete(OBJECT, options));
+    options.put(StorageRpc.Option.CUSTOMER_SUPPLIED_KEY, "some");
+    assertFalse(instance.delete(OBJECT, options));
+  }
+
+  @Test
+  public void testCreateBatch() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.createBatch();
+          }
+        });
+  }
+
+  @Test
+  public void testCompose() {
+    StorageObject[] array = {OBJECT};
+    Iterable<StorageObject> iterable = Arrays.asList(array);
+    assertNull(instance.compose(iterable, OBJECT, options));
+  }
+
+  @Test
+  public void testLoad() {
+    verifyNotFoundStorageException(
+        FULLNAME,
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.load(OBJECT, options);
+          }
+        });
+
+    instance.contents.put(FULLNAME, new byte[42]);
+    byte[] bytes = instance.load(OBJECT, options);
+    assertArrayEquals(new byte[42], bytes);
+  }
+
+  @Test
+  public void testReadBytes() {
+    verifyNotFoundStorageException(
+        FULLNAME,
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.read(OBJECT, options, 0, 0);
+          }
+        });
+    instance.contents.put(FULLNAME, BYTES);
+    Tuple<String, byte[]> read = instance.read(OBJECT, options, 1, BYTES.length - 2);
+    byte[] expected = new byte[BYTES.length - 2];
+    System.arraycopy(BYTES, 1, expected, 0, expected.length);
+    assertEquals("etag-goes-here", read.x());
+    assertArrayEquals(expected, read.y());
+  }
+
+  @Test
+  public void testReadOutputStream() {
+    final ByteArrayOutputStream outputStream = new ByteArrayOutputStream(100);
+    verifyNotFoundStorageException(
+        FULLNAME,
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.read(OBJECT, options, 0, outputStream);
+          }
+        });
+    instance.contents.put(FULLNAME, BYTES);
+    long read = instance.read(OBJECT, options, 0, outputStream);
+    assertEquals(BYTES.length, read);
+    assertArrayEquals(BYTES, outputStream.toByteArray());
+  }
+
+  @Test
+  public void testOpenObject() {
+    String name = instance.open(OBJECT, options);
+    assertEquals(FULLNAME, name);
+    instance.metadata.put(FULLNAME, OBJECT);
+    options.put(StorageRpc.Option.IF_GENERATION_MATCH, new Long(GENERATION));
+    name = instance.open(OBJECT, options);
+    assertEquals(FULLNAME, name);
+    options.put(StorageRpc.Option.IF_GENERATION_MATCH, new Long(123));
+    try {
+      instance.open(OBJECT, options);
+      fail();
+    } catch (StorageException e) {
+      assertEquals("Generation mismatch. Requested 123 but got " + GENERATION, e.getMessage());
+    }
+  }
+
+  @Test
+  public void testOpenSignedURL() {
+    assertNull(instance.open("something"));
+  }
+
+  @Test
+  public void testWrite() {
+    String uploadId = "upload-id";
+    byte[] part1 = {1, 2, 3};
+    byte[] part2 = {3, 4, 5, 6};
+    instance.write(uploadId, part1, 0, 0L, part1.length, false);
+    verifyFields(0, 0, 1);
+    assertArrayEquals(part1, instance.futureContents.get(uploadId));
+
+    instance.write(uploadId, part2, 0, 0L, part2.length, true);
+    verifyFields(0, 1, 0);
+    assertArrayEquals(part2, instance.contents.get(uploadId));
+  }
+
+  @Test
+  public void testOpenRewrite() {
+    StorageObject source =
+        new StorageObject().setBucket(BUCKET_NAME).setName("source").setGeneration(555L);
+    StorageObject target =
+        new StorageObject().setBucket(BUCKET_NAME).setName("target").setGeneration(777L);
+
+    final StorageRpc.RewriteRequest request =
+        new StorageRpc.RewriteRequest(source, options, false, target, options, 10L);
+
+    String sourceFullname = fullname(source);
+    verifyNotFoundStorageException(
+        sourceFullname,
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.openRewrite(request);
+          }
+        });
+    String targetFullname = fullname(target);
+    instance.metadata.put(targetFullname, target);
+    instance.contents.put(sourceFullname, BYTES);
+    StorageRpc.RewriteResponse response = instance.openRewrite(request);
+    assertSame(request, response.rewriteRequest);
+    assertEquals(BYTES.length, response.blobSize);
+    assertArrayEquals(BYTES, instance.contents.get(fullname(target)));
+    assertSame(target, instance.metadata.get(fullname(target)));
+    assertEquals(778L, (long) target.getGeneration());
+  }
+
+  @Test
+  public void testContinueRewrite() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.continueRewrite(null);
+          }
+        });
+  }
+
+  @Test
+  public void testGetAclBucket() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.getAcl(BUCKET_NAME, "entiry", options);
+          }
+        });
+  }
+
+  @Test
+  public void testGetAclObject() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.getAcl(BUCKET_NAME, "object", 0L, "entity");
+          }
+        });
+  }
+
+  @Test
+  public void testDeleteAclBucket() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.deleteAcl(BUCKET_NAME, "entity", options);
+          }
+        });
+  }
+
+  @Test
+  public void testDeleteAclObject() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.deleteAcl(BUCKET_NAME, "object", 0L, "entity");
+          }
+        });
+  }
+
+  @Test
+  public void testCreateAclBucket() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.createAcl(null, options);
+          }
+        });
+  }
+
+  @Test
+  public void testCreateAclObject() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.createAcl(null);
+          }
+        });
+  }
+
+  @Test
+  public void testPatchAclBucket() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.patchAcl(null, options);
+          }
+        });
+  }
+
+  @Test
+  public void testPatchAclObject() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.patchAcl(null);
+          }
+        });
+  }
+
+  @Test
+  public void testListAclsBucket() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.listAcls(BUCKET_NAME, options);
+          }
+        });
+  }
+
+  @Test
+  public void testListAclsObject() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.listAcls(BUCKET_NAME, OBJECT_NAME, 100L);
+          }
+        });
+  }
+
+  @Test
+  public void testCreateHmacKey() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.createHmacKey("account", options);
+          }
+        });
+  }
+
+  @Test
+  public void testListHmacKeys() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.listHmacKeys(options);
+          }
+        });
+  }
+
+  @Test
+  public void testUpdateHmacKey() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.updateHmacKey(null, options);
+          }
+        });
+  }
+
+  @Test
+  public void testGetHmacKey() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.getHmacKey("account", options);
+          }
+        });
+  }
+
+  @Test
+  public void testDeleteHmacKey() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.deleteHmacKey(null, options);
+          }
+        });
+  }
+
+  @Test
+  public void testGetDefaultAcl() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.getDefaultAcl("bucket", "entity");
+          }
+        });
+  }
+
+  @Test
+  public void testDeleteDefaultAcl() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.deleteDefaultAcl("bucket", "entity");
+          }
+        });
+  }
+
+  @Test
+  public void testCreateDefaultAcl() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.createDefaultAcl(null);
+          }
+        });
+  }
+
+  @Test
+  public void testPatchDefaultAcl() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.patchDefaultAcl(null);
+          }
+        });
+  }
+
+  @Test
+  public void testListDefaultAcls() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.listDefaultAcls("bucket");
+          }
+        });
+  }
+
+  @Test
+  public void testGetIamPolicy() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.getIamPolicy("bucket", options);
+          }
+        });
+  }
+
+  @Test
+  public void testSetIamPolicy() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.setIamPolicy("bucket", null, options);
+          }
+        });
+  }
+
+  @Test
+  public void testTestIamPermissions() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.testIamPermissions("bucket", null, options);
+          }
+        });
+  }
+
+  @Test
+  public void testDeleteNotification() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.deleteNotification("bucket", "entity");
+          }
+        });
+  }
+
+  @Test
+  public void testListNotifications() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.listNotifications("bucket");
+          }
+        });
+  }
+
+  @Test
+  public void testCreateNotification() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.createNotification("bucket", null);
+          }
+        });
+  }
+
+  @Test
+  public void testLockRetentionPolicy() {
+    verifyUnsupported(
+        new FakeCall() {
+          @Override
+          public void call() {
+            instance.lockRetentionPolicy(BUCKET, options);
+          }
+        });
+  }
+
+  @Test
+  public void testGetServiceAccount() {
+    assertNull(instance.getServiceAccount("project"));
+  }
+}


### PR DESCRIPTION
Moving FakeStorageRpcTest class implementing the StorageRpc interface from java-storage-nio to java-storage. That will allow extending StorageRpc without breaking cross-project dependencies. 

It was suggested to introduce a new artifact google-cloud-storage-testing, but I hope it's not necessary, because we already have a testing class included in the main java-storage artifact: `com.google.cloud.storage.testingRemoteStorageHelper`. Newly introduced class FakeStorageRpc borrowed from the Storage-Nio is placed next to it.

Fixes #242
