### PR TITLE
chore: generate CODEOWNERS from templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,11 @@
 # Code owners file.
 # This file controls who is tagged for review for any given pull request.
-#
+
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
+# The @googleapis/storage-dpe is the default owner for changes in this repo
+**/*.java               @googleapis/storage-dpe
 
-# The storage-dpe team is the default owner for anything not
-# explicitly taken by someone else.
-*                               @googleapis/storage-dpe
+# The java-samples-reviewers team is the default owner for samples changes
+samples/**/*.java       @googleapis/java-samples-reviewers

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,6 +10,7 @@
   "repo": "googleapis/java-storage",
   "repo_short": "java-storage",
   "distribution_name": "com.google.cloud:google-cloud-storage",
+  "codeowner_team": "@googleapis/storage-dpe",
   "api_id": "storage.googleapis.com",
   "requires_billing": true
 }

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,15 +3,15 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/java-storage.git",
-        "sha": "7ebd39e01d8b37e4f85c2e18b61e39a3a7ba96e4"
+        "remote": "git@github.com:googleapis/java-storage.git",
+        "sha": "ad5182fbe1c5c75ace607e97ca4d2e328811e494"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "5b48b0716a36ca069db3038da7e205c87a22ed19"
+        "sha": "8b65daa222d193b689279162781baf0aa1f0ffd2"
       }
     }
   ]


### PR DESCRIPTION
CODEOWNERS is now managed by templates and we can configure the default team in the .repo-metadata.json file.
