### PR TITLE
test: fix flaky testBucketPolicyV1RequesterPays it test

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageTest.java
@@ -2409,13 +2409,13 @@ public class ITStorageTest {
     storage.create(BucketInfo.newBuilder(bucketName).build());
 
     try {
-      Bucket remoteBucket =
+      Bucket bucketDefault =
           storage.get(
               bucketName, Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
-      assertNull(remoteBucket.requesterPays());
-      remoteBucket = remoteBucket.toBuilder().setRequesterPays(true).build();
-      Bucket updatedBucket = storage.update(remoteBucket);
-      assertTrue(updatedBucket.requesterPays());
+      assertNull(bucketDefault.requesterPays());
+
+      Bucket bucketTrue = storage.update(bucketDefault.toBuilder().setRequesterPays(true).build());
+      assertTrue(bucketTrue.requesterPays());
 
       String projectId = remoteStorageHelper.getOptions().getProjectId();
 
@@ -2471,10 +2471,11 @@ public class ITStorageTest {
               bucketName,
               ImmutableList.of("storage.buckets.getIamPolicy", "storage.buckets.setIamPolicy"),
               bucketOptions));
-      remoteBucket = remoteBucket.toBuilder().setRequesterPays(false).build();
-      updatedBucket =
-          storage.update(remoteBucket, Storage.BucketTargetOption.userProject(projectId));
-      assertFalse(updatedBucket.requesterPays());
+      Bucket bucketFalse =
+          storage.update(
+              bucketTrue.toBuilder().setRequesterPays(false).build(),
+              Storage.BucketTargetOption.userProject(projectId));
+      assertFalse(bucketFalse.requesterPays());
     } finally {
       RemoteStorageHelper.forceDelete(storage, bucketName, 5, TimeUnit.SECONDS);
     }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageTest.java
@@ -2410,7 +2410,8 @@ public class ITStorageTest {
 
     try {
       Bucket remoteBucket =
-          storage.get(bucketName, Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
+          storage.get(
+              bucketName, Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
       assertNull(remoteBucket.requesterPays());
       remoteBucket = remoteBucket.toBuilder().setRequesterPays(true).build();
       Bucket updatedBucket = storage.update(remoteBucket);
@@ -2419,7 +2420,7 @@ public class ITStorageTest {
       String projectId = remoteStorageHelper.getOptions().getProjectId();
 
       Storage.BucketSourceOption[] bucketOptions =
-          new Storage.BucketSourceOption[]{Storage.BucketSourceOption.userProject(projectId)};
+          new Storage.BucketSourceOption[] {Storage.BucketSourceOption.userProject(projectId)};
       Identity projectOwner = Identity.projectOwner(projectId);
       Identity projectEditor = Identity.projectEditor(projectId);
       Identity projectViewer = Identity.projectViewer(projectId);
@@ -2471,7 +2472,8 @@ public class ITStorageTest {
               ImmutableList.of("storage.buckets.getIamPolicy", "storage.buckets.setIamPolicy"),
               bucketOptions));
       remoteBucket = remoteBucket.toBuilder().setRequesterPays(false).build();
-      updatedBucket = storage.update(remoteBucket, Storage.BucketTargetOption.userProject(projectId));
+      updatedBucket =
+          storage.update(remoteBucket, Storage.BucketTargetOption.userProject(projectId));
       assertFalse(updatedBucket.requesterPays());
     } finally {
       RemoteStorageHelper.forceDelete(storage, bucketName, 5, TimeUnit.SECONDS);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageTest.java
@@ -2404,71 +2404,78 @@ public class ITStorageTest {
   }
 
   @Test
-  public void testBucketPolicyV1RequesterPays() {
-    Bucket remoteBucket =
-        storage.get(BUCKET, Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
-    assertFalse(remoteBucket.requesterPays());
-    remoteBucket = remoteBucket.toBuilder().setRequesterPays(true).build();
-    Bucket updatedBucket = storage.update(remoteBucket);
-    assertTrue(updatedBucket.requesterPays());
+  public void testBucketPolicyV1RequesterPays() throws ExecutionException, InterruptedException {
+    String bucketName = RemoteStorageHelper.generateBucketName();
+    storage.create(BucketInfo.newBuilder(bucketName).build());
 
-    String projectId = remoteStorageHelper.getOptions().getProjectId();
+    try {
+      Bucket remoteBucket =
+          storage.get(bucketName, Storage.BucketGetOption.fields(BucketField.ID, BucketField.BILLING));
+      assertNull(remoteBucket.requesterPays());
+      remoteBucket = remoteBucket.toBuilder().setRequesterPays(true).build();
+      Bucket updatedBucket = storage.update(remoteBucket);
+      assertTrue(updatedBucket.requesterPays());
 
-    Storage.BucketSourceOption[] bucketOptions =
-        new Storage.BucketSourceOption[] {Storage.BucketSourceOption.userProject(projectId)};
-    Identity projectOwner = Identity.projectOwner(projectId);
-    Identity projectEditor = Identity.projectEditor(projectId);
-    Identity projectViewer = Identity.projectViewer(projectId);
-    Map<com.google.cloud.Role, Set<Identity>> bindingsWithoutPublicRead =
-        ImmutableMap.of(
-            StorageRoles.legacyBucketOwner(),
-            new HashSet<>(Arrays.asList(projectOwner, projectEditor)),
-            StorageRoles.legacyBucketReader(),
-            (Set<Identity>) new HashSet<>(Collections.singleton(projectViewer)));
-    Map<com.google.cloud.Role, Set<Identity>> bindingsWithPublicRead =
-        ImmutableMap.of(
-            StorageRoles.legacyBucketOwner(),
-            new HashSet<>(Arrays.asList(projectOwner, projectEditor)),
-            StorageRoles.legacyBucketReader(),
-            new HashSet<>(Collections.singleton(projectViewer)),
-            StorageRoles.legacyObjectReader(),
-            (Set<Identity>) new HashSet<>(Collections.singleton(Identity.allUsers())));
+      String projectId = remoteStorageHelper.getOptions().getProjectId();
 
-    // Validate getting policy.
-    Policy currentPolicy = storage.getIamPolicy(BUCKET, bucketOptions);
-    assertEquals(bindingsWithoutPublicRead, currentPolicy.getBindings());
+      Storage.BucketSourceOption[] bucketOptions =
+          new Storage.BucketSourceOption[]{Storage.BucketSourceOption.userProject(projectId)};
+      Identity projectOwner = Identity.projectOwner(projectId);
+      Identity projectEditor = Identity.projectEditor(projectId);
+      Identity projectViewer = Identity.projectViewer(projectId);
+      Map<com.google.cloud.Role, Set<Identity>> bindingsWithoutPublicRead =
+          ImmutableMap.of(
+              StorageRoles.legacyBucketOwner(),
+              new HashSet<>(Arrays.asList(projectOwner, projectEditor)),
+              StorageRoles.legacyBucketReader(),
+              (Set<Identity>) new HashSet<>(Collections.singleton(projectViewer)));
+      Map<com.google.cloud.Role, Set<Identity>> bindingsWithPublicRead =
+          ImmutableMap.of(
+              StorageRoles.legacyBucketOwner(),
+              new HashSet<>(Arrays.asList(projectOwner, projectEditor)),
+              StorageRoles.legacyBucketReader(),
+              new HashSet<>(Collections.singleton(projectViewer)),
+              StorageRoles.legacyObjectReader(),
+              (Set<Identity>) new HashSet<>(Collections.singleton(Identity.allUsers())));
 
-    // Validate updating policy.
-    Policy updatedPolicy =
-        storage.setIamPolicy(
-            BUCKET,
-            currentPolicy
-                .toBuilder()
-                .addIdentity(StorageRoles.legacyObjectReader(), Identity.allUsers())
-                .build(),
-            bucketOptions);
-    assertEquals(bindingsWithPublicRead, updatedPolicy.getBindings());
-    Policy revertedPolicy =
-        storage.setIamPolicy(
-            BUCKET,
-            updatedPolicy
-                .toBuilder()
-                .removeIdentity(StorageRoles.legacyObjectReader(), Identity.allUsers())
-                .build(),
-            bucketOptions);
-    assertEquals(bindingsWithoutPublicRead, revertedPolicy.getBindings());
+      // Validate getting policy.
+      Policy currentPolicy = storage.getIamPolicy(bucketName, bucketOptions);
+      assertEquals(bindingsWithoutPublicRead, currentPolicy.getBindings());
 
-    // Validate testing permissions.
-    List<Boolean> expectedPermissions = ImmutableList.of(true, true);
-    assertEquals(
-        expectedPermissions,
-        storage.testIamPermissions(
-            BUCKET,
-            ImmutableList.of("storage.buckets.getIamPolicy", "storage.buckets.setIamPolicy"),
-            bucketOptions));
-    remoteBucket = remoteBucket.toBuilder().setRequesterPays(false).build();
-    updatedBucket = storage.update(remoteBucket, Storage.BucketTargetOption.userProject(projectId));
-    assertFalse(updatedBucket.requesterPays());
+      // Validate updating policy.
+      Policy updatedPolicy =
+          storage.setIamPolicy(
+              bucketName,
+              currentPolicy
+                  .toBuilder()
+                  .addIdentity(StorageRoles.legacyObjectReader(), Identity.allUsers())
+                  .build(),
+              bucketOptions);
+      assertEquals(bindingsWithPublicRead, updatedPolicy.getBindings());
+      Policy revertedPolicy =
+          storage.setIamPolicy(
+              bucketName,
+              updatedPolicy
+                  .toBuilder()
+                  .removeIdentity(StorageRoles.legacyObjectReader(), Identity.allUsers())
+                  .build(),
+              bucketOptions);
+      assertEquals(bindingsWithoutPublicRead, revertedPolicy.getBindings());
+
+      // Validate testing permissions.
+      List<Boolean> expectedPermissions = ImmutableList.of(true, true);
+      assertEquals(
+          expectedPermissions,
+          storage.testIamPermissions(
+              bucketName,
+              ImmutableList.of("storage.buckets.getIamPolicy", "storage.buckets.setIamPolicy"),
+              bucketOptions));
+      remoteBucket = remoteBucket.toBuilder().setRequesterPays(false).build();
+      updatedBucket = storage.update(remoteBucket, Storage.BucketTargetOption.userProject(projectId));
+      assertFalse(updatedBucket.requesterPays());
+    } finally {
+      RemoteStorageHelper.forceDelete(storage, bucketName, 5, TimeUnit.SECONDS);
+    }
   }
 
   @Test


### PR DESCRIPTION
The test is updated to use a new bucket (and delete it at the end) instead of reusing the shared one.

Fixes #349 
