### PR TITLE
feat: Add abort() to writer

### DIFF
--- a/google-cloud-storage/clirr-ignored-differences.xml
+++ b/google-cloud-storage/clirr-ignored-differences.xml
@@ -22,6 +22,16 @@
         <differenceType>7013</differenceType>
     </difference>
     <difference>
+        <differenceType>7012</differenceType>
+        <className>com/google/cloud/storage/Storage</className>
+        <method>void abort(com.google.cloud.WriteChannel)</method>
+    </difference>
+    <difference>
+        <differenceType>7012</differenceType>
+        <className>com/google/cloud/storage/spi/v1/StorageRpc</className>
+        <method>void abort(java.lang.String)</method>
+    </difference>
+    <difference>
         <className>com/google/cloud/storage/BucketInfo$Builder</className>
         <method>com.google.cloud.storage.BucketInfo$Builder setUpdateTime(java.lang.Long)</method>
         <differenceType>7013</differenceType>

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobWriteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobWriteChannel.java
@@ -78,6 +78,24 @@ class BlobWriteChannel extends BaseWriteChannel<StorageOptions, BlobInfo> {
     }
   }
 
+  void cancelUpload() {
+    try {
+      runWithRetries(
+          callable(
+              new Runnable() {
+                @Override
+                public void run() {
+                  getOptions().getStorageRpcV1().abort(getUploadId());
+                }
+              }),
+          getOptions().getRetrySettings(),
+          StorageImpl.EXCEPTION_HANDLER,
+          getOptions().getClock());
+    } catch (RetryHelper.RetryHelperException e) {
+      throw StorageException.translateAndThrow(e);
+    }
+  }
+
   protected StateImpl.Builder stateBuilder() {
     return StateImpl.builder(getOptions(), getEntity(), getUploadId());
   }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
@@ -2693,6 +2693,17 @@ public interface Storage extends Service<StorageOptions> {
   WriteChannel writer(URL signedURL);
 
   /**
+   * Aborts resumeable upload. Further attempts to write to or close the channel will result in
+   * {@code StorageException} with the code {@code 499}.
+   *
+   * @param channel an instance crated either by {@link #writer(BlobInfo, BlobWriteOption...)} or by
+   *     {@link #writer(URL)} method.
+   * @throws IllegalArgumentException if inappropriate channel is given
+   * @throws StorageException upon failure
+   */
+  void abort(WriteChannel channel);
+
+  /**
    * Generates a signed URL for a blob. If you have a blob that you want to allow access to for a
    * fixed amount of time, you can use this method to generate a URL that is only valid within a
    * certain time period. This is particularly useful if you don't want publicly accessible blobs,

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
@@ -696,6 +696,15 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
     return new BlobWriteChannel(getOptions(), signedURL);
   }
 
+  @Override
+  public void abort(WriteChannel channel) {
+    if (!(channel instanceof BlobWriteChannel)) {
+      throw new IllegalArgumentException("channel is not created by Storage");
+    }
+    BlobWriteChannel blobWriteChannel = (BlobWriteChannel) channel;
+    blobWriteChannel.cancelUpload();
+  }
+
   private BlobWriteChannel writer(BlobInfo blobInfo, BlobTargetOption... options) {
     final Map<StorageRpc.Option, ?> optionsMap = optionMap(blobInfo, options);
     return new BlobWriteChannel(getOptions(), blobInfo, optionsMap);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpcSpans.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpcSpans.java
@@ -44,6 +44,7 @@ class HttpStorageRpcSpans {
   static final String SPAN_NAME_OPEN_REWRITE = getTraceSpanName("openRewrite(RewriteRequest)");
   static final String SPAN_NAME_CONTINUE_REWRITE =
       getTraceSpanName("continueRewrite(RewriteResponse)");
+  static final String SPAN_NAME_ABORT = getTraceSpanName("abort(String)");
   static final String SPAN_NAME_GET_BUCKET_ACL = getTraceSpanName("getAcl(String,String,Map)");
   static final String SPAN_NAME_DELETE_BUCKET_ACL =
       getTraceSpanName("deleteAcl(String,String,Map)");

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/StorageRpc.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/StorageRpc.java
@@ -357,6 +357,13 @@ public interface StorageRpc extends ServiceRpc {
   RewriteResponse openRewrite(RewriteRequest rewriteRequest);
 
   /**
+   * Aborts the given resumable upload.
+   *
+   * @throws StorageException upon failure
+   */
+  void abort(String uploadId);
+
+  /**
    * Continues rewriting on an already open rewrite channel.
    *
    * @throws StorageException upon failure

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/testing/StorageRpcTestBase.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/testing/StorageRpcTestBase.java
@@ -156,6 +156,11 @@ public class StorageRpcTestBase implements StorageRpc {
   }
 
   @Override
+  public void abort(String uploadId) {
+    throw new UnsupportedOperationException("Not implemented yet");
+  }
+
+  @Override
   public RewriteResponse continueRewrite(RewriteResponse previousResponse) {
     throw new UnsupportedOperationException("Not implemented yet");
   }


### PR DESCRIPTION
Fixes #202
The current implementation is not elegant, because one has to call `storage.abort(writer)` to cancel resumable upload. 
Once https://github.com/googleapis/java-core/issues/245 is implemented (I hope it will be implemented sooner or later), we need just to rename private `cancelUpload()` method of `BlobWriteChannel` to `public void abort()`. 