### PR TITLE
fix: prevent NPE in RemoteStorageHelper.cleanBuckets

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/testing/RemoteStorageHelper.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/testing/RemoteStorageHelper.java
@@ -88,7 +88,8 @@ public class RemoteStorageHelper {
                                   Storage.BlobField.EVENT_BASED_HOLD,
                                   Storage.BlobField.TEMPORARY_HOLD))
                           .iterateAll()) {
-                    if (blob.getEventBasedHold() == true || blob.getTemporaryHold() == true) {
+                    if (Boolean.TRUE.equals(blob.getEventBasedHold())
+                        || Boolean.TRUE.equals(blob.getTemporaryHold())) {
                       storage.update(
                           blob.toBuilder().setTemporaryHold(false).setEventBasedHold(false).build(),
                           Storage.BlobTargetOption.userProject(


### PR DESCRIPTION
The method `getEventBasedHold` and `getTemporaryHold` return `Boolean` objects which are either `true`, `false` or `null`. In case of a `null` value, this produced a NPE.