### PR TITLE
chore: ignore generation of nightly kokoro config

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -19,6 +19,7 @@ import synthtool.languages.java as java
 AUTOSYNTH_MULTIPLE_COMMITS = True
 
 java.common_templates(excludes=[
+  '.kokoro/nightly/integration.cfg',
   '.kokoro/presubmit/integration.cfg',
   'CONTRIBUTING.md'
 ])


### PR DESCRIPTION
The .kokoro/nightly/integration.cfg file has manual changes as should be ignoerd by the template generation

See #520 