### PR TITLE
fix(test): update blob paths used in storage.it.ITStorageTest#testDownloadPublicBlobWithoutAuthentication (#759)

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageTest.java
@@ -2125,11 +2125,11 @@ public class ITStorageTest {
 
     // try to download blobs from a public bucket
     String landsatBucket = "gcp-public-data-landsat";
-    String landsatPrefix = "LC08/PRE/044/034/LC80440342016259LGN00/";
-    String landsatBlob = landsatPrefix + "LC80440342016259LGN00_MTL.txt";
+    String landsatPrefix = "LC08/01/001/002/LC08_L1GT_001002_20160817_20170322_01_T2/";
+    String landsatBlob = landsatPrefix + "LC08_L1GT_001002_20160817_20170322_01_T2_ANG.txt";
     byte[] bytes = unauthorizedStorage.readAllBytes(landsatBucket, landsatBlob);
 
-    assertThat(bytes.length).isEqualTo(7903);
+    assertThat(bytes.length).isEqualTo(117255);
     int numBlobs = 0;
     Iterator<Blob> blobIterator =
         unauthorizedStorage
@@ -2140,7 +2140,7 @@ public class ITStorageTest {
       numBlobs++;
       blobIterator.next();
     }
-    assertThat(numBlobs).isEqualTo(13);
+    assertThat(numBlobs).isEqualTo(14);
 
     // try to download blobs from a bucket that requires authentication
     // authenticated client will succeed


### PR DESCRIPTION
Port of https://github.com/googleapis/google-cloud-go/pull/3806

Fixes https://github.com/googleapis/java-storage/issues/755

cherry-pick from
https://github.com/googleapis/java-storage/commit/9a6619c39a89e2c2ee8d0000d595d09ac7b7825f

