### PR TITLE
build: update google-api-client to use version from google-cloud-shared-dependencies

### DIFF
--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -34,7 +34,6 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.31.5</version>
     </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>


### PR DESCRIPTION
By manually specifying the version of google-api-client here a diamond is created if this version is higher than google-cloud-shared-dependencies.

This PR will actually down grade google-api-client to v1.31.4 until shared-dependencies v1.1.1 is released.

