### PR TITLE
build(ci): remove linkage-monitor to pass 1.106.1 patch ci

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -42,7 +42,6 @@ branchProtectionRules:
     requiredStatusCheckContexts:
     - dependencies (8)
     - dependencies (11)
-    - linkage-monitor
     - lint
     - clirr
     - units (7)


### PR DESCRIPTION
The linkage-monitor check on the 1.106.1 patch branch is failing b/c of a mismatched `libraries-bom` dependency reported here: https://github.com/googleapis/java-storage/pull/847/checks?check_run_id=2742109053#step:6:15.

Linkage monitor pulls in the latest libraries-bom & will always fail for this older java-storage version.

This removes linkage-monitor as a required check to pass before merging.