### PR TITLE
build: rename 1.106.1 patch branch name

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -9,5 +9,5 @@ branches:
   - bumpMinorPreMajor: true
     handleGHRelease: true
     releaseType: java-yoshi
-    branch: 1.106.1
+    branch: 1.106.1-patch
     

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -34,7 +34,7 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-  - pattern: 1.106.1
+  - pattern: 1.106.1-patch
     isAdminEnforced: true
     requiredApprovingReviewCount: 1
     requiresCodeOwnerReviews: true


### PR DESCRIPTION
Update branch name in ci config to reduce confusion of tag vs branch

Part of https://github.com/googleapis/java-storage/issues/843
