### PR TITLE
feat: Add from and to storage url options for BlobId

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobId.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobId.java
@@ -58,7 +58,7 @@ public final class BlobId implements Serializable {
   }
 
   /** Returns this blob's Storage url which can be used with gsutil */
-  public String toStorageUrl() {
+  public String toGsUtilUri() {
     return "gs://" + bucket + "/" + name;
   }
 
@@ -123,14 +123,16 @@ public final class BlobId implements Serializable {
   /**
    * Creates a {@code BlobId} object.
    *
-   * @param storageUrl the Storage url to create the blob from
+   * @param gsUtilUri the Storage url to create the blob from
    */
-  public static BlobId fromStorageUrl(String storageUrl) {
-    if(!Pattern.matches("gs://.*/.*", storageUrl)) {
-      throw new IllegalArgumentException(storageUrl + " is not a valid Storage URL");
+  public static BlobId fromGsUtilUri(String gsUtilUri) {
+    if (!Pattern.matches("gs://.*/.*", gsUtilUri)) {
+      throw new IllegalArgumentException(
+          gsUtilUri + " is not a valid gsutil URI (i.e. \"gs://bucket/blob\")");
     }
-    String bucketName = storageUrl.split("/")[2];
-    String blobName = storageUrl.split(bucketName + "/")[1];
+    int blobNameStartIndex = gsUtilUri.indexOf('/', 5);
+    String bucketName = gsUtilUri.substring(5, blobNameStartIndex);
+    String blobName = gsUtilUri.substring(blobNameStartIndex + 1);
 
     return BlobId.of(bucketName, blobName);
   }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobId.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobId.java
@@ -22,6 +22,7 @@ import com.google.api.services.storage.model.StorageObject;
 import com.google.common.base.MoreObjects;
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 /**
  * Google Storage Object identifier. A {@code BlobId} object includes the name of the containing
@@ -54,6 +55,11 @@ public final class BlobId implements Serializable {
   /** Returns blob's data generation. Used for versioning. */
   public Long getGeneration() {
     return generation;
+  }
+
+  /** Returns this blob's Storage url which can be used with gsutil */
+  public String toStorageUrl() {
+    return "gs://" + bucket + "/" + name;
   }
 
   @Override
@@ -112,6 +118,21 @@ public final class BlobId implements Serializable {
    */
   public static BlobId of(String bucket, String name, Long generation) {
     return new BlobId(checkNotNull(bucket), checkNotNull(name), generation);
+  }
+
+  /**
+   * Creates a {@code BlobId} object.
+   *
+   * @param storageUrl the Storage url to create the blob from
+   */
+  public static BlobId fromStorageUrl(String storageUrl) {
+    if(!Pattern.matches("gs://.*/.*", storageUrl)) {
+      throw new IllegalArgumentException(storageUrl + " is not a valid Storage URL");
+    }
+    String bucketName = storageUrl.split("/")[2];
+    String blobName = storageUrl.split(bucketName + "/")[1];
+
+    return BlobId.of(bucketName, blobName);
   }
 
   static BlobId fromPb(StorageObject storageObject) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BlobIdTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BlobIdTest.java
@@ -32,6 +32,14 @@ public class BlobIdTest {
   }
 
   @Test
+  public void testToFromStorageUrl() {
+    BlobId blobId = BlobId.fromStorageUrl("gs://bucket/path/to/blob");
+    assertEquals("bucket", blobId.getBucket());
+    assertEquals("path/to/blob", blobId.getName());
+    assertEquals("gs://bucket/path/to/blob", blobId.toStorageUrl());
+  }
+
+  @Test
   public void testEquals() {
     compareBlobIds(BLOB, BlobId.of("b", "n"));
   }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BlobIdTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BlobIdTest.java
@@ -32,11 +32,11 @@ public class BlobIdTest {
   }
 
   @Test
-  public void testToFromStorageUrl() {
-    BlobId blobId = BlobId.fromStorageUrl("gs://bucket/path/to/blob");
+  public void testToFromGsUtilUri() {
+    BlobId blobId = BlobId.fromGsUtilUri("gs://bucket/path/to/blob");
     assertEquals("bucket", blobId.getBucket());
     assertEquals("path/to/blob", blobId.getName());
-    assertEquals("gs://bucket/path/to/blob", blobId.toStorageUrl());
+    assertEquals("gs://bucket/path/to/blob", blobId.toGsUtilUri());
   }
 
   @Test


### PR DESCRIPTION
Adds options for creating a blob ID from a storage url and vice versa. Fixes https://github.com/googleapis/java-storage/issues/868