### PR TITLE
feat: fix post policy escape bug, update conformance tests

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/PostPolicyV4.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/PostPolicyV4.java
@@ -443,13 +443,21 @@ public final class PostPolicyV4 {
       StringBuilder escapedJson = new StringBuilder();
 
       // Certain characters in a policy must be escaped
-      for (char c : json.toCharArray()) {
+      char[] jsonArray = json.toCharArray();
+      for (int i = 0; i < jsonArray.length; i++) {
+        char c = jsonArray[i];
         if (c >= 128) { // is a unicode character
           escapedJson.append(String.format("\\u%04x", (int) c));
         } else {
           switch (c) {
             case '\\':
-              escapedJson.append("\\\\");
+              // The JsonObject/JsonArray operations above handle quote escapes, so leave any "/""
+              // found alone
+              if (jsonArray[i + 1] == '"') {
+                escapedJson.append("\\");
+              } else {
+                escapedJson.append("\\\\");
+              }
               break;
             case '\b':
               escapedJson.append("\\b");

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/PostPolicyV4.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/PostPolicyV4.java
@@ -451,7 +451,7 @@ public final class PostPolicyV4 {
         } else {
           switch (c) {
             case '\\':
-              // The JsonObject/JsonArray operations above handle quote escapes, so leave any "/""
+              // The JsonObject/JsonArray operations above handle quote escapes, so leave any "\""
               // found alone
               if (jsonArray[i + 1] == '"') {
                 escapedJson.append("\\");

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-conformance-tests</artifactId>
-        <version>0.0.11</version>
+        <version>0.1.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
V4 Post Policy had an issue where quotes in the json policy would get double escaped (`"` would became `\\"` instead of `\"`), this fixes that issue and updates the conformance tests to the latest version