### PR TITLE
chore(retry): introduce RetryAlgorithmManager

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/CopyWriter.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/CopyWriter.java
@@ -100,6 +100,7 @@ public class CopyWriter implements Restorable<CopyWriter> {
       this.rewriteResponse =
           Retrying.run(
               serviceOptions,
+              serviceOptions.getRetryAlgorithmManager().getForObjectsCopy(),
               () -> storageRpc.continueRewrite(rewriteResponse),
               Function.identity());
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/LegacyRetryAlgorithmManager.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/LegacyRetryAlgorithmManager.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import com.google.api.services.storage.model.Bucket;
+import com.google.api.services.storage.model.BucketAccessControl;
+import com.google.api.services.storage.model.HmacKeyMetadata;
+import com.google.api.services.storage.model.ObjectAccessControl;
+import com.google.api.services.storage.model.Policy;
+import com.google.api.services.storage.model.StorageObject;
+import com.google.cloud.BaseService;
+import com.google.cloud.ExceptionHandler;
+import com.google.cloud.storage.spi.v1.StorageRpc;
+import com.google.cloud.storage.spi.v1.StorageRpc.RewriteRequest;
+import java.util.List;
+import java.util.Map;
+
+class LegacyRetryAlgorithmManager implements RetryAlgorithmManager {
+
+  @Override
+  public ExceptionHandler getForBucketAclCreate(
+      BucketAccessControl pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForBucketAclDelete(String pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForBucketAclGet(String pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForBucketAclUpdate(
+      BucketAccessControl pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForBucketAclList(String pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForBucketsCreate(Bucket pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForBucketsDelete(Bucket pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForBucketsGet(Bucket pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForBucketsUpdate(Bucket pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForBucketsList(Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForBucketsLockRetentionPolicy(
+      Bucket pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForBucketsGetIamPolicy(
+      String bucket, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForBucketsSetIamPolicy(
+      String bucket, Policy pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForBucketsTestIamPermissions(
+      String bucket, List<String> permissions, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForDefaultObjectAclCreate(ObjectAccessControl pb) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForDefaultObjectAclDelete(String pb) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForDefaultObjectAclGet(String pb) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForDefaultObjectAclUpdate(ObjectAccessControl pb) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForDefaultObjectAclList(String pb) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForHmacKeyCreate(String pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForHmacKeyDelete(
+      HmacKeyMetadata pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForHmacKeyGet(String accessId, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForHmacKeyUpdate(
+      HmacKeyMetadata pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForHmacKeyList(Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForObjectAclCreate(ObjectAccessControl aclPb) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForObjectAclDelete(
+      String bucket, String name, Long generation, String pb) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForObjectAclList(String bucket, String name, Long generation) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForObjectAclGet(
+      String bucket, String name, Long generation, String pb) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForObjectAclUpdate(ObjectAccessControl aclPb) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForObjectsCreate(
+      StorageObject pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForObjectsDelete(
+      StorageObject pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForObjectsGet(StorageObject pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForObjectsUpdate(
+      StorageObject pb, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForObjectsList(String bucket, Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForObjectsRewrite(RewriteRequest pb) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForObjectsCopy() {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForObjectsCompose(
+      List<StorageObject> sources, StorageObject target, Map<StorageRpc.Option, ?> targetOptions) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForResumableUploadSessionCreate(Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForResumableUploadSessionWrite(Map<StorageRpc.Option, ?> optionsMap) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+
+  @Override
+  public ExceptionHandler getForServiceAccountGet(String pb) {
+    return BaseService.EXCEPTION_HANDLER;
+  }
+}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/NewRetryAlgorithmManager.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/NewRetryAlgorithmManager.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+final class NewRetryAlgorithmManager extends LegacyRetryAlgorithmManager
+    implements RetryAlgorithmManager {}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableMedia.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableMedia.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import com.google.api.core.ApiFutures;
+import com.google.cloud.ExceptionHandler;
+import com.google.cloud.storage.spi.v1.StorageRpc;
+import java.net.URL;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+final class ResumableMedia {
+
+  static Supplier<String> startUploadForBlobInfo(
+      final StorageOptions storageOptions,
+      final BlobInfo blob,
+      final Map<StorageRpc.Option, ?> optionsMap,
+      ExceptionHandler exceptionHandler) {
+    return () ->
+        Retrying.run(
+            storageOptions,
+            exceptionHandler,
+            () -> storageOptions.getStorageRpcV1().open(blob.toPb(), optionsMap),
+            Function.identity());
+  }
+
+  static Supplier<String> startUploadForSignedUrl(
+      final StorageOptions storageOptions, final URL signedURL, ExceptionHandler exceptionHandler) {
+    if (!isValidSignedURL(signedURL.getQuery())) {
+      ApiFutures.immediateFailedFuture(new StorageException(2, "invalid signedURL"));
+    }
+    return () ->
+        Retrying.run(
+            storageOptions,
+            exceptionHandler,
+            () -> storageOptions.getStorageRpcV1().open(signedURL.toString()),
+            Function.identity());
+  }
+
+  private static boolean isValidSignedURL(String signedURLQuery) {
+    boolean isValid = true;
+    if (signedURLQuery.startsWith("X-Goog-Algorithm=")) {
+      if (!signedURLQuery.contains("&X-Goog-Credential=")
+          || !signedURLQuery.contains("&X-Goog-Date=")
+          || !signedURLQuery.contains("&X-Goog-Expires=")
+          || !signedURLQuery.contains("&X-Goog-SignedHeaders=")
+          || !signedURLQuery.contains("&X-Goog-Signature=")) {
+        isValid = false;
+      }
+    } else if (signedURLQuery.startsWith("GoogleAccessId=")) {
+      if (!signedURLQuery.contains("&Expires=") || !signedURLQuery.contains("&Signature=")) {
+        isValid = false;
+      }
+    } else {
+      isValid = false;
+    }
+    return isValid;
+  }
+}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/RetryAlgorithmManager.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/RetryAlgorithmManager.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import com.google.api.services.storage.model.Bucket;
+import com.google.api.services.storage.model.BucketAccessControl;
+import com.google.api.services.storage.model.HmacKeyMetadata;
+import com.google.api.services.storage.model.ObjectAccessControl;
+import com.google.api.services.storage.model.Policy;
+import com.google.api.services.storage.model.StorageObject;
+import com.google.cloud.ExceptionHandler;
+import com.google.cloud.storage.spi.v1.StorageRpc;
+import com.google.cloud.storage.spi.v1.StorageRpc.RewriteRequest;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+interface RetryAlgorithmManager extends Serializable {
+  ExceptionHandler getForBucketAclCreate(
+      BucketAccessControl pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForBucketAclDelete(String pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForBucketAclGet(String pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForBucketAclUpdate(
+      BucketAccessControl pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForBucketAclList(String pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForBucketsCreate(Bucket pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForBucketsDelete(Bucket pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForBucketsGet(Bucket pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForBucketsUpdate(Bucket pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForBucketsList(Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForBucketsLockRetentionPolicy(
+      Bucket pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForBucketsGetIamPolicy(String bucket, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForBucketsSetIamPolicy(
+      String bucket, Policy pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForBucketsTestIamPermissions(
+      String bucket, List<String> permissions, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForDefaultObjectAclCreate(ObjectAccessControl pb);
+
+  ExceptionHandler getForDefaultObjectAclDelete(String pb);
+
+  ExceptionHandler getForDefaultObjectAclGet(String pb);
+
+  ExceptionHandler getForDefaultObjectAclUpdate(ObjectAccessControl pb);
+
+  ExceptionHandler getForDefaultObjectAclList(String pb);
+
+  ExceptionHandler getForHmacKeyCreate(String pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForHmacKeyDelete(HmacKeyMetadata pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForHmacKeyGet(String accessId, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForHmacKeyUpdate(HmacKeyMetadata pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForHmacKeyList(Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForObjectAclCreate(ObjectAccessControl aclPb);
+
+  ExceptionHandler getForObjectAclDelete(String bucket, String name, Long generation, String pb);
+
+  ExceptionHandler getForObjectAclList(String bucket, String name, Long generation);
+
+  ExceptionHandler getForObjectAclGet(String bucket, String name, Long generation, String pb);
+
+  ExceptionHandler getForObjectAclUpdate(ObjectAccessControl aclPb);
+
+  ExceptionHandler getForObjectsCreate(StorageObject pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForObjectsDelete(StorageObject pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForObjectsGet(StorageObject pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForObjectsUpdate(StorageObject pb, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForObjectsList(String bucket, Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForObjectsRewrite(RewriteRequest pb);
+
+  ExceptionHandler getForObjectsCopy();
+
+  ExceptionHandler getForObjectsCompose(
+      List<StorageObject> sources, StorageObject target, Map<StorageRpc.Option, ?> targetOptions);
+
+  ExceptionHandler getForResumableUploadSessionCreate(Map<StorageRpc.Option, ?> optionsMap);
+  /** Resumable upload has differing 429 handling */
+  ExceptionHandler getForResumableUploadSessionWrite(Map<StorageRpc.Option, ?> optionsMap);
+
+  ExceptionHandler getForServiceAccountGet(String pb);
+}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Retrying.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Retrying.java
@@ -21,7 +21,7 @@ import static com.google.cloud.RetryHelper.runWithRetries;
 import com.google.api.core.ApiClock;
 import com.google.api.gax.retrying.ResultRetryAlgorithm;
 import com.google.api.gax.retrying.RetrySettings;
-import com.google.cloud.BaseService;
+import com.google.cloud.ExceptionHandler;
 import com.google.cloud.RetryHelper.RetryHelperException;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
@@ -33,25 +33,27 @@ final class Retrying {
    * RetrySettings, ResultRetryAlgorithm, ApiClock)} that gives us centralized error translation and
    * reduces some duplication in how we resolved the {@link RetrySettings} and {@link ApiClock}.
    *
+   * @param <T> The result type of {@code c}
+   * @param <U> The result type of any mapping that takes place via {@code f}
    * @param options The {@link StorageOptions} which {@link RetrySettings} and {@link ApiClock} will
    *     be resolved from.
+   * @param exceptionHandler The {@link ExceptionHandler} to use when determining if a retry is
+   *     possible
    * @param c The {@link Callable} which will be passed to runWithRetries producing some {@code T},
    *     can optionally return null
    * @param f A post process mapping {@link Function} which can be used to transform the result from
    *     {@code c} if it is successful and non-null
-   * @param <T> The result type of {@code c}
-   * @param <U> The result type of any mapping that takes place via {@code f}
    * @return A {@code U} (possibly null) after applying {@code f} to the result of {@code c}
    * @throws StorageException if {@code c} fails due to any retry exhaustion
    */
-  static <T, U> U run(StorageOptions options, Callable<T> c, Function<T, U> f) {
+  static <T, U> U run(
+      StorageOptions options, ExceptionHandler exceptionHandler, Callable<T> c, Function<T, U> f) {
     try {
-      T answer =
-          runWithRetries(
-              c, options.getRetrySettings(), BaseService.EXCEPTION_HANDLER, options.getClock());
-      return answer == null ? null : f.apply(answer);
+      T result =
+          runWithRetries(c, options.getRetrySettings(), exceptionHandler, options.getClock());
+      return result == null ? null : f.apply(result);
     } catch (RetryHelperException e) {
-      throw StorageException.translateAndThrow(e);
+      throw StorageException.coalesce(e);
     }
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageException.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageException.java
@@ -78,7 +78,26 @@ public final class StorageException extends BaseHttpServiceException {
    */
   public static StorageException translateAndThrow(RetryHelperException ex) {
     BaseServiceException.translate(ex);
-    throw new StorageException(UNKNOWN_CODE, ex.getMessage(), ex.getCause());
+    throw getStorageException(ex);
+  }
+
+  private static StorageException getStorageException(Throwable t) {
+    return new StorageException(UNKNOWN_CODE, t.getMessage(), t.getCause());
+  }
+
+  /**
+   * Attempt to find an Exception which is a {@link BaseServiceException} If neither {@code t} or
+   * {@code t.getCause()} are a {@code BaseServiceException} a {@link StorageException} will be
+   * created with an unknown status code.
+   */
+  static BaseServiceException coalesce(Throwable t) {
+    if (t instanceof BaseServiceException) {
+      return (BaseServiceException) t;
+    }
+    if (t.getCause() instanceof BaseServiceException) {
+      return (BaseServiceException) t.getCause();
+    }
+    return getStorageException(t);
   }
 
   /**

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
@@ -38,4 +38,8 @@ public final class PackagePrivateMethodWorkarounds {
     BlobInfo.BuilderImpl builder = (BlobInfo.BuilderImpl) BlobInfo.fromPb(b.toPb()).toBuilder();
     return new Blob(s, builder);
   }
+
+  public static StorageOptions.Builder useNewRetryAlgorithmManager(StorageOptions.Builder builder) {
+    return builder.setUseDefaultRetryAlgorithms();
+  }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ResumableMediaTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ResumableMediaTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static org.junit.Assert.assertNotNull;
+
+import com.google.cloud.BaseService;
+import com.google.cloud.ExceptionHandler;
+import java.net.URL;
+import org.junit.Assert;
+import org.junit.Test;
+
+public final class ResumableMediaTest {
+  private static final String SIGNED_URL =
+      "http://www.test.com/test-bucket/test1.txt?GoogleAccessId=testClient-test@test.com&Expires=1553839761&Signature=MJUBXAZ7";
+
+  private final ExceptionHandler createResultExceptionHandler = BaseService.EXCEPTION_HANDLER;
+
+  @Test
+  public void startUploadForSignedUrl_expectStorageException_whenUrlInvalid() throws Exception {
+    try {
+      ResumableMedia.startUploadForSignedUrl(
+              StorageOptions.newBuilder().build(),
+              new URL(SIGNED_URL),
+              createResultExceptionHandler)
+          .get();
+      Assert.fail();
+    } catch (StorageException ex) {
+      assertNotNull(ex.getMessage());
+    }
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/SerializationTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/SerializationTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.storage;
 
 import com.google.cloud.BaseSerializationTest;
+import com.google.cloud.ExceptionHandler;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.PageImpl;
 import com.google.cloud.ReadChannel;
@@ -99,12 +100,17 @@ public class SerializationTest extends BaseSerializationTest {
   @Override
   protected Restorable<?>[] restorableObjects() {
     StorageOptions options = StorageOptions.newBuilder().setProjectId("p2").build();
+    ExceptionHandler exceptionHandler =
+        options.getRetryAlgorithmManager().getForResumableUploadSessionWrite(EMPTY_RPC_OPTIONS);
     ReadChannel reader = new BlobReadChannel(options, BlobId.of("b", "n"), EMPTY_RPC_OPTIONS);
     // avoid closing when you don't want partial writes to GCS upon failure
     @SuppressWarnings("resource")
     BlobWriteChannel writer =
         new BlobWriteChannel(
-            options, BlobInfo.newBuilder(BlobId.of("b", "n")).build(), "upload-id");
+            options,
+            BlobInfo.newBuilder(BlobId.of("b", "n")).build(),
+            "upload-id",
+            exceptionHandler);
     return new Restorable<?>[] {reader, writer};
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageBatchTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageBatchTest.java
@@ -54,6 +54,8 @@ public class StorageBatchTest {
     BlobTargetOption.generationMatch(), BlobTargetOption.metagenerationMatch()
   };
   private static final GoogleJsonError GOOGLE_JSON_ERROR = new GoogleJsonError();
+  private final RetryAlgorithmManager retryAlgorithmManager =
+      StorageOptions.getDefaultInstance().getRetryAlgorithmManager();
 
   private StorageOptions optionsMock;
   private StorageRpc storageRpcMock;
@@ -67,6 +69,9 @@ public class StorageBatchTest {
     storageRpcMock = EasyMock.createMock(StorageRpc.class);
     batchMock = EasyMock.createMock(RpcBatch.class);
     EasyMock.expect(optionsMock.getStorageRpcV1()).andReturn(storageRpcMock);
+    EasyMock.expect(optionsMock.getRetryAlgorithmManager())
+        .andReturn(retryAlgorithmManager)
+        .anyTimes();
     EasyMock.expect(storageRpcMock.createBatch()).andReturn(batchMock);
     EasyMock.replay(optionsMock, storageRpcMock, batchMock, storage);
     storageBatch = new StorageBatch(optionsMock);
@@ -165,8 +170,11 @@ public class StorageBatchTest {
   @Test
   public void testUpdateWithOptions() {
     EasyMock.reset(storage, batchMock, optionsMock);
-    EasyMock.expect(storage.getOptions()).andReturn(optionsMock).times(2);
-    EasyMock.expect(optionsMock.getService()).andReturn(storage);
+    EasyMock.expect(storage.getOptions()).andReturn(optionsMock).anyTimes();
+    EasyMock.expect(optionsMock.getService()).andReturn(storage).anyTimes();
+    EasyMock.expect(optionsMock.getRetryAlgorithmManager())
+        .andReturn(retryAlgorithmManager)
+        .anyTimes();
     Capture<RpcBatch.Callback<StorageObject>> callback = Capture.newInstance();
     Capture<Map<StorageRpc.Option, Object>> capturedOptions = Capture.newInstance();
     batchMock.addPatch(
@@ -216,8 +224,11 @@ public class StorageBatchTest {
   @Test
   public void testGetWithOptions() {
     EasyMock.reset(storage, batchMock, optionsMock);
-    EasyMock.expect(storage.getOptions()).andReturn(optionsMock).times(2);
-    EasyMock.expect(optionsMock.getService()).andReturn(storage);
+    EasyMock.expect(storage.getOptions()).andReturn(optionsMock).anyTimes();
+    EasyMock.expect(optionsMock.getService()).andReturn(storage).anyTimes();
+    EasyMock.expect(optionsMock.getRetryAlgorithmManager())
+        .andReturn(retryAlgorithmManager)
+        .anyTimes();
     Capture<RpcBatch.Callback<StorageObject>> callback = Capture.newInstance();
     Capture<Map<StorageRpc.Option, Object>> capturedOptions = Capture.newInstance();
     batchMock.addGet(

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageImplTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageImplTest.java
@@ -38,7 +38,6 @@ import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.Identity;
 import com.google.cloud.Policy;
 import com.google.cloud.ServiceOptions;
-import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.Acl.Project;
 import com.google.cloud.storage.Acl.Project.ProjectRole;
 import com.google.cloud.storage.Acl.Role;
@@ -55,7 +54,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.BaseEncoding;
 import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.security.InvalidKeyException;
@@ -2146,16 +2144,6 @@ public class StorageImplTest {
     } catch (StorageException ex) {
       Assert.assertNotNull(ex.getMessage());
     }
-  }
-
-  @Test
-  public void testWriterWithSignedURL() throws MalformedURLException {
-    EasyMock.expect(storageRpcMock.open(SIGNED_URL)).andReturn("upload-id");
-    EasyMock.replay(storageRpcMock);
-    initializeService();
-    WriteChannel writer = new BlobWriteChannel(options, new URL(SIGNED_URL));
-    assertNotNull(writer);
-    assertTrue(writer.isOpen());
   }
 
   @Test

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RetryTestFixture.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RetryTestFixture.java
@@ -23,6 +23,7 @@ import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.conformance.storage.v1.InstructionList;
 import com.google.cloud.conformance.storage.v1.Method;
+import com.google.cloud.storage.PackagePrivateMethodWorkarounds;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.conformance.retry.TestBench.RetryTestResource;
@@ -138,6 +139,7 @@ final class RetryTestFixture implements TestRule {
             .setHost(testBench.getBaseUri())
             .setCredentials(NoCredentials.getInstance())
             .setProjectId("conformance-tests");
+    builder = PackagePrivateMethodWorkarounds.useNewRetryAlgorithmManager(builder);
     if (forTest) {
       builder.setHeaderProvider(
           new FixedHeaderProvider() {


### PR DESCRIPTION
### Summary
* RetryAlgorithmManager provides an abstraction point for determining
  which ExceptionHandler should be used for a specific call.
* Implement LegacyRetryAlgorithmManager for which all methods return
  BaseService.EXCEPTION_HANDLER which is hardcoded everywhere
  previously.
* Stub out NewRetryAlgorithmManager which currently extends
  LegacyRetryAlgorithmManager, but allows for overriding individual
  methods in an incremental manner.

### Refactoring
* All usages of BaseService.EXCEPTION_HANDLER in StorageImpl, Blob,
  Bucket etc now instead use RetryAlgorithmManager to resolve a
  handler per method.
* Refactor Blob to use Retrying#run instead of runWithRetries
* Split starting of a resumable upload session out of BlobWriteChannel
  to ResumableMedia. This decouple the ability to instantiate a
  BlobWriteChannel independent of performing an RPC to resolve the
  uploadId. This split is also necessary to allow differing configuration
  of ExceptionHandler for open vs write of a resumable upload session.
* Refactor StorageException#translateAndThrow to allow for an option which
  doesn't throw, new StorageException#coalesce which attempts to coalesce
  to a BaseServiceException but doesn't throw.
* Relax several easymock assertions on StorageOptions method. (Calling get
  on an immutable object shouldn't be so concerned with invocation count)

Related to #1024
