### PR TITLE
test: retry conformance tests fixes, round 2

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/CtxFunctions.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/CtxFunctions.java
@@ -97,10 +97,10 @@ final class CtxFunctions {
           Blob resolvedBlob = ctx.getStorage().create(blobInfo);
           return ctx.map(s -> s.with(resolvedBlob));
         };
-    private static final CtxFunction serviceAccount =
+    static final CtxFunction serviceAccount =
         (ctx, c) ->
             ctx.map(s -> s.with(ServiceAccount.of(c.getServiceAccountSigner().getAccount())));
-    private static final CtxFunction hmacKey =
+    static final CtxFunction hmacKey =
         (ctx, c) -> ctx.map(s -> s.with(ctx.getStorage().createHmacKey(s.getServiceAccount())));
 
     private static final CtxFunction processResources =

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/CtxFunctions.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/CtxFunctions.java
@@ -27,6 +27,7 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.HmacKey;
 import com.google.cloud.storage.ServiceAccount;
 import com.google.cloud.storage.conformance.retry.Functions.CtxFunction;
 import com.google.common.base.Joiner;
@@ -101,7 +102,12 @@ final class CtxFunctions {
         (ctx, c) ->
             ctx.map(s -> s.with(ServiceAccount.of(c.getServiceAccountSigner().getAccount())));
     static final CtxFunction hmacKey =
-        (ctx, c) -> ctx.map(s -> s.with(ctx.getStorage().createHmacKey(s.getServiceAccount())));
+        (ctx, c) ->
+            ctx.map(
+                s -> {
+                  HmacKey hmacKey1 = ctx.getStorage().createHmacKey(s.getServiceAccount());
+                  return s.withHmacKey(hmacKey1).with(hmacKey1.getMetadata());
+                });
 
     private static final CtxFunction processResources =
         (ctx, c) -> {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
@@ -32,6 +32,7 @@ import com.google.cloud.storage.conformance.retry.Functions.CtxFunction;
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.util.JsonFormat;
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,6 +41,7 @@ import java.math.BigInteger;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -332,10 +334,12 @@ public class ITRetryConformanceTest {
 
     /**
      * Filtering predicate in which only those test cases which match up to the specified {@code
-     * mappingId} will be included and run.
+     * mappingIds} will be included and run.
      */
-    static BiPredicate<RpcMethod, TestRetryConformance> individualMapping(int mappingId) {
-      return (m, c) -> c.getMappingId() == mappingId;
+    static BiPredicate<RpcMethod, TestRetryConformance> specificMappings(int... mappingIds) {
+      ImmutableSet<Integer> set = Arrays.stream(mappingIds).boxed()
+          .collect(ImmutableSet.toImmutableSet());
+      return (m, c) -> set.contains(c.getMappingId());
     }
 
     static final class Builder {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
@@ -337,8 +337,8 @@ public class ITRetryConformanceTest {
      * mappingIds} will be included and run.
      */
     static BiPredicate<RpcMethod, TestRetryConformance> specificMappings(int... mappingIds) {
-      ImmutableSet<Integer> set = Arrays.stream(mappingIds).boxed()
-          .collect(ImmutableSet.toImmutableSet());
+      ImmutableSet<Integer> set =
+          Arrays.stream(mappingIds).boxed().collect(ImmutableSet.toImmutableSet());
       return (m, c) -> set.contains(c.getMappingId());
     }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
@@ -20,6 +20,8 @@ import static com.google.cloud.storage.conformance.retry.CtxFunctions.Local.blob
 import static com.google.cloud.storage.conformance.retry.CtxFunctions.Local.blobInfoWithGenerationZero;
 import static com.google.cloud.storage.conformance.retry.CtxFunctions.Local.blobInfoWithoutGeneration;
 import static com.google.cloud.storage.conformance.retry.CtxFunctions.Local.bucketInfo;
+import static com.google.cloud.storage.conformance.retry.CtxFunctions.ResourceSetup.defaultSetup;
+import static com.google.cloud.storage.conformance.retry.CtxFunctions.ResourceSetup.serviceAccount;
 import static com.google.common.base.Predicates.not;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.truth.Truth.assertThat;
@@ -835,6 +837,7 @@ final class RpcMethodMappings {
       private static void create(ArrayList<RpcMethodMapping> a) {
         a.add(
             RpcMethodMapping.newBuilder(25, hmacKey.create)
+                .withSetup(defaultSetup.andThen(serviceAccount))
                 .withTest(
                     (ctx, c) ->
                         ctx.map(

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
@@ -537,15 +537,14 @@ final class RpcMethodMappings {
             RpcMethodMapping.newBuilder(122, buckets.patch)
                 .withApplicable(TestRetryConformance::isPreconditionsProvided)
                 .withTest(
-                    bucketInfo.andThen(
-                        (ctx, c) ->
-                            ctx.map(
-                                state ->
-                                    state.with(
-                                        ctx.getStorage()
-                                            .update(
-                                                state.getBucketInfo(),
-                                                BucketTargetOption.metagenerationMatch())))))
+                    (ctx, c) ->
+                        ctx.map(
+                            state ->
+                                state.with(
+                                    ctx.getStorage()
+                                        .update(
+                                            state.getBucket(),
+                                            BucketTargetOption.metagenerationMatch()))))
                 .build());
         a.add(
             RpcMethodMapping.newBuilder(101, buckets.patch)

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
@@ -591,29 +591,17 @@ final class RpcMethodMappings {
                                                 BucketTargetOption.metagenerationMatch())))))
                 .build());
         a.add(
-            RpcMethodMapping.newBuilder(99, buckets.lockRetentionPolicy)
-                .withTest(
-                    bucketInfo
-                        .andThen(Rpc.bucket)
-                        .andThen(
-                            (ctx, c) ->
-                                ctx.map(
-                                    state -> state.with(state.getBucket().lockRetentionPolicy()))))
-                .build());
-        a.add(
             RpcMethodMapping.newBuilder(100, buckets.lockRetentionPolicy)
+                .withApplicable(TestRetryConformance::isPreconditionsProvided)
                 .withTest(
-                    bucketInfo
-                        .andThen(Rpc.bucket)
-                        .andThen(
-                            (ctx, c) ->
-                                ctx.map(
-                                    state ->
-                                        state.with(
-                                            state
-                                                .getBucket()
-                                                .lockRetentionPolicy(
-                                                    BucketTargetOption.metagenerationMatch())))))
+                    (ctx, c) ->
+                        ctx.map(
+                            state ->
+                                state.with(
+                                    state
+                                        .getBucket()
+                                        .lockRetentionPolicy(
+                                            BucketTargetOption.metagenerationMatch()))))
                 .build());
       }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/State.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/State.java
@@ -211,7 +211,7 @@ final class State {
     return getValue(KEY_HMAC_KEY);
   }
 
-  public State with(HmacKey hmacKey) {
+  public State withHmacKey(HmacKey hmacKey) {
     return newStateWith(KEY_HMAC_KEY, hmacKey);
   }
 


### PR DESCRIPTION
* test: fix setup for hmacKey create
* test: fix setup for bucket patch
* test: cleanup bucket.lockRetentionPolicy mapping 
  * Add precondition predicate to mapping with IfMetagenerationMatch and remove mapping with no guard. Metageneration is a required argument.
* test: fix mappings for ReadChannel
  * ReadChannel wrap any exceptions in an IOException, and doesn't extract the cause from the RetryHelperException
* test: fix mappings hmacKey.delete
  * As part of setup for delete we need to set the key to inactive
* test: individualMapping(int) -> specificMappings(int...)