### PR TITLE
test(retry): fix objects.compose tests

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/NewRetryAlgorithmManager.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/NewRetryAlgorithmManager.java
@@ -284,7 +284,7 @@ final class NewRetryAlgorithmManager implements RetryAlgorithmManager {
   @Override
   public ExceptionHandler getForObjectsCompose(
       List<StorageObject> sources, StorageObject target, Map<StorageRpc.Option, ?> optionsMap) {
-    return optionsMap.containsKey(StorageRpc.Option.IF_METAGENERATION_MATCH)
+    return optionsMap.containsKey(StorageRpc.Option.IF_GENERATION_MATCH)
         ? IDEMPOTENT_HANDLER
         : NON_IDEMPOTENT_HANDLER;
   }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/State.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/State.java
@@ -30,6 +30,7 @@ import com.google.cloud.storage.CopyWriter;
 import com.google.cloud.storage.HmacKey;
 import com.google.cloud.storage.HmacKey.HmacKeyMetadata;
 import com.google.cloud.storage.ServiceAccount;
+import com.google.cloud.storage.Storage.ComposeRequest;
 import com.google.cloud.storage.conformance.retry.Functions.VoidFunction;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.Immutable;
@@ -75,6 +76,7 @@ final class State {
       new Key<>("testIamPermissionsResults");
   private static final Key<List<Acl>> KEY_ACLS = new Key<>("acls");
   private static final Key<byte[]> KEY_BYTES = new Key<>("bytes");
+  private static final Key<ComposeRequest> KEY_COMPOSE_REQUEST = new Key<>("composeRequest");
 
   private final ImmutableMap<Key<?>, Object> data;
 
@@ -291,6 +293,18 @@ final class State {
     List<T> collect =
         StreamSupport.stream(page.iterateAll().spliterator(), false).collect(Collectors.toList());
     return newStateWith(KEY_LIST_OBJECTS, collect);
+  }
+
+  public State with(ComposeRequest composeRequest) {
+    return newStateWith(KEY_COMPOSE_REQUEST, composeRequest);
+  }
+
+  public ComposeRequest getComposeRequest() {
+    return getValue(KEY_COMPOSE_REQUEST);
+  }
+
+  public boolean hasComposeRequest() {
+    return hasValue(KEY_COMPOSE_REQUEST);
   }
 
   private <T> T getValue(Key<T> key) {

--- a/google-cloud-storage/src/test/resources/com/google/cloud/storage/conformance/retry/testNamesWhichShouldSucceed.txt
+++ b/google-cloud-storage/src/test/resources/com/google/cloud/storage/conformance/retry/testNamesWhichShouldSucceed.txt
@@ -142,6 +142,7 @@ TestRetryConformance/1-[return-reset-connection_return-reset-connection]-storage
 TestRetryConformance/1-[return-reset-connection_return-reset-connection]-storage.serviceaccount.get-59
 TestRetryConformance/2-[return-503_return-503]-storage.buckets.patch-101
 TestRetryConformance/2-[return-503_return-503]-storage.buckets.patch-122
+TestRetryConformance/2-[return-503_return-503]-storage.objects.compose-35
 TestRetryConformance/2-[return-503_return-503]-storage.objects.delete-37
 TestRetryConformance/2-[return-503_return-503]-storage.objects.delete-38
 TestRetryConformance/2-[return-503_return-503]-storage.objects.delete-68
@@ -151,6 +152,7 @@ TestRetryConformance/2-[return-503_return-503]-storage.objects.patch-57
 TestRetryConformance/2-[return-503_return-503]-storage.objects.patch-80
 TestRetryConformance/2-[return-reset-connection_return-503]-storage.buckets.patch-101
 TestRetryConformance/2-[return-reset-connection_return-503]-storage.buckets.patch-122
+TestRetryConformance/2-[return-reset-connection_return-503]-storage.objects.compose-35
 TestRetryConformance/2-[return-reset-connection_return-503]-storage.objects.delete-37
 TestRetryConformance/2-[return-reset-connection_return-503]-storage.objects.delete-38
 TestRetryConformance/2-[return-reset-connection_return-503]-storage.objects.delete-68
@@ -160,6 +162,7 @@ TestRetryConformance/2-[return-reset-connection_return-503]-storage.objects.patc
 TestRetryConformance/2-[return-reset-connection_return-503]-storage.objects.patch-80
 TestRetryConformance/2-[return-reset-connection_return-reset-connection]-storage.buckets.patch-101
 TestRetryConformance/2-[return-reset-connection_return-reset-connection]-storage.buckets.patch-122
+TestRetryConformance/2-[return-reset-connection_return-reset-connection]-storage.objects.compose-35
 TestRetryConformance/2-[return-reset-connection_return-reset-connection]-storage.objects.delete-37
 TestRetryConformance/2-[return-reset-connection_return-reset-connection]-storage.objects.delete-38
 TestRetryConformance/2-[return-reset-connection_return-reset-connection]-storage.objects.delete-68
@@ -170,7 +173,7 @@ TestRetryConformance/2-[return-reset-connection_return-reset-connection]-storage
 TestRetryConformance/3-[return-503]-storage.buckets.patch-17
 TestRetryConformance/3-[return-503]-storage.buckets.setIamPolicy-18
 TestRetryConformance/3-[return-503]-storage.hmacKey.update-29
-TestRetryConformance/3-[return-503]-storage.objects.compose-35
+TestRetryConformance/3-[return-503]-storage.objects.compose-241
 TestRetryConformance/3-[return-503]-storage.objects.delete-36
 TestRetryConformance/3-[return-503]-storage.objects.delete-67
 TestRetryConformance/3-[return-503]-storage.objects.insert-108
@@ -195,7 +198,7 @@ TestRetryConformance/3-[return-503]-storage.objects.rewrite-86
 TestRetryConformance/3-[return-reset-connection]-storage.buckets.patch-17
 TestRetryConformance/3-[return-reset-connection]-storage.buckets.setIamPolicy-18
 TestRetryConformance/3-[return-reset-connection]-storage.hmacKey.update-29
-TestRetryConformance/3-[return-reset-connection]-storage.objects.compose-35
+TestRetryConformance/3-[return-reset-connection]-storage.objects.compose-241
 TestRetryConformance/3-[return-reset-connection]-storage.objects.insert-108
 TestRetryConformance/3-[return-reset-connection]-storage.objects.insert-109
 TestRetryConformance/3-[return-reset-connection]-storage.objects.insert-110
@@ -303,7 +306,7 @@ TestRetryConformance/5-[return-400]-storage.object_acl.list-33
 TestRetryConformance/5-[return-400]-storage.object_acl.list-65
 TestRetryConformance/5-[return-400]-storage.object_acl.patch-34
 TestRetryConformance/5-[return-400]-storage.object_acl.patch-66
-TestRetryConformance/5-[return-400]-storage.objects.compose-35
+TestRetryConformance/5-[return-400]-storage.objects.compose-241
 TestRetryConformance/5-[return-400]-storage.objects.delete-36
 TestRetryConformance/5-[return-400]-storage.objects.delete-67
 TestRetryConformance/5-[return-400]-storage.objects.get-107
@@ -396,7 +399,7 @@ TestRetryConformance/5-[return-401]-storage.object_acl.list-33
 TestRetryConformance/5-[return-401]-storage.object_acl.list-65
 TestRetryConformance/5-[return-401]-storage.object_acl.patch-34
 TestRetryConformance/5-[return-401]-storage.object_acl.patch-66
-TestRetryConformance/5-[return-401]-storage.objects.compose-35
+TestRetryConformance/5-[return-401]-storage.objects.compose-241
 TestRetryConformance/5-[return-401]-storage.objects.delete-36
 TestRetryConformance/5-[return-401]-storage.objects.delete-67
 TestRetryConformance/5-[return-401]-storage.objects.get-107
@@ -467,6 +470,7 @@ TestRetryConformance/6-[return-503_return-400]-storage.object_acl.get-31
 TestRetryConformance/6-[return-503_return-400]-storage.object_acl.get-63
 TestRetryConformance/6-[return-503_return-400]-storage.object_acl.list-33
 TestRetryConformance/6-[return-503_return-400]-storage.object_acl.list-65
+TestRetryConformance/6-[return-503_return-400]-storage.objects.compose-35
 TestRetryConformance/6-[return-503_return-400]-storage.objects.delete-37
 TestRetryConformance/6-[return-503_return-400]-storage.objects.delete-38
 TestRetryConformance/6-[return-503_return-400]-storage.objects.delete-68
@@ -523,6 +527,7 @@ TestRetryConformance/6-[return-reset-connection_return-401]-storage.object_acl.g
 TestRetryConformance/6-[return-reset-connection_return-401]-storage.object_acl.get-63
 TestRetryConformance/6-[return-reset-connection_return-401]-storage.object_acl.list-33
 TestRetryConformance/6-[return-reset-connection_return-401]-storage.object_acl.list-65
+TestRetryConformance/6-[return-reset-connection_return-401]-storage.objects.compose-35
 TestRetryConformance/6-[return-reset-connection_return-401]-storage.objects.delete-37
 TestRetryConformance/6-[return-reset-connection_return-401]-storage.objects.delete-38
 TestRetryConformance/6-[return-reset-connection_return-401]-storage.objects.delete-68


### PR DESCRIPTION
* fix incorrect evaluation of idempotency for objects.compose (now generation, previously metageneration)
* add mapping for non-idempotent objects.compose invocation
* add CtxFunction to construct a ComposeRequest relative to the state
* add ComposeRequest handling to state

