### PR TITLE
test(retry): configure project id in TestRetryConformance along with other parameters

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
@@ -136,6 +136,7 @@ public class ITRetryConformanceTest {
             .setRetryTestsJsonResourcePath(
                 "com/google/cloud/conformance/storage/v1/retry_tests.json")
             .setMappings(new RpcMethodMappings())
+            .setProjectId("conformance-tests")
             .setHost(TEST_BENCH.getBaseUri().replaceAll("https?://", ""))
             .setTestAllowFilter(RetryTestCaseResolver.includeAll())
             .build();
@@ -182,18 +183,21 @@ public class ITRetryConformanceTest {
     private final BiPredicate<RpcMethod, TestRetryConformance> testAllowFilter;
     private final Random rand;
     private final String host;
+    private final String projectId;
 
     RetryTestCaseResolver(
         String retryTestsJsonResourcePath,
         RpcMethodMappings mappings,
         BiPredicate<RpcMethod, TestRetryConformance> testAllowFilter,
         Random rand,
-        String host) {
+        String host,
+        String projectId) {
       this.retryTestsJsonResourcePath = retryTestsJsonResourcePath;
       this.mappings = mappings;
       this.testAllowFilter = testAllowFilter;
       this.rand = rand;
       this.host = host;
+      this.projectId = projectId;
     }
 
     /** Load, permute and generate all RetryTestCases which are to be run in this suite */
@@ -254,6 +258,7 @@ public class ITRetryConformanceTest {
             if (mappings.isEmpty()) {
               TestRetryConformance testRetryConformance =
                   new TestRetryConformance(
+                      projectId,
                       host,
                       testCase.getId(),
                       method,
@@ -268,6 +273,7 @@ public class ITRetryConformanceTest {
               for (RpcMethodMapping mapping : mappings) {
                 TestRetryConformance testRetryConformance =
                     new TestRetryConformance(
+                        projectId,
                         host,
                         testCase.getId(),
                         method,
@@ -348,6 +354,7 @@ public class ITRetryConformanceTest {
       private String host;
       private BiPredicate<RpcMethod, TestRetryConformance> testAllowFilter;
       private final Random rand;
+      private String projectId;
 
       public Builder() {
         this.rand = resolveRand();
@@ -374,6 +381,11 @@ public class ITRetryConformanceTest {
         return this;
       }
 
+      public Builder setProjectId(String projectId) {
+        this.projectId = projectId;
+        return this;
+      }
+
       /**
        * Set the allow filter for determining if a particular {@link RpcMethod} and {@link
        * TestRetryConformance} should be included in the generated test suite.
@@ -391,7 +403,8 @@ public class ITRetryConformanceTest {
             requireNonNull(mappings, "mappings must be non null"),
             requireNonNull(testAllowFilter, "testAllowList must be non null"),
             rand,
-            host);
+            requireNonNull(host, "host must be non null"),
+            requireNonNull(projectId, "projectId must be non null"));
       }
 
       /**

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RetryTestFixture.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RetryTestFixture.java
@@ -140,7 +140,7 @@ final class RetryTestFixture implements TestRule {
         StorageOptions.newBuilder()
             .setHost(testBench.getBaseUri())
             .setCredentials(NoCredentials.getInstance())
-            .setProjectId("conformance-tests");
+            .setProjectId(testRetryConformance.getProjectId());
     builder = PackagePrivateMethodWorkarounds.useNewRetryAlgorithmManager(builder);
     if (forTest) {
       builder.setHeaderProvider(

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
@@ -639,7 +639,7 @@ final class RpcMethodMappings {
                                                             .setMembers(
                                                                 ImmutableList.of(
                                                                     Identity.projectOwner(
-                                                                            "project-id")
+                                                                            c.getProjectId())
                                                                         .getValue()))
                                                             .build()))
                                                 .build()))))
@@ -667,11 +667,11 @@ final class RpcMethodMappings {
                                                             .setMembers(
                                                                 ImmutableList.of(
                                                                     Identity.projectOwner(
-                                                                            "project-id")
+                                                                            c.getProjectId())
                                                                         .getValue()))
                                                             .build()))
                                                 .build(),
-                                            BucketSourceOption.userProject("project-id")))))
+                                            BucketSourceOption.userProject(c.getProjectId())))))
                 .build());
       }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestRetryConformance.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestRetryConformance.java
@@ -58,6 +58,7 @@ final class TestRetryConformance {
     BASE_ID = formatter.format(now).replaceAll("[:]", "").substring(0, 6);
   }
 
+  private final String projectId;
   private final String bucketName;
   private final String bucketName2;
   private final String userProject;
@@ -78,16 +79,18 @@ final class TestRetryConformance {
   private final int mappingId;
 
   TestRetryConformance(
+      String projectId,
       String host,
       int scenarioId,
       Method method,
       InstructionList instruction,
       boolean preconditionsProvided,
       boolean expectSuccess) {
-    this(host, scenarioId, method, instruction, preconditionsProvided, expectSuccess, 0);
+    this(projectId, host, scenarioId, method, instruction, preconditionsProvided, expectSuccess, 0);
   }
 
   TestRetryConformance(
+      String projectId,
       String host,
       int scenarioId,
       Method method,
@@ -95,6 +98,7 @@ final class TestRetryConformance {
       boolean preconditionsProvided,
       boolean expectSuccess,
       int mappingId) {
+    this.projectId = projectId;
     this.host = host;
     this.scenarioId = scenarioId;
     this.method = requireNonNull(method, "method must be non null");
@@ -114,6 +118,10 @@ final class TestRetryConformance {
         String.format("%s_s%03d-%s-m%03d_prj1", BASE_ID, scenarioId, instructionsString, mappingId);
     this.objectName =
         String.format("%s_s%03d-%s-m%03d_obj1", BASE_ID, scenarioId, instructionsString, mappingId);
+  }
+
+  public String getProjectId() {
+    return projectId;
   }
 
   public String getHost() {


### PR DESCRIPTION
Add new `projectId` field to TestRetryConformance to manage and provide project id literal value that can be used everywhere.