### PR TITLE
test(retry): fix mappings 48 and 114

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
@@ -1430,19 +1430,18 @@ final class RpcMethodMappings {
                 .build());
         a.add(
             RpcMethodMapping.newBuilder(48, objects.insert)
-                .withApplicable(TestRetryConformance::isPreconditionsProvided)
+                .withApplicable(not(TestRetryConformance::isPreconditionsProvided))
+                .withSetup(defaultSetup.andThen(blobInfoWithGenerationZero))
                 .withTest(
-                    blobInfoWithGenerationZero.andThen(
-                        (ctx, c) ->
-                            ctx.map(
-                                state ->
-                                    state.with(
-                                        ctx.getStorage()
-                                            .create(
-                                                ctx.getState().getBlobInfo(),
-                                                new ByteArrayInputStream(
-                                                    c.getHelloWorldUtf8Bytes()),
-                                                BlobWriteOption.generationMatch())))))
+                    (ctx, c) ->
+                        ctx.map(
+                            state ->
+                                state.with(
+                                    ctx.getStorage()
+                                        .create(
+                                            ctx.getState().getBlobInfo(),
+                                            new ByteArrayInputStream(c.getHelloWorldUtf8Bytes()),
+                                            BlobWriteOption.generationMatch()))))
                 .build());
         a.add(
             RpcMethodMapping.newBuilder(49, objects.insert)
@@ -1670,17 +1669,16 @@ final class RpcMethodMappings {
         a.add(
             RpcMethodMapping.newBuilder(114, objects.insert)
                 .withApplicable(not(TestRetryConformance::isPreconditionsProvided))
+                .withSetup(defaultSetup.andThen(blobInfoWithoutGeneration))
                 .withTest(
-                    blobInfoWithoutGeneration.andThen(
-                        (ctx, c) ->
-                            ctx.map(
-                                state ->
-                                    state.with(
-                                        ctx.getStorage()
-                                            .create(
-                                                ctx.getState().getBlobInfo(),
-                                                new ByteArrayInputStream(
-                                                    c.getHelloWorldUtf8Bytes()))))))
+                    (ctx, c) ->
+                        ctx.map(
+                            state ->
+                                state.with(
+                                    ctx.getStorage()
+                                        .create(
+                                            ctx.getState().getBlobInfo(),
+                                            new ByteArrayInputStream(c.getHelloWorldUtf8Bytes())))))
                 .build());
         a.add(
             RpcMethodMapping.newBuilder(115, objects.insert)


### PR DESCRIPTION
com.google.cloud.storage.Storage.create(com.google.cloud.storage.BlobInfo, java.io.InputStream, com.google.cloud.storage.Storage.BlobWriteOption...) is never safe to retry as it does not wrap the inputstream provided to allow it to be safely read multiple times

Fixes #1083
