### PR TITLE
test(retry): fix mapping 78

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/CtxFunctions.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/CtxFunctions.java
@@ -113,13 +113,13 @@ final class CtxFunctions {
   }
 
   static final class ResourceSetup {
-    private static final CtxFunction bucket =
+    static final CtxFunction bucket =
         (ctx, c) -> {
           BucketInfo bucketInfo = BucketInfo.newBuilder(c.getBucketName()).build();
           Bucket resolvedBucket = ctx.getStorage().create(bucketInfo);
           return ctx.map(s -> s.with(resolvedBucket));
         };
-    private static final CtxFunction object =
+    static final CtxFunction object =
         (ctx, c) -> {
           BlobInfo blobInfo =
               BlobInfo.newBuilder(ctx.getState().getBucket().getName(), c.getObjectName()).build();

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RetryTestFixture.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RetryTestFixture.java
@@ -18,7 +18,6 @@ package com.google.cloud.storage.conformance.retry;
 
 import static org.junit.Assert.assertTrue;
 
-import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.conformance.storage.v1.InstructionList;
@@ -143,14 +142,17 @@ final class RetryTestFixture implements TestRule {
             .setProjectId(testRetryConformance.getProjectId());
     builder = PackagePrivateMethodWorkarounds.useNewRetryAlgorithmManager(builder);
     if (forTest) {
-      builder.setHeaderProvider(
-          new FixedHeaderProvider() {
-            @Override
-            public Map<String, String> getHeaders() {
-              return ImmutableMap.of(
-                  "x-retry-test-id", retryTest.id, "User-Agent", "java-conformance-tests/");
-            }
-          });
+      builder
+          .setHeaderProvider(
+              new FixedHeaderProvider() {
+                @Override
+                public Map<String, String> getHeaders() {
+                  return ImmutableMap.of(
+                      "x-retry-test-id", retryTest.id, "User-Agent", "java-conformance-tests/");
+                }
+              })
+          .setRetrySettings(
+              StorageOptions.getDefaultRetrySettings().toBuilder().setMaxAttempts(3).build());
     } else {
       builder
           .setHeaderProvider(
@@ -160,7 +162,8 @@ final class RetryTestFixture implements TestRule {
                   return ImmutableMap.of("User-Agent", "java-conformance-tests/");
                 }
               })
-          .setRetrySettings(RetrySettings.newBuilder().setMaxAttempts(1).build());
+          .setRetrySettings(
+              StorageOptions.getDefaultRetrySettings().toBuilder().setMaxAttempts(1).build());
     }
     return builder.build().getService();
   }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
@@ -52,6 +52,7 @@ import com.google.cloud.storage.Storage.SignUrlOption;
 import com.google.cloud.storage.Storage.UriScheme;
 import com.google.cloud.storage.StorageRoles;
 import com.google.cloud.storage.conformance.retry.CtxFunctions.Local;
+import com.google.cloud.storage.conformance.retry.CtxFunctions.ResourceSetup;
 import com.google.cloud.storage.conformance.retry.CtxFunctions.Rpc;
 import com.google.cloud.storage.conformance.retry.CtxFunctions.Util;
 import com.google.cloud.storage.conformance.retry.RpcMethod.storage.bucket_acl;
@@ -1611,21 +1612,17 @@ final class RpcMethodMappings {
         a.add(
             RpcMethodMapping.newBuilder(78, objects.insert)
                 .withApplicable(TestRetryConformance::isPreconditionsProvided)
+                .withSetup(
+                    defaultSetup.andThen(blobInfoWithoutGeneration).andThen(ResourceSetup.object))
                 .withTest(
-                    blobInfoWithoutGeneration
-                        .andThen(Rpc.createEmptyBlob)
-                        .andThen(Rpc.blobWithGeneration)
-                        .andThen(
-                            (ctx, c) ->
-                                ctx.peek(
-                                    state -> {
-                                      try (WriteChannel writer =
-                                          state
-                                              .getBlob()
-                                              .writer(BlobWriteOption.generationMatch())) {
-                                        writer.write(ByteBuffer.wrap(c.getHelloWorldUtf8Bytes()));
-                                      }
-                                    })))
+                    (ctx, c) ->
+                        ctx.peek(
+                            state -> {
+                              try (WriteChannel writer =
+                                  state.getBlob().writer(BlobWriteOption.generationMatch())) {
+                                writer.write(ByteBuffer.wrap(c.getHelloWorldUtf8Bytes()));
+                              }
+                            }))
                 .build());
         a.add(
             RpcMethodMapping.newBuilder(108, objects.insert)


### PR DESCRIPTION
* move creation of object from withTest to withSetup to ensure it doesn't consume the instructions for the test
* update RetryTestFixture to set max attempts to 3 to match what our conformance tests expect
* update Exception Handler Interceptor to handle HttpResponseExceptions related to resumable media operations

Fixes #1089

