### PR TITLE
retry(test): improve user agent strings to provide more information while debugging

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestBench.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestBench.java
@@ -92,7 +92,9 @@ final class TestBench implements TestRule {
                 request -> {
                   request.setCurlLoggingEnabled(false);
                   request.getHeaders().setAccept("application/json");
-                  request.getHeaders().setUserAgent("java-conformance-tests/");
+                  request
+                      .getHeaders()
+                      .setUserAgent("test-bench/ java-conformance-tests/");
                 });
   }
 


### PR DESCRIPTION
When debugging and looking at access logs it is useful to be able to identify individual test cases and test bench operations simply by the user agent string. This change adds test names to operations related to each test, and annotates calls for testbench as such.