### PR TITLE
feat: update all automatic retry behavior to be idempotency aware

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageOptions.java
@@ -87,7 +87,7 @@ public class StorageOptions extends ServiceOptions<Storage, StorageOptions> {
      * @return the builder
      * @see StorageRetryStrategy#getDefaultStorageRetryStrategy()
      */
-    Builder setStorageRetryStrategy(StorageRetryStrategy storageRetryStrategy) {
+    public Builder setStorageRetryStrategy(StorageRetryStrategy storageRetryStrategy) {
       this.storageRetryStrategy =
           requireNonNull(storageRetryStrategy, "storageRetryStrategy must be non null");
       return this;
@@ -125,7 +125,7 @@ public class StorageOptions extends ServiceOptions<Storage, StorageOptions> {
     }
 
     public StorageRetryStrategy getStorageRetryStrategy() {
-      return StorageRetryStrategy.getLegacyStorageRetryStrategy();
+      return StorageRetryStrategy.getDefaultStorageRetryStrategy();
     }
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageRetryStrategy.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageRetryStrategy.java
@@ -29,7 +29,7 @@ import java.io.Serializable;
  * @see #getDefaultStorageRetryStrategy()
  * @see #getUniformStorageRetryStrategy()
  */
-interface StorageRetryStrategy extends Serializable {
+public interface StorageRetryStrategy extends Serializable {
 
   /**
    * Factory method to provide a {@link ResultRetryAlgorithm} which will be used to evaluate whether

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BlobWriteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BlobWriteChannelTest.java
@@ -65,11 +65,12 @@ public class BlobWriteChannelTest {
   private static final String BLOB_NAME = "n";
   private static final String UPLOAD_ID = "uploadid";
   private static final BlobInfo BLOB_INFO = BlobInfo.newBuilder(BUCKET_NAME, BLOB_NAME).build();
-  private static final BlobInfo BLOB_INFO_WITH_GENERATION = BlobInfo.newBuilder(BUCKET_NAME, BLOB_NAME, 1L).build();
+  private static final BlobInfo BLOB_INFO_WITH_GENERATION =
+      BlobInfo.newBuilder(BUCKET_NAME, BLOB_NAME, 1L).build();
   private static final StorageObject UPDATED_BLOB = new StorageObject();
   private static final Map<StorageRpc.Option, ?> EMPTY_RPC_OPTIONS = ImmutableMap.of();
-  private static final Map<StorageRpc.Option, ?> RPC_OPTIONS_GENERATION = ImmutableMap.of(
-      StorageRpc.Option.IF_GENERATION_MATCH, 1L);
+  private static final Map<StorageRpc.Option, ?> RPC_OPTIONS_GENERATION =
+      ImmutableMap.of(StorageRpc.Option.IF_GENERATION_MATCH, 1L);
   private static final int MIN_CHUNK_SIZE = 256 * 1024;
   private static final int DEFAULT_CHUNK_SIZE = 60 * MIN_CHUNK_SIZE; // 15MiB
   private static final int CUSTOM_CHUNK_SIZE = 4 * MIN_CHUNK_SIZE;
@@ -117,7 +118,8 @@ public class BlobWriteChannelTest {
   public void testCreateRetryableError() {
     expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION))
         .andThrow(socketClosedException);
-    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION)).andReturn(UPLOAD_ID);
+    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION))
+        .andReturn(UPLOAD_ID);
     replay(storageRpcMock);
     writer = newWriter(true);
     assertTrue(writer.isOpen());
@@ -149,7 +151,8 @@ public class BlobWriteChannelTest {
   public void testWriteWithFlushRetryChunk() throws Exception {
     ByteBuffer buffer = randomBuffer(MIN_CHUNK_SIZE);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION)).andReturn(UPLOAD_ID);
+    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION))
+        .andReturn(UPLOAD_ID);
     expect(
             storageRpcMock.writeWithResponse(
                 eq(UPLOAD_ID),
@@ -182,7 +185,8 @@ public class BlobWriteChannelTest {
   public void testWriteWithRetryFullChunk() throws Exception {
     ByteBuffer buffer = randomBuffer(MIN_CHUNK_SIZE);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION)).andReturn(UPLOAD_ID);
+    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION))
+        .andReturn(UPLOAD_ID);
     expect(
             storageRpcMock.writeWithResponse(
                 eq(UPLOAD_ID), (byte[]) anyObject(), eq(0), eq(0L), eq(MIN_CHUNK_SIZE), eq(false)))
@@ -220,7 +224,8 @@ public class BlobWriteChannelTest {
   public void testWriteWithRemoteProgressMade() throws Exception {
     ByteBuffer buffer = randomBuffer(MIN_CHUNK_SIZE);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION)).andReturn(UPLOAD_ID);
+    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION))
+        .andReturn(UPLOAD_ID);
     expect(
             storageRpcMock.writeWithResponse(
                 eq(UPLOAD_ID),
@@ -254,7 +259,8 @@ public class BlobWriteChannelTest {
   public void testWriteWithDriftRetryCase4() throws Exception {
     ByteBuffer buffer = randomBuffer(MIN_CHUNK_SIZE);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION)).andReturn(UPLOAD_ID);
+    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION))
+        .andReturn(UPLOAD_ID);
     expect(
             storageRpcMock.writeWithResponse(
                 eq(UPLOAD_ID),
@@ -291,7 +297,8 @@ public class BlobWriteChannelTest {
   public void testWriteWithUnreachableRemoteOffset() throws Exception {
     ByteBuffer buffer = randomBuffer(MIN_CHUNK_SIZE);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION)).andReturn(UPLOAD_ID);
+    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION))
+        .andReturn(UPLOAD_ID);
     expect(
             storageRpcMock.writeWithResponse(
                 eq(UPLOAD_ID),
@@ -320,7 +327,8 @@ public class BlobWriteChannelTest {
   public void testWriteWithRetryAndObjectMetadata() throws Exception {
     ByteBuffer buffer = randomBuffer(MIN_CHUNK_SIZE);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION)).andReturn(UPLOAD_ID);
+    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION))
+        .andReturn(UPLOAD_ID);
     expect(
             storageRpcMock.writeWithResponse(
                 eq(UPLOAD_ID),
@@ -361,7 +369,8 @@ public class BlobWriteChannelTest {
   public void testWriteWithUploadCompletedByAnotherClient() throws Exception {
     ByteBuffer buffer = randomBuffer(MIN_CHUNK_SIZE);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION)).andReturn(UPLOAD_ID);
+    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION))
+        .andReturn(UPLOAD_ID);
     expect(
             storageRpcMock.writeWithResponse(
                 eq(UPLOAD_ID),
@@ -402,7 +411,8 @@ public class BlobWriteChannelTest {
   public void testWriteWithLocalOffsetGoingBeyondRemoteOffset() throws Exception {
     ByteBuffer buffer = randomBuffer(MIN_CHUNK_SIZE);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION)).andReturn(UPLOAD_ID);
+    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION))
+        .andReturn(UPLOAD_ID);
     expect(
             storageRpcMock.writeWithResponse(
                 eq(UPLOAD_ID),
@@ -440,7 +450,8 @@ public class BlobWriteChannelTest {
   public void testGetCurrentUploadOffset() throws Exception {
     ByteBuffer buffer = randomBuffer(MIN_CHUNK_SIZE);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION)).andReturn(UPLOAD_ID);
+    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION))
+        .andReturn(UPLOAD_ID);
     expect(
             storageRpcMock.writeWithResponse(
                 eq(UPLOAD_ID),
@@ -484,7 +495,8 @@ public class BlobWriteChannelTest {
   public void testWriteWithLastFlushRetryChunkButCompleted() throws Exception {
     ByteBuffer buffer = randomBuffer(MIN_CHUNK_SIZE);
     Capture<byte[]> capturedBuffer = Capture.newInstance();
-    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION)).andReturn(UPLOAD_ID);
+    expect(storageRpcMock.open(BLOB_INFO_WITH_GENERATION.toPb(), RPC_OPTIONS_GENERATION))
+        .andReturn(UPLOAD_ID);
     expect(
             storageRpcMock.writeWithResponse(
                 eq(UPLOAD_ID),
@@ -830,9 +842,10 @@ public class BlobWriteChannelTest {
   private BlobWriteChannel newWriter() {
     return newWriter(false);
   }
-  
+
   private BlobWriteChannel newWriter(boolean withGeneration) {
-    Map<StorageRpc.Option, ?> optionsMap = withGeneration? RPC_OPTIONS_GENERATION : EMPTY_RPC_OPTIONS;
+    Map<StorageRpc.Option, ?> optionsMap =
+        withGeneration ? RPC_OPTIONS_GENERATION : EMPTY_RPC_OPTIONS;
     ResultRetryAlgorithm<?> createResultAlgorithm =
         retryAlgorithmManager.getForResumableUploadSessionCreate(optionsMap);
     ResultRetryAlgorithm<?> writeResultAlgorithm =

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
@@ -38,9 +38,4 @@ public final class PackagePrivateMethodWorkarounds {
     BlobInfo.BuilderImpl builder = (BlobInfo.BuilderImpl) BlobInfo.fromPb(b.toPb()).toBuilder();
     return new Blob(s, builder);
   }
-
-  public static StorageOptions.Builder useDefaultStorageRetryStrategy(
-      StorageOptions.Builder builder) {
-    return builder.setStorageRetryStrategy(StorageRetryStrategy.getDefaultStorageRetryStrategy());
-  }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageImplMockitoTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageImplMockitoTest.java
@@ -36,6 +36,7 @@ import com.google.cloud.ReadChannel;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.Tuple;
 import com.google.cloud.WriteChannel;
+import com.google.cloud.storage.Storage.BlobTargetOption;
 import com.google.cloud.storage.spi.StorageRpcFactory;
 import com.google.cloud.storage.spi.v1.StorageRpc;
 import com.google.common.collect.ImmutableList;
@@ -121,6 +122,9 @@ public class StorageImplMockitoTest {
 
   // Empty StorageRpc options
   private static final Map<StorageRpc.Option, ?> EMPTY_RPC_OPTIONS = ImmutableMap.of();
+  private static final Map<StorageRpc.Option, ?> BLOB_INFO1_RPC_OPTIONS_WITH_GENERATION = ImmutableMap.of(
+      StorageRpc.Option.IF_GENERATION_MATCH, 24L
+  );
 
   // Bucket target options
   private static final Storage.BucketTargetOption BUCKET_TARGET_METAGENERATION =
@@ -726,7 +730,7 @@ public class StorageImplMockitoTest {
         .doReturn(BLOB_INFO1.toPb())
         .doThrow(UNEXPECTED_CALL_EXCEPTION)
         .when(storageRpcMock)
-        .create(Mockito.eq(storageObject), capturedStream.capture(), Mockito.eq(EMPTY_RPC_OPTIONS));
+        .create(Mockito.eq(storageObject), capturedStream.capture(), Mockito.eq(BLOB_INFO1_RPC_OPTIONS_WITH_GENERATION));
 
     storage =
         options
@@ -736,7 +740,7 @@ public class StorageImplMockitoTest {
             .getService();
     initializeServiceDependentObjects();
 
-    Blob blob = storage.create(BLOB_INFO1, BLOB_CONTENT);
+    Blob blob = storage.create(BLOB_INFO1, BLOB_CONTENT, BlobTargetOption.generationMatch());
 
     assertEquals(expectedBlob1, blob);
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageImplMockitoTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageImplMockitoTest.java
@@ -122,9 +122,8 @@ public class StorageImplMockitoTest {
 
   // Empty StorageRpc options
   private static final Map<StorageRpc.Option, ?> EMPTY_RPC_OPTIONS = ImmutableMap.of();
-  private static final Map<StorageRpc.Option, ?> BLOB_INFO1_RPC_OPTIONS_WITH_GENERATION = ImmutableMap.of(
-      StorageRpc.Option.IF_GENERATION_MATCH, 24L
-  );
+  private static final Map<StorageRpc.Option, ?> BLOB_INFO1_RPC_OPTIONS_WITH_GENERATION =
+      ImmutableMap.of(StorageRpc.Option.IF_GENERATION_MATCH, 24L);
 
   // Bucket target options
   private static final Storage.BucketTargetOption BUCKET_TARGET_METAGENERATION =
@@ -730,7 +729,10 @@ public class StorageImplMockitoTest {
         .doReturn(BLOB_INFO1.toPb())
         .doThrow(UNEXPECTED_CALL_EXCEPTION)
         .when(storageRpcMock)
-        .create(Mockito.eq(storageObject), capturedStream.capture(), Mockito.eq(BLOB_INFO1_RPC_OPTIONS_WITH_GENERATION));
+        .create(
+            Mockito.eq(storageObject),
+            capturedStream.capture(),
+            Mockito.eq(BLOB_INFO1_RPC_OPTIONS_WITH_GENERATION));
 
     storage =
         options

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RetryTestFixture.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RetryTestFixture.java
@@ -23,7 +23,6 @@ import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.conformance.storage.v1.InstructionList;
 import com.google.cloud.conformance.storage.v1.Method;
-import com.google.cloud.storage.PackagePrivateMethodWorkarounds;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.conformance.retry.TestBench.RetryTestResource;
@@ -141,7 +140,6 @@ final class RetryTestFixture implements TestRule {
             .setHost(testBench.getBaseUri())
             .setCredentials(NoCredentials.getInstance())
             .setProjectId(testRetryConformance.getProjectId());
-    builder = PackagePrivateMethodWorkarounds.useDefaultStorageRetryStrategy(builder);
     RetrySettings.Builder retrySettingsBuilder =
         StorageOptions.getDefaultRetrySettings().toBuilder();
     if (forTest) {


### PR DESCRIPTION
1. Add new configuration option `StorageOptions.Builder#setStorageRetryStrategy`
2. Add new interface `StorageRetryStrategy`
3. Update all calls to be made idempotency aware
4. Change default behavior of automatic retries to only retry those operations which are deemed to be idempotent
5. Add @deprecated method `StorageRetryStrategy.getLegacyStorageRetryStrategy` providing access to a strategy which matches the previous sometimes unsafe behavior

