### PR TITLE
fix: update StorageOptions to not overwrite any previously set host

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageOptions.java
@@ -166,7 +166,7 @@ public class StorageOptions extends ServiceOptions<Storage, StorageOptions> {
   @SuppressWarnings("unchecked")
   @Override
   public Builder toBuilder() {
-    return new Builder(this).setHost(DEFAULT_HOST);
+    return new Builder(this);
   }
 
   @Override

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageOptionsTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageOptionsTest.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.storage;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.cloud.TransportOptions;
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -32,5 +34,35 @@ public class StorageOptionsTest {
     } catch (IllegalArgumentException ex) {
       Assert.assertNotNull(ex.getMessage());
     }
+  }
+
+  @Test
+  public void testConfigureHostShouldBeKeptOnToBuilder() {
+    StorageOptions opts1 = StorageOptions.newBuilder().setHost("custom-host").build();
+    StorageOptions opts2 = opts1.toBuilder().build();
+
+    assertThat(opts2.getHost()).isEqualTo("custom-host");
+  }
+
+  @Test
+  public void testToBuilderShouldSpecifyDefaultIfNotOtherwiseSet() {
+    StorageOptions opts1 = StorageOptions.newBuilder().build();
+    StorageOptions opts2 = opts1.toBuilder().build();
+
+    assertThat(opts2.getHost()).isEqualTo("https://storage.googleapis.com");
+  }
+
+  @Test
+  public void testNewBuilderSpecifiesCorrectHost() {
+    StorageOptions opts1 = StorageOptions.newBuilder().build();
+
+    assertThat(opts1.getHost()).isEqualTo("https://storage.googleapis.com");
+  }
+
+  @Test
+  public void testDefaultInstanceSpecifiesCorrectHost() {
+    StorageOptions opts1 = StorageOptions.getDefaultInstance();
+
+    assertThat(opts1.getHost()).isEqualTo("https://storage.googleapis.com");
   }
 }


### PR DESCRIPTION
When calling `StorageOptions#toBuilder()` after creating the builder the host was explicitly set to the default host. This change removes that behavior instead moving the setting of the default host to the instantiation of a new builder.

Add unit tests to ensure host is set to the expected values based on different ways of creating an instance of StorageOptions.

Related:
* https://github.com/googleapis/google-cloud-java/pull/6579
* https://github.com/googleapis/google-cloud-java/issues/7004
* https://github.com/googleapis/google-cloud-java/pull/7034
