### PR TITLE
fix: update retry handling to retry idempotent requests that encounter unexpected EOF while parsing json responses

### DIFF
--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -87,6 +87,11 @@
       <groupId>org.threeten</groupId>
       <artifactId>threetenbp</artifactId>
     </dependency>
+    <!-- Access to exception for retry handling -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/DataGeneration.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/DataGeneration.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public final class DataGeneration implements TestRule {
+
+  private final Random rand;
+
+  public DataGeneration(Random rand) {
+    this.rand = rand;
+  }
+
+  public ByteBuffer randByteBuffer(int limit) {
+    ByteBuffer b = ByteBuffer.allocate(limit);
+    fillByteBuffer(b);
+    return b;
+  }
+
+  public void fillByteBuffer(ByteBuffer b) {
+    while (b.position() < b.limit()) {
+      int i = rand.nextInt('z');
+      char c = (char) i;
+      if (Character.isLetter(c) || Character.isDigit(c)) {
+        b.put(Character.toString(c).getBytes(StandardCharsets.UTF_8));
+      }
+    }
+    b.position(0);
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        base.evaluate();
+      }
+    };
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
@@ -16,7 +16,11 @@
 
 package com.google.cloud.storage;
 
+import com.google.api.services.storage.model.StorageObject;
+import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.BucketInfo.BuilderImpl;
+import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * Several classes in the High Level Model for storage include package-local constructors and
@@ -37,5 +41,16 @@ public final class PackagePrivateMethodWorkarounds {
   public static Blob blobCopyWithStorage(Blob b, Storage s) {
     BlobInfo.BuilderImpl builder = (BlobInfo.BuilderImpl) BlobInfo.fromPb(b.toPb()).toBuilder();
     return new Blob(s, builder);
+  }
+
+  public static Function<WriteChannel, Optional<StorageObject>> maybeGetStorageObjectFunction() {
+    return (w) -> {
+      if (w instanceof BlobWriteChannel) {
+        BlobWriteChannel blobWriteChannel = (BlobWriteChannel) w;
+        return Optional.of(blobWriteChannel.getStorageObject());
+      } else {
+        return Optional.empty();
+      }
+    };
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/CleanupStrategy.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/CleanupStrategy.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.storage.conformance.retry;
 
-enum CleanupStrategy {
+public enum CleanupStrategy {
   ALWAYS,
   ONLY_ON_SUCCESS,
   NEVER

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RetryTestFixture.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RetryTestFixture.java
@@ -21,15 +21,10 @@ import static org.junit.Assert.assertTrue;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.cloud.NoCredentials;
-import com.google.cloud.conformance.storage.v1.InstructionList;
-import com.google.cloud.conformance.storage.v1.Method;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.conformance.retry.TestBench.RetryTestResource;
 import com.google.common.collect.ImmutableMap;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import java.util.Map;
 import java.util.logging.Logger;
 import org.junit.AssumptionViolatedException;
 import org.junit.rules.TestRule;
@@ -88,7 +83,7 @@ final class RetryTestFixture implements TestRule {
         try {
           LOGGER.fine("Setting up retry_test resource...");
           RetryTestResource retryTestResource =
-              newRetryTestResource(
+              RetryTestResource.newRetryTestResource(
                   testRetryConformance.getMethod(), testRetryConformance.getInstruction());
           retryTest = testBench.createRetryTest(retryTestResource);
           LOGGER.fine("Setting up retry_test resource complete");
@@ -123,17 +118,6 @@ final class RetryTestFixture implements TestRule {
         || ((testSuccess || testSkipped) && cleanupStrategy == CleanupStrategy.ONLY_ON_SUCCESS);
   }
 
-  private static RetryTestResource newRetryTestResource(Method m, InstructionList l) {
-    RetryTestResource resource = new RetryTestResource();
-    resource.instructions = new JsonObject();
-    JsonArray instructions = new JsonArray();
-    for (String s : l.getInstructionsList()) {
-      instructions.add(s);
-    }
-    resource.instructions.add(m.getName(), instructions);
-    return resource;
-  }
-
   private Storage newStorage(boolean forTest) {
     StorageOptions.Builder builder =
         StorageOptions.newBuilder()
@@ -145,23 +129,14 @@ final class RetryTestFixture implements TestRule {
     if (forTest) {
       builder
           .setHeaderProvider(
-              new FixedHeaderProvider() {
-                @Override
-                public Map<String, String> getHeaders() {
-                  return ImmutableMap.of(
-                      "x-retry-test-id", retryTest.id, "User-Agent", fmtUserAgent("test"));
-                }
-              })
+              FixedHeaderProvider.create(
+                  ImmutableMap.of(
+                      "x-retry-test-id", retryTest.id, "User-Agent", fmtUserAgent("test"))))
           .setRetrySettings(retrySettingsBuilder.setMaxAttempts(3).build());
     } else {
       builder
           .setHeaderProvider(
-              new FixedHeaderProvider() {
-                @Override
-                public Map<String, String> getHeaders() {
-                  return ImmutableMap.of("User-Agent", fmtUserAgent("non-test"));
-                }
-              })
+              FixedHeaderProvider.create(ImmutableMap.of("User-Agent", fmtUserAgent("non-test"))))
           .setRetrySettings(retrySettingsBuilder.setMaxAttempts(1).build());
     }
     return builder.build().getService();

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestBench.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestBench.java
@@ -30,6 +30,8 @@ import com.google.api.core.NanoClock;
 import com.google.api.gax.retrying.BasicResultRetryAlgorithm;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.RetryHelper.RetryHelperException;
+import com.google.cloud.conformance.storage.v1.InstructionList;
+import com.google.cloud.conformance.storage.v1.Method;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -60,7 +62,7 @@ import org.threeten.bp.Duration;
  *
  * <p>This rule expects to be bound as an {@link org.junit.ClassRule @ClassRule} field.
  */
-final class TestBench implements TestRule {
+public final class TestBench implements TestRule {
 
   private static final Logger LOGGER = Logger.getLogger(TestBench.class.getName());
 
@@ -69,6 +71,7 @@ final class TestBench implements TestRule {
   private final String dockerImageName;
   private final String dockerImageTag;
   private final CleanupStrategy cleanupStrategy;
+  private final String containerName;
 
   private final Gson gson;
   private final HttpRequestFactory requestFactory;
@@ -78,12 +81,14 @@ final class TestBench implements TestRule {
       String baseUri,
       String dockerImageName,
       String dockerImageTag,
-      CleanupStrategy cleanupStrategy) {
+      CleanupStrategy cleanupStrategy,
+      String containerName) {
     this.ignorePullError = ignorePullError;
     this.baseUri = baseUri;
     this.dockerImageName = dockerImageName;
     this.dockerImageTag = dockerImageTag;
     this.cleanupStrategy = cleanupStrategy;
+    this.containerName = containerName;
     this.gson = new Gson();
     this.requestFactory =
         new NetHttpTransport.Builder()
@@ -92,15 +97,17 @@ final class TestBench implements TestRule {
                 request -> {
                   request.setCurlLoggingEnabled(false);
                   request.getHeaders().setAccept("application/json");
-                  request.getHeaders().setUserAgent("test-bench/ java-conformance-tests/");
+                  request
+                      .getHeaders()
+                      .setUserAgent(String.format("%s/ test-bench/", this.containerName));
                 });
   }
 
-  String getBaseUri() {
+  public String getBaseUri() {
     return baseUri;
   }
 
-  RetryTestResource createRetryTest(RetryTestResource retryTestResource) throws IOException {
+  public RetryTestResource createRetryTest(RetryTestResource retryTestResource) throws IOException {
     GenericUrl url = new GenericUrl(baseUri + "/retry_test");
     String jsonString = gson.toJson(retryTestResource);
     HttpContent content =
@@ -112,14 +119,14 @@ final class TestBench implements TestRule {
     return result;
   }
 
-  void deleteRetryTest(RetryTestResource retryTestResource) throws IOException {
+  public void deleteRetryTest(RetryTestResource retryTestResource) throws IOException {
     GenericUrl url = new GenericUrl(baseUri + "/retry_test/" + retryTestResource.id);
     HttpRequest req = requestFactory.buildDeleteRequest(url);
     HttpResponse resp = req.execute();
     resp.disconnect();
   }
 
-  RetryTestResource getRetryTest(RetryTestResource retryTestResource) throws IOException {
+  public RetryTestResource getRetryTest(RetryTestResource retryTestResource) throws IOException {
     GenericUrl url = new GenericUrl(baseUri + "/retry_test/" + retryTestResource.id);
     HttpRequest req = requestFactory.buildGetRequest(url);
     HttpResponse resp = req.execute();
@@ -128,7 +135,7 @@ final class TestBench implements TestRule {
     return result;
   }
 
-  List<RetryTestResource> listRetryTests() throws IOException {
+  public List<RetryTestResource> listRetryTests() throws IOException {
     GenericUrl url = new GenericUrl(baseUri + "/retry_tests");
     HttpRequest req = requestFactory.buildGetRequest(url);
     HttpResponse resp = req.execute();
@@ -147,7 +154,8 @@ final class TestBench implements TestRule {
     return new Statement() {
       @Override
       public void evaluate() throws Throwable {
-        Path tempDirectory = Files.createTempDirectory("retry-conformance-server");
+        String fullContainerName = String.format("storage-testbench_%s", containerName);
+        Path tempDirectory = Files.createTempDirectory(fullContainerName);
         Path outPath = tempDirectory.resolve("stdout");
         Path errPath = tempDirectory.resolve("stderr");
 
@@ -190,7 +198,7 @@ final class TestBench implements TestRule {
                     "--rm",
                     "--publish",
                     port + ":9000",
-                    "--name=retry-conformance-server",
+                    String.format("--name=%s", fullContainerName),
                     dockerImage)
                 .redirectOutput(outFile)
                 .redirectError(errFile)
@@ -261,14 +269,31 @@ final class TestBench implements TestRule {
     }
   }
 
-  static Builder newBuilder() {
+  public static Builder newBuilder() {
     return new Builder();
   }
 
-  static final class RetryTestResource {
+  public static final class RetryTestResource {
     public String id;
     public Boolean completed;
     public JsonObject instructions;
+
+    public RetryTestResource() {}
+
+    public RetryTestResource(JsonObject instructions) {
+      this.instructions = instructions;
+    }
+
+    public static RetryTestResource newRetryTestResource(Method m, InstructionList l) {
+      RetryTestResource resource = new RetryTestResource();
+      resource.instructions = new JsonObject();
+      JsonArray instructions = new JsonArray();
+      for (String s : l.getInstructionsList()) {
+        instructions.add(s);
+      }
+      resource.instructions.add(m.getName(), instructions);
+      return resource;
+    }
 
     @Override
     public String toString() {
@@ -284,36 +309,46 @@ final class TestBench implements TestRule {
     }
   }
 
-  static final class Builder {
+  public static final class Builder {
     private static final String DEFAULT_BASE_URI = "http://localhost:9000";
     private static final String DEFAULT_IMAGE_NAME =
         "gcr.io/cloud-devrel-public-resources/storage-testbench";
-    private static final String DEFAULT_IMAGE_TAG = "v0.8.0";
+    private static final String DEFAULT_IMAGE_TAG = "v0.10.0";
+    private static final String DEFAULT_CONTAINER_NAME = "default";
 
     private boolean ignorePullError;
     private String baseUri;
     private String dockerImageName;
     private String dockerImageTag;
     private CleanupStrategy cleanupStrategy;
+    private String containerName;
 
-    public Builder() {
-      this(false, DEFAULT_BASE_URI, DEFAULT_IMAGE_NAME, DEFAULT_IMAGE_TAG, CleanupStrategy.ALWAYS);
+    private Builder() {
+      this(
+          false,
+          DEFAULT_BASE_URI,
+          DEFAULT_IMAGE_NAME,
+          DEFAULT_IMAGE_TAG,
+          CleanupStrategy.ALWAYS,
+          DEFAULT_CONTAINER_NAME);
     }
 
-    public Builder(
+    private Builder(
         boolean ignorePullError,
         String baseUri,
         String dockerImageName,
         String dockerImageTag,
-        CleanupStrategy cleanupStrategy) {
+        CleanupStrategy cleanupStrategy,
+        String containerName) {
       this.ignorePullError = ignorePullError;
       this.baseUri = baseUri;
       this.dockerImageName = dockerImageName;
       this.dockerImageTag = dockerImageTag;
       this.cleanupStrategy = cleanupStrategy;
+      this.containerName = containerName;
     }
 
-    public Builder setCleanupStraegy(CleanupStrategy cleanupStrategy) {
+    public Builder setCleanupStrategy(CleanupStrategy cleanupStrategy) {
       this.cleanupStrategy = requireNonNull(cleanupStrategy, "cleanupStrategy must be non null");
       return this;
     }
@@ -338,9 +373,19 @@ final class TestBench implements TestRule {
       return this;
     }
 
+    public Builder setContainerName(String containerName) {
+      this.containerName = requireNonNull(containerName, "containerName must be non null");
+      return this;
+    }
+
     public TestBench build() {
       return new TestBench(
-          ignorePullError, baseUri, dockerImageName, dockerImageTag, cleanupStrategy);
+          ignorePullError,
+          baseUri,
+          dockerImageName,
+          dockerImageTag,
+          cleanupStrategy,
+          containerName);
     }
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobWriteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobWriteChannelTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.it;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.api.client.json.JsonParser;
+import com.google.api.gax.rpc.FixedHeaderProvider;
+import com.google.api.services.storage.model.StorageObject;
+import com.google.cloud.NoCredentials;
+import com.google.cloud.WriteChannel;
+import com.google.cloud.conformance.storage.v1.InstructionList;
+import com.google.cloud.conformance.storage.v1.Method;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.DataGeneration;
+import com.google.cloud.storage.PackagePrivateMethodWorkarounds;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobWriteOption;
+import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.storage.conformance.retry.TestBench;
+import com.google.cloud.storage.conformance.retry.TestBench.RetryTestResource;
+import com.google.cloud.storage.spi.v1.StorageRpc;
+import com.google.cloud.storage.testing.RemoteStorageHelper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.Reflection;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.Random;
+import java.util.logging.Logger;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.threeten.bp.Clock;
+import org.threeten.bp.Instant;
+import org.threeten.bp.ZoneId;
+import org.threeten.bp.ZoneOffset;
+import org.threeten.bp.format.DateTimeFormatter;
+
+public final class ITBlobWriteChannelTest {
+  private static final Logger LOGGER = Logger.getLogger(ITBlobWriteChannelTest.class.getName());
+  private static final String NOW_STRING;
+
+  static {
+    Instant now = Clock.systemUTC().instant();
+    DateTimeFormatter formatter =
+        DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.from(ZoneOffset.UTC));
+    NOW_STRING = formatter.format(now);
+  }
+
+  private static final String BUCKET = RemoteStorageHelper.generateBucketName();
+
+  @ClassRule public static final TestBench testBench = TestBench.newBuilder().build();
+
+  @Rule public final TestName testName = new TestName();
+
+  @Rule public final DataGeneration dataGeneration = new DataGeneration(new Random(1234567890));
+
+  /**
+   * Test for unexpected EOF at the beginning of trying to read the json response.
+   *
+   * <p>The error of this case shows up as an IllegalArgumentException rather than a json parsing
+   * error which comes from {@link JsonParser}{@code #startParsing()} which fails to find a node to
+   * start parsing.
+   */
+  @Test
+  public void testJsonEOF_0B() throws IOException {
+    int contentSize = 512 * 1024;
+    int cappedByteCount = 0;
+
+    doJsonUnexpectedEOFTest(contentSize, cappedByteCount);
+  }
+
+  /** Test for unexpected EOF 10 bytes into the json response */
+  @Test
+  public void testJsonEOF_10B() throws IOException {
+    int contentSize = 512 * 1024;
+    int cappedByteCount = 10;
+
+    doJsonUnexpectedEOFTest(contentSize, cappedByteCount);
+  }
+
+  private void doJsonUnexpectedEOFTest(int contentSize, int cappedByteCount) throws IOException {
+    String blobPath = String.format("%s/%s/blob", testName.getMethodName(), NOW_STRING);
+
+    BucketInfo bucketInfo = BucketInfo.of(BUCKET);
+    BlobInfo blobInfo = BlobInfo.newBuilder(bucketInfo, blobPath, 0L).build();
+
+    RetryTestResource retryTestResource =
+        RetryTestResource.newRetryTestResource(
+            Method.newBuilder().setName("storage.objects.insert").build(),
+            InstructionList.newBuilder()
+                .addInstructions(
+                    String.format("return-broken-stream-final-chunk-after-%dB", cappedByteCount))
+                .build());
+    RetryTestResource retryTest = testBench.createRetryTest(retryTestResource);
+
+    StorageOptions baseOptions =
+        StorageOptions.newBuilder()
+            .setCredentials(NoCredentials.getInstance())
+            .setHost(testBench.getBaseUri())
+            .setProjectId("project-id")
+            .build();
+    StorageRpc noHeader = (StorageRpc) baseOptions.getRpc();
+    StorageRpc yesHeader =
+        (StorageRpc)
+            baseOptions
+                .toBuilder()
+                .setHeaderProvider(
+                    FixedHeaderProvider.create(ImmutableMap.of("x-retry-test-id", retryTest.id)))
+                .build()
+                .getRpc();
+    //noinspection UnstableApiUsage
+    StorageOptions storageOptions =
+        baseOptions
+            .toBuilder()
+            .setServiceRpcFactory(
+                options ->
+                    Reflection.newProxy(
+                        StorageRpc.class,
+                        (proxy, method, args) -> {
+                          try {
+                            if ("writeWithResponse".equals(method.getName())) {
+                              boolean lastChunk = (boolean) args[5];
+                              LOGGER.info(
+                                  String.format(
+                                      "writeWithResponse called. (lastChunk = %b)", lastChunk));
+                              if (lastChunk) {
+                                return method.invoke(yesHeader, args);
+                              }
+                            }
+                            return method.invoke(noHeader, args);
+                          } catch (Exception e) {
+                            if (e.getCause() != null) {
+                              throw e.getCause();
+                            } else {
+                              throw e;
+                            }
+                          }
+                        }))
+            .build();
+
+    Storage testStorage = storageOptions.getService();
+
+    testStorage.create(bucketInfo);
+
+    ByteBuffer content = dataGeneration.randByteBuffer(contentSize);
+    // create a duplicate to preserve the initial offset and limit for assertion later
+    ByteBuffer expected = content.duplicate();
+
+    WriteChannel w = testStorage.writer(blobInfo, BlobWriteOption.generationMatch());
+    w.write(content);
+    w.close();
+
+    RetryTestResource postRunState = testBench.getRetryTest(retryTest);
+    assertTrue(postRunState.completed);
+
+    Optional<StorageObject> optionalStorageObject =
+        PackagePrivateMethodWorkarounds.maybeGetStorageObjectFunction().apply(w);
+
+    assertTrue(optionalStorageObject.isPresent());
+    StorageObject storageObject = optionalStorageObject.get();
+    assertThat(storageObject.getName()).isEqualTo(blobInfo.getName());
+
+    Blob blobGen2 = testStorage.get(blobInfo.getBlobId());
+    assertEquals(contentSize, (long) blobGen2.getSize());
+    assertNotEquals(blobInfo.getGeneration(), blobGen2.getGeneration());
+    ByteArrayOutputStream actualData = new ByteArrayOutputStream();
+    blobGen2.downloadTo(actualData);
+    ByteBuffer actual = ByteBuffer.wrap(actualData.toByteArray());
+    assertEquals(expected, actual);
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobWriteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobWriteChannelTest.java
@@ -71,7 +71,15 @@ public final class ITBlobWriteChannelTest {
 
   private static final String BUCKET = RemoteStorageHelper.generateBucketName();
 
-  @ClassRule public static final TestBench testBench = TestBench.newBuilder().build();
+  @ClassRule
+  public static final TestBench testBench =
+      TestBench.newBuilder()
+          .setContainerName("blob-write-channel-test")
+          // set a different base uri to prevent collision with conformance tests.
+          // It's possible for ITRetryConformanceTest to finish running and start shutting down
+          // when this test starts so the liveness check passes against the shutting down server.
+          .setBaseUri("http://localhost:9100")
+          .build();
 
   @Rule public final TestName testName = new TestName();
 


### PR DESCRIPTION
### Fix
Update DefaultStorageRetryStrategy to account for EOF errors from Json. When parsing json it's possible we've only received a partial document and parsing will fail. If an unexpected EOF happens from parsing and the request is idempotent retry it.

#### Tests
Add two new integration tests which leverage the testbench to force the EOF to happen upon the completion of the resumable session.
* Add 0B offset test
* Add 10B offset test

Add new cases to DefaultRetryHandlingBehaviorTest to ensure continued expected handling for the new EOF behavior.

#### Refactor
* Make TestBench.java (and its associated Builder) public to allow for use outside the retry conformance test package
* Create new JUnit @rule DataGeneration moving com.google.cloud.storage.it.ITStorageTest#randString to it and change the signature to produce a ByteBuffer rather than a string. (this should simplify use since the strings returned were immediately turned to bytes)

Fixes #1154