### PR TITLE
test: bump storage-testbench to v0.11.0

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/DataGeneration.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/DataGeneration.java
@@ -19,6 +19,7 @@ package com.google.cloud.storage;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
+import java.util.UUID;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -26,9 +27,15 @@ import org.junit.runners.model.Statement;
 public final class DataGeneration implements TestRule {
 
   private final Random rand;
+  private final String bucketName;
 
   public DataGeneration(Random rand) {
     this.rand = rand;
+    this.bucketName = String.format("rand-bkt-%s", UUID.randomUUID());
+  }
+
+  public String getBucketName() {
+    return bucketName;
   }
 
   public ByteBuffer randByteBuffer(int limit) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestBench.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestBench.java
@@ -337,7 +337,7 @@ public final class TestBench implements TestRule {
     private static final String DEFAULT_BASE_URI = "http://localhost:9000";
     private static final String DEFAULT_IMAGE_NAME =
         "gcr.io/cloud-devrel-public-resources/storage-testbench";
-    private static final String DEFAULT_IMAGE_TAG = "v0.10.0";
+    private static final String DEFAULT_IMAGE_TAG = "v0.11.0";
     private static final String DEFAULT_CONTAINER_NAME = "default";
 
     private boolean ignorePullError;


### PR DESCRIPTION
* Update ITBlobWriteChannelTest to be compliant with new enforcements
  * Unique bucket per test
  * Explicitly do not attempt to get the object with generation 0
