### PR TITLE
docs: adjust retry settings for hmac samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ implementation 'com.google.cloud:google-cloud-storage'
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-storage:2.4.5'
+implementation 'com.google.cloud:google-cloud-storage:2.5.1'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "2.4.5"
+libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "2.5.1"
 ```
 
 ## Authentication

--- a/samples/snippets/src/test/java/com/example/storage/ITHmacSnippets.java
+++ b/samples/snippets/src/test/java/com/example/storage/ITHmacSnippets.java
@@ -33,6 +33,7 @@ import com.google.cloud.storage.HmacKey.HmacKeyMetadata;
 import com.google.cloud.storage.HmacKey.HmacKeyState;
 import com.google.cloud.storage.ServiceAccount;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageRetryStrategy;
 import com.google.cloud.storage.testing.RemoteStorageHelper;
 import java.io.ByteArrayOutputStream;
 import java.io.FileDescriptor;
@@ -42,6 +43,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.threeten.bp.Duration;
 
 public class ITHmacSnippets {
   private static final String PROJECT_ID = ServiceOptions.getDefaultProjectId();
@@ -63,8 +65,11 @@ public class ITHmacSnippets {
                     .getOptions()
                     .getRetrySettings()
                     .toBuilder()
-                    .setRetryDelayMultiplier(3.0)
+                    .setMaxAttempts(10)
+                    .setTotalTimeout(Duration.ofMinutes(5))
+                    .setRetryDelayMultiplier(10.0)
                     .build())
+            .setStorageRetryStrategy(StorageRetryStrategy.getUniformStorageRetryStrategy())
             .build()
             .getService();
   }

--- a/samples/snippets/src/test/java/com/example/storage/ITHmacSnippets.java
+++ b/samples/snippets/src/test/java/com/example/storage/ITHmacSnippets.java
@@ -33,7 +33,6 @@ import com.google.cloud.storage.HmacKey.HmacKeyMetadata;
 import com.google.cloud.storage.HmacKey.HmacKeyState;
 import com.google.cloud.storage.ServiceAccount;
 import com.google.cloud.storage.Storage;
-
 import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import org.junit.Assert;
 import org.junit.Before;
@@ -50,8 +49,7 @@ public class ITHmacSnippets extends TestBase {
     cleanUpHmacKeys(ServiceAccount.of(HMAC_KEY_TEST_SERVICE_ACCOUNT));
   }
 
-  @Rule
-  public MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(5);
+  @Rule public MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(5);
 
   private void cleanUpHmacKeys(ServiceAccount serviceAccount) {
     Page<HmacKey.HmacKeyMetadata> metadatas =
@@ -68,7 +66,7 @@ public class ITHmacSnippets extends TestBase {
 
   @Test
   public void testCreateHmacKey() throws Exception {
-;
+    ;
     CreateHmacKey.createHmacKey(HMAC_KEY_TEST_SERVICE_ACCOUNT, PROJECT_ID);
     String snippetOutput = stdOut.getCapturedOutputAsUtf8String();
     String accessId = snippetOutput.split("Access ID: ")[1].split("\n")[0];

--- a/samples/snippets/src/test/java/com/example/storage/ITHmacSnippets.java
+++ b/samples/snippets/src/test/java/com/example/storage/ITHmacSnippets.java
@@ -33,56 +33,27 @@ import com.google.cloud.storage.HmacKey.HmacKeyMetadata;
 import com.google.cloud.storage.HmacKey.HmacKeyState;
 import com.google.cloud.storage.ServiceAccount;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageRetryStrategy;
-import com.google.cloud.storage.testing.RemoteStorageHelper;
-import java.io.ByteArrayOutputStream;
-import java.io.FileDescriptor;
-import java.io.FileOutputStream;
-import java.io.PrintStream;
+
+import com.google.cloud.testing.junit4.MultipleAttemptsRule;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
-import org.threeten.bp.Duration;
 
-public class ITHmacSnippets {
+public class ITHmacSnippets extends TestBase {
   private static final String PROJECT_ID = ServiceOptions.getDefaultProjectId();
   private static final String HMAC_KEY_TEST_SERVICE_ACCOUNT =
       PROJECT_ID + "@" + PROJECT_ID + ".iam.gserviceaccount.com";
-  private final PrintStream standardOut = new PrintStream(new FileOutputStream(FileDescriptor.out));
-
-  private static Storage storage;
-
-  @BeforeClass
-  public static void beforeClass() {
-    RemoteStorageHelper helper = RemoteStorageHelper.create();
-    storage =
-        helper
-            .getOptions()
-            .toBuilder()
-            .setRetrySettings(
-                helper
-                    .getOptions()
-                    .getRetrySettings()
-                    .toBuilder()
-                    .setMaxAttempts(10)
-                    .setTotalTimeout(Duration.ofMinutes(5))
-                    .setRetryDelayMultiplier(10.0)
-                    .build())
-            .setStorageRetryStrategy(StorageRetryStrategy.getUniformStorageRetryStrategy())
-            .build()
-            .getService();
-  }
 
   @Before
   public void before() {
     cleanUpHmacKeys(ServiceAccount.of(HMAC_KEY_TEST_SERVICE_ACCOUNT));
-
-    // This is just in case any tests failed before they could reset the value
-    System.setOut(standardOut);
   }
 
-  private static void cleanUpHmacKeys(ServiceAccount serviceAccount) {
+  @Rule
+  public MultipleAttemptsRule multipleAttemptsRule = new MultipleAttemptsRule(5);
+
+  private void cleanUpHmacKeys(ServiceAccount serviceAccount) {
     Page<HmacKey.HmacKeyMetadata> metadatas =
         storage.listHmacKeys(Storage.ListHmacKeysOption.serviceAccount(serviceAccount));
     for (HmacKey.HmacKeyMetadata hmacKeyMetadata : metadatas.iterateAll()) {
@@ -97,11 +68,9 @@ public class ITHmacSnippets {
 
   @Test
   public void testCreateHmacKey() throws Exception {
-    final ByteArrayOutputStream snippetOutputCapture = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(snippetOutputCapture));
+;
     CreateHmacKey.createHmacKey(HMAC_KEY_TEST_SERVICE_ACCOUNT, PROJECT_ID);
-    String snippetOutput = snippetOutputCapture.toString();
-    System.setOut(standardOut);
+    String snippetOutput = stdOut.getCapturedOutputAsUtf8String();
     String accessId = snippetOutput.split("Access ID: ")[1].split("\n")[0];
     Thread.sleep(5000);
     assertNotNull(storage.getHmacKey(accessId));
@@ -110,13 +79,9 @@ public class ITHmacSnippets {
   @Test
   public void testGetHmacKey() throws Exception {
     HmacKey hmacKey = storage.createHmacKey(ServiceAccount.of(HMAC_KEY_TEST_SERVICE_ACCOUNT));
-
-    final ByteArrayOutputStream snippetOutputCapture = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(snippetOutputCapture));
     Thread.sleep(5000);
     GetHmacKey.getHmacKey(hmacKey.getMetadata().getAccessId(), PROJECT_ID);
-    String snippetOutput = snippetOutputCapture.toString();
-    System.setOut(standardOut);
+    String snippetOutput = stdOut.getCapturedOutputAsUtf8String();
     Assert.assertTrue(snippetOutput.contains(HMAC_KEY_TEST_SERVICE_ACCOUNT));
   }
 
@@ -134,9 +99,8 @@ public class ITHmacSnippets {
   @Test
   public void testDeactivateHmacKey() throws Exception {
     HmacKey hmacKey = storage.createHmacKey(ServiceAccount.of(HMAC_KEY_TEST_SERVICE_ACCOUNT));
-
-    DeactivateHmacKey.deactivateHmacKey(hmacKey.getMetadata().getAccessId(), PROJECT_ID);
     Thread.sleep(5000);
+    DeactivateHmacKey.deactivateHmacKey(hmacKey.getMetadata().getAccessId(), PROJECT_ID);
     assertEquals(
         HmacKeyState.INACTIVE, storage.getHmacKey(hmacKey.getMetadata().getAccessId()).getState());
   }
@@ -163,12 +127,9 @@ public class ITHmacSnippets {
             ServiceAccount.of(HMAC_KEY_TEST_SERVICE_ACCOUNT),
             Storage.CreateHmacKeyOption.projectId(PROJECT_ID));
 
-    final ByteArrayOutputStream snippetOutputCapture = new ByteArrayOutputStream();
-    System.setOut(new PrintStream(snippetOutputCapture));
     ListHmacKeys.listHmacKeys(PROJECT_ID);
-    String snippetOutput = snippetOutputCapture.toString();
+    String snippetOutput = stdOut.getCapturedOutputAsUtf8String();
     assertTrue(snippetOutput.contains(one.getMetadata().getAccessId()));
     assertTrue(snippetOutput.contains(two.getMetadata().getAccessId()));
-    System.setOut(standardOut);
   }
 }


### PR DESCRIPTION
Adjust retry settings for HMAC samples to make sure that these requests are getting retried. 

This was also needed in Go (See https://github.com/GoogleCloudPlatform/golang-samples/blob/main/storage/service_account/hmac/hmac_test.go#L195)

Should fix https://github.com/googleapis/java-storage/issues/1302