### PR TITLE
deps: allow snapshot to update properly

### DIFF
--- a/samples/snapshot/pom.xml
+++ b/samples/snapshot/pom.xml
@@ -23,12 +23,11 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <!-- {x-version-update-start::current} -->
   <dependencies>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>2.4.6-SNAPSHOT</version>
+      <version>2.4.6-SNAPSHOT</version><!-- {x-version-update:google-cloud-storage:current} -->
     </dependency>
 
     <dependency>
@@ -50,7 +49,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <!-- {x-version-update-end} -->
 
   <!-- compile and run all snippet tests -->
   <build>


### PR DESCRIPTION
The samples build on https://github.com/googleapis/java-storage/pull/1293 is broken due to 

`Failed to execute goal on project storage-snapshot: Could not resolve dependencies for project com.google.cloud:storage-snapshot:jar:1.2.0: Could not find artifact com.google.cloud:google-cloud-storage:jar:2.4.6-SNAPSHOT `

It appears the version is not updating properly. This should fix the issue.
