### PR TITLE
fix(java): add service account email to Native Image testing kokoro job

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -91,6 +91,20 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
+  - pattern: feat/grpc-storage
+    isAdminEnforced: true
+    requiredApprovingReviewCount: 1
+    requiresCodeOwnerReviews: true
+    requiresStrictStatusChecks: false
+    requiredStatusCheckContexts:
+      - dependencies (8)
+      - dependencies (11)
+      - lint
+      - clirr
+      - units (8)
+      - units (11)
+      - 'Kokoro - Test: Integration'
+      - cla/google
 permissionRules:
   - team: yoshi-admins
     permission: admin

--- a/.kokoro/presubmit/graalvm-native.cfg
+++ b/.kokoro/presubmit/graalvm-native.cfg
@@ -31,3 +31,8 @@ env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "java-it-service-account"
 }
+
+env_vars: {
+  key: "IT_SERVICE_ACCOUNT_EMAIL"
+  value: "it-service-account@gcloud-devel.iam.gserviceaccount.com"
+}

--- a/owlbot.py
+++ b/owlbot.py
@@ -33,5 +33,6 @@ java.common_templates(excludes=[
   '.kokoro/nightly/samples.cfg',
   '.kokoro/presubmit/integration.cfg',
   '.kokoro/presubmit/samples.cfg',
+  '.kokoro/presubmit/graalvm-native.cfg',
   'CONTRIBUTING.md'
 ])


### PR DESCRIPTION
This PR reduces the discrepancy between the standard Java and Native Image kokoro job. It should also fix the following error:
```
java.lang.AssertionError: Unable to determine service account email
	at com.google.cloud.storage.it.ITStorageTest.testHmacKey(ITStorageTest.java:2472)
```
