### PR TITLE
deps: try gax 2.17.0 for Java 8 compatibility (not for merge)

### DIFF
--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -54,6 +54,7 @@
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax</artifactId>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.google.api</groupId>
+        <artifactId>gax-bom</artifactId>
+        <version>2.17.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
         <version>${google.cloud.shared-dependencies.version}</version>


### PR DESCRIPTION
Not for merging.

Confirming GAX 2.17.0's Java 8 compatibility.