### PR TITLE
feat: refactor model classes to prefer to java.time types

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BackwardCompatibilityUtils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BackwardCompatibilityUtils.java
@@ -19,6 +19,7 @@ package com.google.cloud.storage;
 import static java.util.Objects.requireNonNull;
 
 import com.google.cloud.storage.Conversions.Codec;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -37,11 +38,21 @@ final class BackwardCompatibilityUtils {
   // would.
   static final Codec<@Nullable Long, @Nullable OffsetDateTime> millisOffsetDateTimeCodec =
       Codec.<Long, OffsetDateTime>of(
-              m ->
-                  Instant.ofEpochMilli(requireNonNull(m, "m must be non null"))
+              l ->
+                  Instant.ofEpochMilli(requireNonNull(l, "l must be non null"))
                       .atOffset(ZoneOffset.systemDefault().getRules().getOffset(Instant.now())),
               odt -> requireNonNull(odt, "odt must be non null").toInstant().toEpochMilli())
           .nullable();
+
+  static final Codec<Long, OffsetDateTime> millisUtcCodec =
+      Codec.of(
+          l ->
+              Instant.ofEpochMilli(requireNonNull(l, "l must be non null"))
+                  .atOffset(ZoneOffset.UTC),
+          odt -> requireNonNull(odt, "odt must be non null").toInstant().toEpochMilli());
+
+  static final Codec<@Nullable Duration, @Nullable Long> nullableDurationMillisCodec =
+      Utils.durationMillisCodec.nullable();
 
   private BackwardCompatibilityUtils() {}
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Blob.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Blob.java
@@ -37,6 +37,7 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.nio.file.Path;
 import java.security.Key;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -384,9 +385,18 @@ public class Blob extends BlobInfo {
       return this;
     }
 
+    /** @deprecated Use {@link #setTimeStorageClassUpdatedOffsetDateTime(OffsetDateTime)} */
     @Override
+    @Deprecated
     public Builder setTimeStorageClassUpdated(Long timeStorageClassUpdated) {
       infoBuilder.setTimeStorageClassUpdated(timeStorageClassUpdated);
+      return this;
+    }
+
+    @Override
+    public BlobInfo.Builder setTimeStorageClassUpdatedOffsetDateTime(
+        OffsetDateTime timeStorageClassUpdated) {
+      infoBuilder.setTimeStorageClassUpdatedOffsetDateTime(timeStorageClassUpdated);
       return this;
     }
 
@@ -396,27 +406,58 @@ public class Blob extends BlobInfo {
       return this;
     }
 
+    /** @deprecated Use {@link #setDeleteTimeOffsetDateTime(OffsetDateTime)} */
     @Override
+    @Deprecated
     Builder setDeleteTime(Long deleteTime) {
       infoBuilder.setDeleteTime(deleteTime);
       return this;
     }
 
     @Override
+    BlobInfo.Builder setDeleteTimeOffsetDateTime(OffsetDateTime deleteTime) {
+      infoBuilder.setDeleteTimeOffsetDateTime(deleteTime);
+      return this;
+    }
+
+    /** @deprecated Use {@link #setUpdateTimeOffsetDateTime(OffsetDateTime)} */
+    @Override
+    @Deprecated
     Builder setUpdateTime(Long updateTime) {
       infoBuilder.setUpdateTime(updateTime);
       return this;
     }
 
     @Override
+    BlobInfo.Builder setUpdateTimeOffsetDateTime(OffsetDateTime updateTime) {
+      infoBuilder.setUpdateTimeOffsetDateTime(updateTime);
+      return this;
+    }
+
+    @Override
+    @Deprecated
     Builder setCreateTime(Long createTime) {
       infoBuilder.setCreateTime(createTime);
       return this;
     }
 
     @Override
+    BlobInfo.Builder setCreateTimeOffsetDateTime(OffsetDateTime createTime) {
+      infoBuilder.setCreateTimeOffsetDateTime(createTime);
+      return this;
+    }
+
+    /** @deprecated Use {@link #setCustomTimeOffsetDateTime(OffsetDateTime)} */
+    @Override
+    @Deprecated
     public Builder setCustomTime(Long customTime) {
       infoBuilder.setCustomTime(customTime);
+      return this;
+    }
+
+    @Override
+    public BlobInfo.Builder setCustomTimeOffsetDateTime(OffsetDateTime customTime) {
+      infoBuilder.setCustomTimeOffsetDateTime(customTime);
       return this;
     }
 
@@ -450,9 +491,18 @@ public class Blob extends BlobInfo {
       return this;
     }
 
+    /** @deprecated Use {@link #setRetentionExpirationTimeOffsetDateTime(OffsetDateTime)} */
     @Override
+    @Deprecated
     Builder setRetentionExpirationTime(Long retentionExpirationTime) {
       infoBuilder.setRetentionExpirationTime(retentionExpirationTime);
+      return this;
+    }
+
+    @Override
+    BlobInfo.Builder setRetentionExpirationTimeOffsetDateTime(
+        OffsetDateTime retentionExpirationTime) {
+      infoBuilder.setRetentionExpirationTimeOffsetDateTime(retentionExpirationTime);
       return this;
     }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobInfo.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobInfo.java
@@ -263,7 +263,7 @@ public class BlobInfo implements Serializable {
      * BlobInfo blob = BlobInfo.newBuilder(bucketName, blobName).setCustomTime(customTime).build();
      * }</pre>
      *
-     * @deprecated {@link #setCustomTime(OffsetDateTime)}
+     * @deprecated Use {@link #setCustomTimeOffsetDateTime(OffsetDateTime)}
      */
     @Deprecated
     public Builder setCustomTime(Long customTime) {
@@ -286,7 +286,7 @@ public class BlobInfo implements Serializable {
      * BlobInfo blob = BlobInfo.newBuilder(bucketName, blobName).setCustomTime(customTime).build();
      * }</pre>
      */
-    public Builder setCustomTime(OffsetDateTime customTime) {
+    public Builder setCustomTimeOffsetDateTime(OffsetDateTime customTime) {
       // provide an implementation for source and binary compatibility which we override ourselves
       return setCustomTime(millisOffsetDateTimeCodec.decode(customTime));
     }
@@ -311,7 +311,7 @@ public class BlobInfo implements Serializable {
      * Sets the modification time of an object's storage class. Once set it can't be unset directly,
      * the only way is to rewrite the object with the desired storage class.
      *
-     * @deprecated {@link #setTimeStorageClassUpdated(OffsetDateTime)}
+     * @deprecated Use {@link #setTimeStorageClassUpdatedOffsetDateTime(OffsetDateTime)}
      */
     @Deprecated
     public Builder setTimeStorageClassUpdated(Long timeStorageClassUpdated) {
@@ -320,7 +320,8 @@ public class BlobInfo implements Serializable {
               + " or use com.google.cloud.storage.Blob.");
     }
 
-    public Builder setTimeStorageClassUpdated(OffsetDateTime timeStorageClassUpdated) {
+    public Builder setTimeStorageClassUpdatedOffsetDateTime(
+        OffsetDateTime timeStorageClassUpdated) {
       // provide an implementation for source and binary compatibility which we override ourselves
       return setTimeStorageClassUpdated(millisOffsetDateTimeCodec.decode(timeStorageClassUpdated));
     }
@@ -330,29 +331,29 @@ public class BlobInfo implements Serializable {
 
     abstract Builder setMetageneration(Long metageneration);
 
-    /** @deprecated {@link #setDeleteTime(OffsetDateTime)} */
+    /** @deprecated Use {@link #setDeleteTimeOffsetDateTime(OffsetDateTime)} */
     @Deprecated
     abstract Builder setDeleteTime(Long deleteTime);
 
-    Builder setDeleteTime(OffsetDateTime deleteTime) {
+    Builder setDeleteTimeOffsetDateTime(OffsetDateTime deleteTime) {
       // provide an implementation for source and binary compatibility which we override ourselves
       return setDeleteTime(millisOffsetDateTimeCodec.decode(deleteTime));
     }
 
-    /** @deprecated {@link #setUpdateTime(OffsetDateTime)} */
+    /** @deprecated Use {@link #setUpdateTimeOffsetDateTime(OffsetDateTime)} */
     @Deprecated
     abstract Builder setUpdateTime(Long updateTime);
 
-    Builder setUpdateTime(OffsetDateTime updateTime) {
+    Builder setUpdateTimeOffsetDateTime(OffsetDateTime updateTime) {
       // provide an implementation for source and binary compatibility which we override ourselves
       return setUpdateTime(millisOffsetDateTimeCodec.decode(updateTime));
     }
 
-    /** @deprecated {@link #setCreateTime(OffsetDateTime)} */
+    /** @deprecated Use {@link #setCreateTimeOffsetDateTime(OffsetDateTime)} */
     @Deprecated
     abstract Builder setCreateTime(Long createTime);
 
-    Builder setCreateTime(OffsetDateTime createTime) {
+    Builder setCreateTimeOffsetDateTime(OffsetDateTime createTime) {
       // provide an implementation for source and binary compatibility which we override ourselves
       return setCreateTime(millisOffsetDateTimeCodec.decode(createTime));
     }
@@ -388,13 +389,13 @@ public class BlobInfo implements Serializable {
     @BetaApi
     public abstract Builder setTemporaryHold(Boolean temporaryHold);
 
-    /** @deprecated {@link #setRetentionExpirationTime(OffsetDateTime)} */
+    /** @deprecated {@link #setRetentionExpirationTimeOffsetDateTime(OffsetDateTime)} */
     @BetaApi
     @Deprecated
     abstract Builder setRetentionExpirationTime(Long retentionExpirationTime);
 
     @BetaApi
-    Builder setRetentionExpirationTime(OffsetDateTime retentionExpirationTime) {
+    Builder setRetentionExpirationTimeOffsetDateTime(OffsetDateTime retentionExpirationTime) {
       // provide an implementation for source and binary compatibility which we override ourselves
       return setRetentionExpirationTime(millisOffsetDateTimeCodec.decode(retentionExpirationTime));
     }
@@ -587,13 +588,15 @@ public class BlobInfo implements Serializable {
       return this;
     }
 
+    /** @deprecated {@link #setCustomTimeOffsetDateTime(OffsetDateTime)} */
     @Override
+    @Deprecated
     public Builder setCustomTime(Long customTime) {
-      return setCustomTime(millisOffsetDateTimeCodec.encode(customTime));
+      return setCustomTimeOffsetDateTime(millisOffsetDateTimeCodec.encode(customTime));
     }
 
     @Override
-    public Builder setCustomTime(OffsetDateTime customTime) {
+    public Builder setCustomTimeOffsetDateTime(OffsetDateTime customTime) {
       this.customTime = customTime;
       return this;
     }
@@ -645,13 +648,17 @@ public class BlobInfo implements Serializable {
       return this;
     }
 
+    /** @deprecated Use {@link #setTimeStorageClassUpdatedOffsetDateTime(OffsetDateTime)} */
+    @Deprecated
     @Override
     public Builder setTimeStorageClassUpdated(Long timeStorageClassUpdated) {
-      return setTimeStorageClassUpdated(millisOffsetDateTimeCodec.encode(timeStorageClassUpdated));
+      return setTimeStorageClassUpdatedOffsetDateTime(
+          millisOffsetDateTimeCodec.encode(timeStorageClassUpdated));
     }
 
     @Override
-    public Builder setTimeStorageClassUpdated(OffsetDateTime timeStorageClassUpdated) {
+    public Builder setTimeStorageClassUpdatedOffsetDateTime(
+        OffsetDateTime timeStorageClassUpdated) {
       this.timeStorageClassUpdated = timeStorageClassUpdated;
       return this;
     }
@@ -662,35 +669,40 @@ public class BlobInfo implements Serializable {
       return this;
     }
 
+    /** @deprecated Use {@link #setDeleteTimeOffsetDateTime(OffsetDateTime)} */
+    @Deprecated
     @Override
     Builder setDeleteTime(Long deleteTime) {
-      return setDeleteTime(millisOffsetDateTimeCodec.encode(deleteTime));
+      return setDeleteTimeOffsetDateTime(millisOffsetDateTimeCodec.encode(deleteTime));
     }
 
     @Override
-    Builder setDeleteTime(OffsetDateTime deleteTime) {
+    Builder setDeleteTimeOffsetDateTime(OffsetDateTime deleteTime) {
       this.deleteTime = deleteTime;
       return this;
     }
 
+    /** @deprecated Use {@link #setUpdateTimeOffsetDateTime(OffsetDateTime)} */
     @Override
     Builder setUpdateTime(Long updateTime) {
-      return setUpdateTime(millisOffsetDateTimeCodec.encode(updateTime));
+      return setUpdateTimeOffsetDateTime(millisOffsetDateTimeCodec.encode(updateTime));
     }
 
     @Override
-    Builder setUpdateTime(OffsetDateTime updateTime) {
+    Builder setUpdateTimeOffsetDateTime(OffsetDateTime updateTime) {
       this.updateTime = updateTime;
       return this;
     }
 
+    /** @deprecated Use {@link #setCreateTimeOffsetDateTime(OffsetDateTime)} */
+    @Deprecated
     @Override
     Builder setCreateTime(Long createTime) {
-      return setCreateTime(millisOffsetDateTimeCodec.encode(createTime));
+      return setCreateTimeOffsetDateTime(millisOffsetDateTimeCodec.encode(createTime));
     }
 
     @Override
-    Builder setCreateTime(OffsetDateTime createTime) {
+    Builder setCreateTimeOffsetDateTime(OffsetDateTime createTime) {
       this.createTime = createTime;
       return this;
     }
@@ -725,13 +737,16 @@ public class BlobInfo implements Serializable {
       return this;
     }
 
+    /** @deprecated {@link #setRetentionExpirationTimeOffsetDateTime(OffsetDateTime)} */
     @Override
+    @Deprecated
     Builder setRetentionExpirationTime(Long retentionExpirationTime) {
-      return setRetentionExpirationTime(millisOffsetDateTimeCodec.encode(retentionExpirationTime));
+      return setRetentionExpirationTimeOffsetDateTime(
+          millisOffsetDateTimeCodec.encode(retentionExpirationTime));
     }
 
     @Override
-    Builder setRetentionExpirationTime(OffsetDateTime retentionExpirationTime) {
+    Builder setRetentionExpirationTimeOffsetDateTime(OffsetDateTime retentionExpirationTime) {
       this.retentionExpirationTime = retentionExpirationTime;
       return this;
     }
@@ -980,7 +995,7 @@ public class BlobInfo implements Serializable {
    * Returns the deletion time of the blob expressed as the number of milliseconds since the Unix
    * epoch.
    *
-   * @deprecated {@link #getDeleteTimeOffsetDateTime()}
+   * @deprecated Use {@link #getDeleteTimeOffsetDateTime()}
    */
   @Deprecated
   public Long getDeleteTime() {
@@ -996,7 +1011,7 @@ public class BlobInfo implements Serializable {
    * Returns the last modification time of the blob's metadata expressed as the number of
    * milliseconds since the Unix epoch.
    *
-   * @deprecated {@link #getUpdateTimeOffsetDateTime()}
+   * @deprecated Use {@link #getUpdateTimeOffsetDateTime()}
    */
   @Deprecated
   public Long getUpdateTime() {
@@ -1012,7 +1027,7 @@ public class BlobInfo implements Serializable {
    * Returns the creation time of the blob expressed as the number of milliseconds since the Unix
    * epoch.
    *
-   * @deprecated {@link #getCreateTimeOffsetDateTime()}
+   * @deprecated Use {@link #getCreateTimeOffsetDateTime()}
    */
   @Deprecated
   public Long getCreateTime() {
@@ -1027,7 +1042,7 @@ public class BlobInfo implements Serializable {
   /**
    * Returns the custom time specified by the user for an object.
    *
-   * @deprecated {@link #getCustomTimeOffsetDateTime()}
+   * @deprecated Use {@link #getCustomTimeOffsetDateTime()}
    */
   @Deprecated
   public Long getCustomTime() {
@@ -1068,7 +1083,7 @@ public class BlobInfo implements Serializable {
    * Returns the time that the object's storage class was last changed or the time of the object
    * creation.
    *
-   * @deprecated {@link #getTimeStorageClassUpdatedOffsetDateTime()}
+   * @deprecated Use {@link #getTimeStorageClassUpdatedOffsetDateTime()}
    */
   @Deprecated
   public Long getTimeStorageClassUpdated() {
@@ -1146,7 +1161,7 @@ public class BlobInfo implements Serializable {
    * Returns the retention expiration time of the blob as {@code Long}, if a retention period is
    * defined. If retention period is not defined this value returns {@code null}
    *
-   * @deprecated {@link #getRetentionExpirationTimeOffsetDateTime()}
+   * @deprecated Use {@link #getRetentionExpirationTimeOffsetDateTime()}
    */
   @BetaApi
   @Deprecated

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Bucket.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Bucket.java
@@ -38,6 +38,8 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.security.Key;
+import java.time.Duration;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -558,6 +560,11 @@ public class Bucket extends BucketInfo {
       return this;
     }
 
+    /**
+     * @deprecated Use {@link #setLifecycleRules(Iterable)} instead, as in {@code
+     *     setLifecycleRules(Collections.singletonList( new BucketInfo.LifecycleRule(
+     *     LifecycleAction.newDeleteAction(), LifecycleCondition.newBuilder().setAge(5).build())));}
+     */
     @Override
     @Deprecated
     public Builder setDeleteRules(Iterable<? extends DeleteRule> rules) {
@@ -601,15 +608,31 @@ public class Bucket extends BucketInfo {
       return this;
     }
 
+    /** @deprecated Use {@link #setCreateTimeOffsetDateTime(OffsetDateTime)} */
     @Override
+    @Deprecated
     Builder setCreateTime(Long createTime) {
       infoBuilder.setCreateTime(createTime);
       return this;
     }
 
     @Override
+    BucketInfo.Builder setCreateTimeOffsetDateTime(OffsetDateTime createTime) {
+      infoBuilder.setCreateTimeOffsetDateTime(createTime);
+      return this;
+    }
+
+    /** @deprecated Use {@link #setUpdateTimeOffsetDateTime(OffsetDateTime)} */
+    @Override
+    @Deprecated
     Builder setUpdateTime(Long updateTime) {
       infoBuilder.setUpdateTime(updateTime);
+      return this;
+    }
+
+    @Override
+    BucketInfo.Builder setUpdateTimeOffsetDateTime(OffsetDateTime updateTime) {
+      infoBuilder.setUpdateTimeOffsetDateTime(updateTime);
       return this;
     }
 
@@ -655,9 +678,18 @@ public class Bucket extends BucketInfo {
       return this;
     }
 
+    /** @deprecated {@link #setRetentionEffectiveTimeOffsetDateTime(OffsetDateTime)} */
     @Override
+    @Deprecated
     Builder setRetentionEffectiveTime(Long retentionEffectiveTime) {
       infoBuilder.setRetentionEffectiveTime(retentionEffectiveTime);
+      return this;
+    }
+
+    @Override
+    BucketInfo.Builder setRetentionEffectiveTimeOffsetDateTime(
+        OffsetDateTime retentionEffectiveTime) {
+      infoBuilder.setRetentionEffectiveTimeOffsetDateTime(retentionEffectiveTime);
       return this;
     }
 
@@ -667,9 +699,17 @@ public class Bucket extends BucketInfo {
       return this;
     }
 
+    /** @deprecated Use {@link #setRetentionPeriodDuration(Duration)} */
     @Override
+    @Deprecated
     public Builder setRetentionPeriod(Long retentionPeriod) {
       infoBuilder.setRetentionPeriod(retentionPeriod);
+      return this;
+    }
+
+    @Override
+    public BucketInfo.Builder setRetentionPeriodDuration(Duration retentionPeriod) {
+      infoBuilder.setRetentionPeriodDuration(retentionPeriod);
       return this;
     }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/HmacKey.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/HmacKey.java
@@ -16,7 +16,10 @@
 
 package com.google.cloud.storage;
 
+import static com.google.cloud.storage.BackwardCompatibilityUtils.millisOffsetDateTimeCodec;
+
 import java.io.Serializable;
+import java.time.OffsetDateTime;
 import java.util.Objects;
 
 /** HMAC key for a service account. */
@@ -113,8 +116,8 @@ public class HmacKey implements Serializable {
     private final String projectId;
     private final ServiceAccount serviceAccount;
     private final HmacKeyState state;
-    private final Long createTime;
-    private final Long updateTime;
+    private final OffsetDateTime createTime;
+    private final OffsetDateTime updateTime;
 
     private HmacKeyMetadata(Builder builder) {
       this.accessId = builder.accessId;
@@ -200,13 +203,33 @@ public class HmacKey implements Serializable {
       return state;
     }
 
-    /** Returns the creation time of this HMAC key. * */
+    /**
+     * Returns the creation time of this HMAC key.
+     *
+     * @deprecated Use {@link #getCreateTimeOffsetDateTime()}
+     */
+    @Deprecated
     public Long getCreateTime() {
+      return millisOffsetDateTimeCodec.decode(createTime);
+    }
+
+    /** Returns the creation time of this HMAC key. * */
+    public OffsetDateTime getCreateTimeOffsetDateTime() {
       return createTime;
     }
 
-    /** Returns the last updated time of this HMAC key. * */
+    /**
+     * Returns the last updated time of this HMAC key.
+     *
+     * @deprecated Use {@link #getUpdateTimeOffsetDateTime()}
+     */
+    @Deprecated
     public Long getUpdateTime() {
+      return millisOffsetDateTimeCodec.decode(updateTime);
+    }
+
+    /** Returns the last updated time of this HMAC key. * */
+    public OffsetDateTime getUpdateTimeOffsetDateTime() {
       return updateTime;
     }
 
@@ -218,8 +241,8 @@ public class HmacKey implements Serializable {
       private String projectId;
       private ServiceAccount serviceAccount;
       private HmacKeyState state;
-      private Long createTime;
-      private Long updateTime;
+      private OffsetDateTime createTime;
+      private OffsetDateTime updateTime;
 
       private Builder(ServiceAccount serviceAccount) {
         this.serviceAccount = serviceAccount;
@@ -261,7 +284,13 @@ public class HmacKey implements Serializable {
         return this;
       }
 
+      /** @deprecated Use {@link #setCreateTimeOffsetDateTime(OffsetDateTime)} */
+      @Deprecated
       public Builder setCreateTime(long createTime) {
+        return setCreateTimeOffsetDateTime(millisOffsetDateTimeCodec.encode(createTime));
+      }
+
+      public Builder setCreateTimeOffsetDateTime(OffsetDateTime createTime) {
         this.createTime = createTime;
         return this;
       }
@@ -276,7 +305,13 @@ public class HmacKey implements Serializable {
         return new HmacKeyMetadata(this);
       }
 
+      /** @deprecated Use {@link #setUpdateTimeOffsetDateTime(OffsetDateTime)} */
+      @Deprecated
       public Builder setUpdateTime(long updateTime) {
+        return setUpdateTimeOffsetDateTime(millisOffsetDateTimeCodec.encode(updateTime));
+      }
+
+      public Builder setUpdateTimeOffsetDateTime(OffsetDateTime updateTime) {
         this.updateTime = updateTime;
         return this;
       }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Utils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Utils.java
@@ -17,7 +17,9 @@
 package com.google.cloud.storage;
 
 import com.google.api.core.InternalApi;
+import com.google.cloud.storage.Conversions.Codec;
 import com.google.common.collect.ImmutableList;
+import java.time.Duration;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.function.Consumer;
@@ -35,6 +37,8 @@ final class Utils {
 
   static final DateTimeFormatter RFC_3339_DATE_TIME_FORMATTER =
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+  static final Codec<Duration, Long> durationMillisCodec =
+      Codec.of(Duration::toMillis, Duration::ofMillis);
 
   private Utils() {}
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/DateTimeCodecPropertyTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/DateTimeCodecPropertyTest.java
@@ -34,7 +34,7 @@ import net.jqwik.time.api.DateTimes;
 
 final class DateTimeCodecPropertyTest {
 
-  private static final Codec<DateTime, OffsetDateTime> codec =
+  private static final Codec<OffsetDateTime, DateTime> codec =
       ApiaryConversions.INSTANCE.dateTimeCodec;
 
   @Example
@@ -55,8 +55,8 @@ final class DateTimeCodecPropertyTest {
   @Property(tries = 10000)
   void codecShouldRoundTrip(@ForAll("rfc3339") String rfc3339String) {
     DateTime actual = new DateTime(rfc3339String);
-    OffsetDateTime odt = codec.encode(actual);
-    DateTime dt = codec.decode(odt);
+    OffsetDateTime odt = codec.decode(actual);
+    DateTime dt = codec.encode(odt);
 
     assertThat(dt.toStringRfc3339()).isEqualTo(rfc3339String);
   }


### PR DESCRIPTION
### What's been added

Fields which map to apiary DateTime RFC 3339 fields will now also have
a preferred java.time.OffsetDateTime getter & setter.

Fields which map to apiary long to represent a duration in epoch millis
will no also have a preferred java.time.Duration getter & setter.

All new methods currently have the name of the corresponding java.time
type appended to the property name.

#### Refactor Long -> java.time.OffsetDateTime
* BlobInfo#createTime
* BlobInfo#customTime
* BlobInfo#deleteTime
* BlobInfo#retentionExpirationTime
* BlobInfo#timeStorageClassUpdated
* BlobInfo#updateTime
* Blob#createTime
* Blob#customTime
* Blob#deleteTime
* Blob#retentionExpirationTime
* Blob#timeStorageClassUpdated
* Blob#updateTime
* BucketInfo.CreatedBeforeDeleteRule
* BucketInfo.DeleteRule
* BucketInfo.IsLiveDeleteRule
* BucketInfo.NumNewerVersionsDeleteRule
* BucketInfo.RawDeleteRule
* BucketInfo#createTime
* BucketInfo#updateTime
* Bucket#createTime
* Bucket#updateTime
* Bucket#retentionEffectiveTime
* HmacKey.HmacKeyMetadata#createTime
* HmacKey.HmacKeyMetadata#updateTime

#### Refactor Long -> java.time.Duration
* BucketInfo#retentionPeriod
* Bucket#retentionPeriod

### Deprecation of existing methods
All existing "Long" based methods have been marked as `@Deprecated`
and had their javadocs updated to point to the new preferred
corresponding java.time method.

When the existing "Long" based methods are removed, the corresponding
java.time method will replace it at which point the java.time suffix
methods will be deprecated for later cleanup.

All existing "Long" based methods take care of performing the necessary
conversion to the respective java.time type and will continue to work
until their removal.

##### Why append the java.time type as a suffix?
1. Getters can't be overloaded, so we already need something to disambiguate
   which type should be returned.
2. For setters: we theoretically could overload since we have different 
   method arguments, however, if a customer is already passing `null` as the
   method argument we've now created an ambiguity as to which method to
   invoke. By suffixing the setters as well, we avoid creating this possible
   ambiguity.

Part 2 of https://github.com/googleapis/java-storage/pull/1388