### PR TITLE
chore: add initial skeleton of Retrying for Grpc

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobReadChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobReadChannel.java
@@ -42,7 +42,7 @@ class BlobReadChannel implements ReadChannel {
   private final HttpStorageOptions serviceOptions;
   private final BlobId blob;
   private final Map<StorageRpc.Option, ?> requestOptions;
-  private final RetryAlgorithmManager retryAlgorithmManager;
+  private final HttpRetryAlgorithmManager retryAlgorithmManager;
   private String lastEtag;
   private long position;
   private boolean isOpen;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Conversions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Conversions.java
@@ -38,6 +38,10 @@ final class Conversions {
   @FunctionalInterface
   interface Decoder<From, To> {
     To decode(From f);
+
+    static <X> Decoder<X, X> identity() {
+      return (x) -> x;
+    }
   }
 
   interface Codec<A, B> extends Encoder<A, B>, Decoder<B, A> {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcRetryAlgorithmManager.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcRetryAlgorithmManager.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import com.google.api.gax.retrying.ResultRetryAlgorithm;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.storage.v2.ComposeObjectRequest;
+import com.google.storage.v2.CreateBucketRequest;
+import com.google.storage.v2.CreateHmacKeyRequest;
+import com.google.storage.v2.CreateNotificationRequest;
+import com.google.storage.v2.DeleteBucketRequest;
+import com.google.storage.v2.DeleteHmacKeyRequest;
+import com.google.storage.v2.DeleteNotificationRequest;
+import com.google.storage.v2.DeleteObjectRequest;
+import com.google.storage.v2.GetBucketRequest;
+import com.google.storage.v2.GetHmacKeyRequest;
+import com.google.storage.v2.GetNotificationRequest;
+import com.google.storage.v2.GetObjectRequest;
+import com.google.storage.v2.GetServiceAccountRequest;
+import com.google.storage.v2.ListBucketsRequest;
+import com.google.storage.v2.ListHmacKeysRequest;
+import com.google.storage.v2.ListNotificationsRequest;
+import com.google.storage.v2.ListObjectsRequest;
+import com.google.storage.v2.LockBucketRetentionPolicyRequest;
+import com.google.storage.v2.QueryWriteStatusRequest;
+import com.google.storage.v2.ReadObjectRequest;
+import com.google.storage.v2.RewriteObjectRequest;
+import com.google.storage.v2.StartResumableWriteRequest;
+import com.google.storage.v2.UpdateBucketRequest;
+import com.google.storage.v2.UpdateHmacKeyRequest;
+import com.google.storage.v2.UpdateObjectRequest;
+import com.google.storage.v2.WriteObjectRequest;
+import java.io.Serializable;
+
+final class GrpcRetryAlgorithmManager implements Serializable {
+
+  private static final long serialVersionUID = -355073454247905645L;
+  private final StorageRetryStrategy retryStrategy;
+
+  GrpcRetryAlgorithmManager(StorageRetryStrategy retryStrategy) {
+    this.retryStrategy = retryStrategy;
+  }
+
+  public ResultRetryAlgorithm<?> getFor(ComposeObjectRequest req) {
+    return req.hasIfGenerationMatch()
+        ? retryStrategy.getIdempotentHandler()
+        : retryStrategy.getNonidempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(CreateBucketRequest req) {
+    return retryStrategy.getIdempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(CreateHmacKeyRequest req) {
+    return retryStrategy.getNonidempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(CreateNotificationRequest req) {
+    return retryStrategy.getNonidempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(DeleteBucketRequest req) {
+    return retryStrategy.getNonidempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(DeleteHmacKeyRequest req) {
+    return retryStrategy.getNonidempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(DeleteNotificationRequest req) {
+    return retryStrategy.getNonidempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(DeleteObjectRequest req) {
+    return retryStrategy.getNonidempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(GetBucketRequest req) {
+    return retryStrategy.getIdempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(GetHmacKeyRequest req) {
+    return retryStrategy.getIdempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(GetIamPolicyRequest req) {
+    return retryStrategy.getIdempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(GetNotificationRequest req) {
+    return retryStrategy.getIdempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(GetObjectRequest req) {
+    return retryStrategy.getIdempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(GetServiceAccountRequest req) {
+    return retryStrategy.getIdempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(ListBucketsRequest req) {
+    return retryStrategy.getIdempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(ListHmacKeysRequest req) {
+    return retryStrategy.getIdempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(ListNotificationsRequest req) {
+    return retryStrategy.getIdempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(ListObjectsRequest req) {
+    return retryStrategy.getIdempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(LockBucketRetentionPolicyRequest req) {
+    return retryStrategy.getIdempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(QueryWriteStatusRequest req) {
+    // unique upload Id, always idempotent
+    return retryStrategy.getIdempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(ReadObjectRequest req) {
+    return retryStrategy.getIdempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(RewriteObjectRequest req) {
+    return req.hasIfGenerationMatch()
+        ? retryStrategy.getIdempotentHandler()
+        : retryStrategy.getNonidempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(SetIamPolicyRequest req) {
+    // TODO: etag
+    return retryStrategy.getNonidempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(StartResumableWriteRequest req) {
+    return req.getWriteObjectSpec().hasIfGenerationMatch()
+        ? retryStrategy.getIdempotentHandler()
+        : retryStrategy.getNonidempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(TestIamPermissionsRequest req) {
+    return retryStrategy.getIdempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(UpdateBucketRequest req) {
+    // TODO: account for acl "patch"
+    // TODO: etag
+    return req.hasIfMetagenerationMatch()
+        ? retryStrategy.getIdempotentHandler()
+        : retryStrategy.getNonidempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(UpdateHmacKeyRequest req) {
+    // TODO: etag
+    return retryStrategy.getNonidempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(UpdateObjectRequest req) {
+    // TODO: account for acl "patch"
+    return req.hasIfMetagenerationMatch()
+        ? retryStrategy.getIdempotentHandler()
+        : retryStrategy.getNonidempotentHandler();
+  }
+
+  public ResultRetryAlgorithm<?> getFor(WriteObjectRequest req) {
+    return req.getWriteObjectSpec().hasIfGenerationMatch()
+        ? retryStrategy.getIdempotentHandler()
+        : retryStrategy.getNonidempotentHandler();
+  }
+}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
@@ -46,12 +46,12 @@ public final class GrpcStorageOptions extends StorageOptions {
   private static final Set<String> SCOPES = ImmutableSet.of(GCS_SCOPE);
   private static final String DEFAULT_HOST = "https://storage.googleapis.com";
 
-  private final RetryAlgorithmManager retryAlgorithmManager;
+  private final GrpcRetryAlgorithmManager retryAlgorithmManager;
 
   public GrpcStorageOptions(Builder builder, StorageDefaults serviceDefaults) {
     super(builder, serviceDefaults);
     this.retryAlgorithmManager =
-        new RetryAlgorithmManager(
+        new GrpcRetryAlgorithmManager(
             MoreObjects.firstNonNull(
                 builder.storageRetryStrategy, defaults().getStorageRetryStrategy()));
   }
@@ -61,8 +61,7 @@ public final class GrpcStorageOptions extends StorageOptions {
     return SCOPES;
   }
 
-  @Override
-  RetryAlgorithmManager getRetryAlgorithmManager() {
+  GrpcRetryAlgorithmManager getRetryAlgorithmManager() {
     return retryAlgorithmManager;
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpRetryAlgorithmManager.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpRetryAlgorithmManager.java
@@ -29,12 +29,12 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
-final class RetryAlgorithmManager implements Serializable {
+final class HttpRetryAlgorithmManager implements Serializable {
 
   private static final long serialVersionUID = -8615379702537758604L;
   private final StorageRetryStrategy retryStrategy;
 
-  RetryAlgorithmManager(StorageRetryStrategy retryStrategy) {
+  HttpRetryAlgorithmManager(StorageRetryStrategy retryStrategy) {
     this.retryStrategy = retryStrategy;
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpStorageOptions.java
@@ -44,12 +44,12 @@ public class HttpStorageOptions extends StorageOptions {
   private static final Set<String> SCOPES = ImmutableSet.of(GCS_SCOPE);
   private static final String DEFAULT_HOST = "https://storage.googleapis.com";
 
-  private final RetryAlgorithmManager retryAlgorithmManager;
+  private final HttpRetryAlgorithmManager retryAlgorithmManager;
 
   private HttpStorageOptions(Builder builder, StorageDefaults serviceDefaults) {
     super(builder, serviceDefaults);
     this.retryAlgorithmManager =
-        new RetryAlgorithmManager(
+        new HttpRetryAlgorithmManager(
             MoreObjects.firstNonNull(
                 builder.storageRetryStrategy, defaults().getStorageRetryStrategy()));
   }
@@ -60,7 +60,7 @@ public class HttpStorageOptions extends StorageOptions {
   }
 
   @Override
-  RetryAlgorithmManager getRetryAlgorithmManager() {
+  HttpRetryAlgorithmManager getRetryAlgorithmManager() {
     return retryAlgorithmManager;
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Retrying.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Retrying.java
@@ -22,6 +22,7 @@ import com.google.api.core.ApiClock;
 import com.google.api.gax.retrying.ResultRetryAlgorithm;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.RetryHelper.RetryHelperException;
+import com.google.cloud.storage.Conversions.Decoder;
 import com.google.cloud.storage.spi.v1.HttpRpcContext;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
@@ -85,10 +86,10 @@ final class Retrying {
       GrpcStorageOptions options,
       ResultRetryAlgorithm<?> algorithm,
       Callable<T> c,
-      Function<T, U> f) {
+      Decoder<T, U> f) {
     try {
       T result = runWithRetries(c, options.getRetrySettings(), algorithm, options.getClock());
-      return result == null ? null : f.apply(result);
+      return result == null ? null : f.decode(result);
     } catch (RetryHelperException e) {
       throw StorageException.coalesce(e);
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
@@ -113,7 +113,7 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
 
   private static final ApiaryConversions codecs = Conversions.apiary();
 
-  private final RetryAlgorithmManager retryAlgorithmManager;
+  private final HttpRetryAlgorithmManager retryAlgorithmManager;
   private final StorageRpc storageRpc;
 
   StorageImpl(HttpStorageOptions options) {
@@ -357,12 +357,12 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
 
     private static final long serialVersionUID = 308012320541700881L;
     private final HttpStorageOptions serviceOptions;
-    private final RetryAlgorithmManager retryAlgorithmManager;
+    private final HttpRetryAlgorithmManager retryAlgorithmManager;
     private final Map<StorageRpc.Option, ?> options;
 
     HmacKeyMetadataPageFetcher(
         HttpStorageOptions serviceOptions,
-        RetryAlgorithmManager retryAlgorithmManager,
+        HttpRetryAlgorithmManager retryAlgorithmManager,
         Map<StorageRpc.Option, ?> options) {
       this.serviceOptions = serviceOptions;
       this.retryAlgorithmManager = retryAlgorithmManager;
@@ -1381,7 +1381,7 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
 
   private static Page<HmacKeyMetadata> listHmacKeys(
       final HttpStorageOptions serviceOptions,
-      final RetryAlgorithmManager retryAlgorithmManager,
+      final HttpRetryAlgorithmManager retryAlgorithmManager,
       final Map<StorageRpc.Option, ?> options) {
     ResultRetryAlgorithm<?> algorithm = retryAlgorithmManager.getForHmacKeyList(options);
     return Retrying.run(

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageOptions.java
@@ -94,8 +94,6 @@ public abstract class StorageOptions extends ServiceOptions<Storage, StorageOpti
   @Override
   public abstract boolean equals(Object obj);
 
-  abstract RetryAlgorithmManager getRetryAlgorithmManager();
-
   /** Returns a default {@code StorageOptions} instance. */
   public static StorageOptions getDefaultInstance() {
     return HttpStorageOptions.newBuilder().build();

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BlobTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BlobTest.java
@@ -165,7 +165,7 @@ public class BlobTest {
   private Blob expectedBlob;
   private Storage serviceMockReturnsOptions = createMock(Storage.class);
   private HttpStorageOptions mockOptions = createMock(HttpStorageOptions.class);
-  private final RetryAlgorithmManager retryAlgorithmManager =
+  private final HttpRetryAlgorithmManager retryAlgorithmManager =
       HttpStorageOptions.getDefaultInstance().getRetryAlgorithmManager();
 
   @Before

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BlobWriteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BlobWriteChannelTest.java
@@ -83,7 +83,7 @@ public class BlobWriteChannelTest {
   private StorageRpcFactory rpcFactoryMock;
   private StorageRpc storageRpcMock;
   private BlobWriteChannel writer;
-  private RetryAlgorithmManager retryAlgorithmManager;
+  private HttpRetryAlgorithmManager retryAlgorithmManager;
 
   @Before
   public void setUp() {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BucketTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BucketTest.java
@@ -136,7 +136,7 @@ public class BucketTest {
   private static final String BASE64_KEY = "JVzfVl8NLD9FjedFuStegjRfES5ll5zc59CIXw572OA=";
   private static final Key KEY =
       new SecretKeySpec(BaseEncoding.base64().decode(BASE64_KEY), "AES256");
-  private final RetryAlgorithmManager retryAlgorithmManager =
+  private final HttpRetryAlgorithmManager retryAlgorithmManager =
       HttpStorageOptions.getDefaultInstance().getRetryAlgorithmManager();
 
   private Storage storage;

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageBatchTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageBatchTest.java
@@ -54,7 +54,7 @@ public class StorageBatchTest {
     BlobTargetOption.generationMatch(), BlobTargetOption.metagenerationMatch()
   };
   private static final GoogleJsonError GOOGLE_JSON_ERROR = new GoogleJsonError();
-  private final RetryAlgorithmManager retryAlgorithmManager =
+  private final HttpRetryAlgorithmManager retryAlgorithmManager =
       HttpStorageOptions.getDefaultInstance().getRetryAlgorithmManager();
 
   private HttpStorageOptions optionsMock;


### PR DESCRIPTION
* rename RetryAlgorithmManager -> HttpRetryAlgorithmManager
* Add GrpcRetryAlgorithmManager
* Update Retrying.run(GrpcStorageOptions, ...) to take a Decoder instead
  of a Function (this helps narrow things a bit to our decoders)
* Add GrpcStorageImpl#SyntaxDecoders
  * For our "Syntax" types - Blob, Bucket, etc - Decoding an instance is
    always of the form message -> info -> syntax. This new class gives
    us a decoder that can use simply for message -> syntax by binding
    to the enclosing storage instance.
  * update "Syntax" return points to use new decoders
