### PR TITLE
fix: update request method of HttpStorageRpc to properly configure offset on requests

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageException.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageException.java
@@ -108,9 +108,11 @@ public final class StorageException extends BaseHttpServiceException {
    * @returns {@code StorageException}
    */
   public static StorageException translate(IOException exception) {
-    if (exception.getMessage().contains("Connection closed prematurely")) {
-      return new StorageException(
-          0, exception.getMessage(), CONNECTION_CLOSED_PREMATURELY, exception);
+    String message = exception.getMessage();
+    if (message != null
+        && (message.contains("Connection closed prematurely")
+            || message.contains("Premature EOF"))) {
+      return new StorageException(0, message, CONNECTION_CLOSED_PREMATURELY, exception);
     } else {
       // default
       return new StorageException(exception);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
@@ -154,7 +154,7 @@ public class ITRetryConformanceTest {
                     .and(
                         (m, trc) ->
                             trc.getScenarioId()
-                                < 7) // Temporarily exclude resumable media scenarios
+                                != 7) // Temporarily exclude resumable upload scenarios
                 )
             .build();
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITDownloadToTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITDownloadToTest.java
@@ -50,10 +50,8 @@ public final class ITDownloadToTest {
     BucketInfo bucketInfo = BucketInfo.of(BUCKET);
     blobId = BlobId.of(BUCKET, "zipped_blob");
 
-    BlobInfo blobInfo = BlobInfo.newBuilder(blobId)
-            .setContentEncoding("gzip")
-            .setContentType("text/plain")
-            .build();
+    BlobInfo blobInfo =
+        BlobInfo.newBuilder(blobId).setContentEncoding("gzip").setContentType("text/plain").build();
 
     storage = StorageOptions.newBuilder().build().getService();
     storage.create(bucketInfo);
@@ -63,7 +61,8 @@ public final class ITDownloadToTest {
   @Test
   public void downloadTo_returnRawInputStream_yes() throws IOException {
     Path helloWorldTxtGz = File.createTempFile("helloWorld", ".txt.gz").toPath();
-    storage.downloadTo(blobId, helloWorldTxtGz, Storage.BlobSourceOption.shouldReturnRawInputStream(true));
+    storage.downloadTo(
+        blobId, helloWorldTxtGz, Storage.BlobSourceOption.shouldReturnRawInputStream(true));
 
     byte[] actualTxtGzBytes = Files.readAllBytes(helloWorldTxtGz);
     if (Arrays.equals(actualTxtGzBytes, helloWorldTextBytes)) {
@@ -75,7 +74,8 @@ public final class ITDownloadToTest {
   @Test
   public void downloadTo_returnRawInputStream_no() throws IOException {
     Path helloWorldTxt = File.createTempFile("helloWorld", ".txt").toPath();
-    storage.downloadTo(blobId, helloWorldTxt, Storage.BlobSourceOption.shouldReturnRawInputStream(false));
+    storage.downloadTo(
+        blobId, helloWorldTxt, Storage.BlobSourceOption.shouldReturnRawInputStream(false));
     byte[] actualTxtBytes = Files.readAllBytes(helloWorldTxt);
     assertThat(actualTxtBytes).isEqualTo(helloWorldTextBytes);
   }
@@ -84,9 +84,9 @@ public final class ITDownloadToTest {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     try (OutputStream out = new GZIPOutputStream(byteArrayOutputStream)) {
       out.write(bytes);
-    } catch (IOException ignore) {}
+    } catch (IOException ignore) {
+    }
 
     return byteArrayOutputStream.toByteArray();
   }
-
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITDownloadToTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITDownloadToTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.it;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.storage.testing.RemoteStorageHelper;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.zip.GZIPOutputStream;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public final class ITDownloadToTest {
+
+  private static final String BUCKET = RemoteStorageHelper.generateBucketName();
+  private static final byte[] helloWorldTextBytes = "hello world".getBytes();
+  private static final byte[] helloWorldGzipBytes = gzipBytes(helloWorldTextBytes);
+
+  private static Storage storage;
+  private static BlobId blobId;
+
+  @BeforeClass
+  public static void beforeClass() {
+    BucketInfo bucketInfo = BucketInfo.of(BUCKET);
+    blobId = BlobId.of(BUCKET, "zipped_blob");
+
+    BlobInfo blobInfo = BlobInfo.newBuilder(blobId)
+            .setContentEncoding("gzip")
+            .setContentType("text/plain")
+            .build();
+
+    storage = StorageOptions.newBuilder().build().getService();
+    storage.create(bucketInfo);
+    storage.create(blobInfo, helloWorldGzipBytes);
+  }
+
+  @Test
+  public void downloadTo_returnRawInputStream_yes() throws IOException {
+    Path helloWorldTxtGz = File.createTempFile("helloWorld", ".txt.gz").toPath();
+    storage.downloadTo(blobId, helloWorldTxtGz, Storage.BlobSourceOption.shouldReturnRawInputStream(true));
+
+    byte[] actualTxtGzBytes = Files.readAllBytes(helloWorldTxtGz);
+    if (Arrays.equals(actualTxtGzBytes, helloWorldTextBytes)) {
+      fail("expected gzipped bytes, but got un-gzipped bytes");
+    }
+    assertThat(actualTxtGzBytes).isEqualTo(helloWorldGzipBytes);
+  }
+
+  @Test
+  public void downloadTo_returnRawInputStream_no() throws IOException {
+    Path helloWorldTxt = File.createTempFile("helloWorld", ".txt").toPath();
+    storage.downloadTo(blobId, helloWorldTxt, Storage.BlobSourceOption.shouldReturnRawInputStream(false));
+    byte[] actualTxtBytes = Files.readAllBytes(helloWorldTxt);
+    assertThat(actualTxtBytes).isEqualTo(helloWorldTextBytes);
+  }
+
+  private static byte[] gzipBytes(byte[] bytes) {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    try (OutputStream out = new GZIPOutputStream(byteArrayOutputStream)) {
+      out.write(bytes);
+    } catch (IOException ignore) {}
+
+    return byteArrayOutputStream.toByteArray();
+  }
+
+}


### PR DESCRIPTION
When invoking downloadTo(..., OutputStream) if a retry was attempted the proper byte
offset was not being sent in the retried request. Update logic of HttpStorageRpc.read
to manually set the range header rather than trying to rely on MediaDownloader to do
it along with not automatically decompressing the byte stream.

Update ITRetryConformanceTest to run Scenario 8 test cases, which cover resuming a
download which could have caught this error sooner.

Update StorageException.translate(IOException) to classify `IOException: Premature EOF`
as the existing retryable reason `connectionClosedPrematurely`. Add case to
DefaultRetryHandlingBehaviorTest to ensure conformance to this categorization.

Break downloadTo integration test out into their own class, and separate
the multiple scenarios being tested in the same method.

Related to https://github.com/googleapis/java-storage/issues/1425