### PR TITLE
feat: support formatted bucket name with projectID

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Bucket.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Bucket.java
@@ -519,6 +519,12 @@ public class Bucket extends BucketInfo {
     }
 
     @Override
+    Builder setProject(String project) {
+      infoBuilder.setProject(project);
+      return this;
+    }
+
+    @Override
     Builder setGeneratedId(String generatedId) {
       infoBuilder.setGeneratedId(generatedId);
       return this;

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/jqwik/BucketArbitraryProvider.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/jqwik/BucketArbitraryProvider.java
@@ -66,8 +66,9 @@ public final class BucketArbitraryProvider implements ArbitraryProvider {
             .as(
                 (t1, t2, t3) ->
                     Bucket.newBuilder()
-                        .setBucketId(t1.get1().get())
-                        .setName(t1.get2().get())
+                        .setBucketId(t1.get1().getBucket())
+                        .setName(t1.get2().toString())
+                        .setProject(t1.get2().getProject())
                         .setStorageClass(t1.get3())
                         .setLocation(t1.get4())
                         .setLocationType(t1.get5())

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/jqwik/ObjectArbitraryProvider.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/jqwik/ObjectArbitraryProvider.java
@@ -72,7 +72,7 @@ public final class ObjectArbitraryProvider implements ArbitraryProvider {
                 (t1, t2, t3) ->
                     Object.newBuilder()
                         .setName(t1.get1())
-                        .setBucket(t1.get2().get())
+                        .setBucket(t1.get2().toString())
                         .setGeneration(t1.get3())
                         .setMetageneration(t1.get4())
                         .setStorageClass(t1.get5())


### PR DESCRIPTION
1. Added Bucket+ProjectID model in BucketInfo and update setters and getters for Bucket name to use this new model.
1. Added setters and getters for projectID in BucketInfo and Bucket (using BucketName helper)
1. Added unformatted bucket name into property based test "bucket" vs. "projects/project-id/buckets/bucket-id"
1. Support default value when presented with unformatted bucket name to  use "_" for project id
1. Added fall for unformatted into log bucket parser in grpc conversions.
1. Tested unformatted bucket name only for log bucket name (do not do it for BucketInfo)
