### PR TITLE
chore(test): reduce console output when running on GitHub

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BaseConvertablePropertyTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BaseConvertablePropertyTest.java
@@ -37,7 +37,9 @@ abstract class BaseConvertablePropertyTest<ModelT, ProtoT extends Message> {
   final void edgeCases() {
     TypeUsage baseTypeUsage = findBaseTypeUsage(this.getClass());
     TypeUsage protoTType = baseTypeUsage.getTypeArgument(1);
-    report(protoTType);
+    if (!CIUtils.isRunningOnGitHubActions() || CIUtils.isJobTypeIntegration()) {
+      report(protoTType);
+    }
   }
 
   /**

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/CIUtils.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/CIUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+public final class CIUtils {
+
+  private CIUtils() {}
+
+  public static boolean isRunningInCI() {
+    return isJobTypeUnit() || isJobTypeIntegration();
+  }
+
+  public static boolean isJobTypeUnit() {
+    return isJobTypeEq("test");
+  }
+
+  public static boolean isJobTypeIntegration() {
+    return isJobTypeEq("integration");
+  }
+
+  public static boolean isRunningOnGitHubActions() {
+    return System.getenv("GITHUB_JOB") != null;
+  }
+
+  private static boolean isJobTypeEq(String integration) {
+    return integration.equals(System.getenv("JOB_TYPE"));
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/GracefulConformanceEnforcement.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/GracefulConformanceEnforcement.java
@@ -18,6 +18,7 @@ package com.google.cloud.storage.conformance.retry;
 
 import static org.junit.Assert.assertNotNull;
 
+import com.google.cloud.storage.CIUtils;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.CharStreams;
 import java.io.IOException;
@@ -64,7 +65,7 @@ final class GracefulConformanceEnforcement implements TestRule {
           if (!testNamesWhichCanFail.contains(testName)) {
             throw t;
           } else {
-            if (isRunningInCI()) {
+            if (CIUtils.isRunningInCI()) {
               throw new AssumptionViolatedException(
                   String.format(
                       "Test %s is allowed to fail, downgrading failure to ignored.", testName),
@@ -76,11 +77,6 @@ final class GracefulConformanceEnforcement implements TestRule {
         }
       }
     };
-  }
-
-  private static boolean isRunningInCI() {
-    return "test".equals(System.getenv("JOB_TYPE"))
-        || "integration".equals(System.getenv("JOB_TYPE"));
   }
 
   private static Set<String> loadTestNamesWhichCanFail() {


### PR DESCRIPTION
GitHub Actions UI can lag quite a bit when there is a fair amount of console output, in an effort to reduce this update BaseConvertablePropertyTest to only report edgeCases when not running on GitHub Actions or if running in integration test mode.

Add CIUtils class to corral CI Environment related util methods.

