### PR TITLE
chore: refactor Buffered Channels such that buffer allocation is now lazy

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BufferHandle.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BufferHandle.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.nio.ByteBuffer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Sometimes, we need a handle to create a buffer but do not want to unnecessarily allocate it. This
+ * class can be though of as an enriched {@code Supplier<ByteBuffer>} that still implements the
+ * common stateful methods of {@link ByteBuffer} without allocating the ByteBuffer until necessary.
+ *
+ * <p>{@link ByteBuffer} is a sealed class hierarchy, meaning we can't simply extend it to provide
+ * laziness without this new class.
+ */
+abstract class BufferHandle implements Supplier<ByteBuffer> {
+
+  @VisibleForTesting
+  BufferHandle() {}
+
+  abstract int remaining();
+
+  abstract int capacity();
+
+  abstract int position();
+
+  static BufferHandle allocateAligned(int alignmentMultiple, int size) {
+    int actualSize = alignSize(alignmentMultiple, size);
+    return allocate(actualSize);
+  }
+
+  static BufferHandle allocate(int capacity) {
+    return new LazyBufferHandle(capacity, ByteBuffer::allocate);
+  }
+
+  static BufferHandle handleOf(ByteBuffer buf) {
+    return new EagerBufferHandle(buf);
+  }
+
+  /**
+   * Give {@code size} "snap" it to the next {@code alignmentMultiple} that is >= {@code size}.
+   *
+   * <p>i.e. Given 344k size, 256k alignmentMultiple expect 512k
+   */
+  private static int alignSize(int alignmentMultiple, int size) {
+    int actualSize = size;
+    if (size < alignmentMultiple) {
+      actualSize = alignmentMultiple;
+    } else if (size % alignmentMultiple != 0) {
+      // TODO: this mod will cause two divisions to happen
+      //   * try and measure how expensive two divisions is compared to one
+      //   * also measure the case where size is a multiple, and how much the
+      //     following calculation costs
+
+      // add almost another full alignmentMultiple to the size
+      // then integer divide it before multiplying it by the alignmentMultiple
+      actualSize = (size + alignmentMultiple - 1) / alignmentMultiple * alignmentMultiple;
+    } // else size is already aligned
+    return actualSize;
+  }
+
+  static final class LazyBufferHandle extends BufferHandle {
+
+    private final int capacity;
+    private final Function<Integer, ByteBuffer> factory;
+
+    private volatile ByteBuffer buf;
+
+    @VisibleForTesting
+    LazyBufferHandle(int capacity, Function<Integer, ByteBuffer> factory) {
+      this.capacity = capacity;
+      this.factory = factory;
+    }
+
+    @Override
+    int remaining() {
+      return buf == null ? capacity() : buf.remaining();
+    }
+
+    @Override
+    int capacity() {
+      return buf == null ? capacity : buf.capacity();
+    }
+
+    @Override
+    int position() {
+      return buf == null ? 0 : buf.position();
+    }
+
+    @Override
+    public ByteBuffer get() {
+      if (buf == null) {
+        synchronized (this) {
+          if (buf == null) {
+            buf = factory.apply(capacity);
+          }
+        }
+      }
+      return buf;
+    }
+  }
+
+  static final class EagerBufferHandle extends BufferHandle {
+    private final ByteBuffer buf;
+
+    private EagerBufferHandle(ByteBuffer buf) {
+      this.buf = buf;
+    }
+
+    @Override
+    int remaining() {
+      return buf.remaining();
+    }
+
+    @Override
+    int capacity() {
+      return buf.capacity();
+    }
+
+    @Override
+    int position() {
+      return buf.position();
+    }
+
+    @Override
+    public ByteBuffer get() {
+      return buf;
+    }
+  }
+}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicDownloadSessionBuilder.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicDownloadSessionBuilder.java
@@ -62,8 +62,14 @@ final class GapicDownloadSessionBuilder {
       return this;
     }
 
+    public BufferedReadableByteChannelSessionBuilder buffered(int capacity) {
+      return new BufferedReadableByteChannelSessionBuilder(
+          BufferHandle.allocate(capacity), getF(read, hasher));
+    }
+
     public BufferedReadableByteChannelSessionBuilder buffered(ByteBuffer buffer) {
-      return new BufferedReadableByteChannelSessionBuilder(buffer, getF(read, hasher));
+      return new BufferedReadableByteChannelSessionBuilder(
+          BufferHandle.handleOf(buffer), getF(read, hasher));
     }
 
     public UnbufferedReadableByteChannelSessionBuilder unbuffered() {
@@ -82,7 +88,7 @@ final class GapicDownloadSessionBuilder {
       private Object obj;
 
       private BufferedReadableByteChannelSessionBuilder(
-          ByteBuffer buffer,
+          BufferHandle buffer,
           BiFunction<Object, SettableApiFuture<Object>, UnbufferedReadableByteChannel> f) {
         this.f = f.andThen(c -> new DefaultBufferedReadableByteChannel(buffer, c));
       }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicResumableUploadSessionBuilder.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicResumableUploadSessionBuilder.java
@@ -72,7 +72,14 @@ final class GapicResumableUploadSessionBuilder {
 
     public BufferedWritableByteChannelSessionBuilder buffered(ByteBuffer buffer) {
       return new BufferedWritableByteChannelSessionBuilder(
-          buffer, getF(write, byteStringStrategy, hasher));
+          BufferHandle.handleOf(buffer), getF(write, byteStringStrategy, hasher));
+    }
+
+    public BufferedWritableByteChannelSessionBuilder bufferedAndAligned(
+        int alignmentMultiple, int capacity) {
+      return new BufferedWritableByteChannelSessionBuilder(
+          BufferHandle.allocateAligned(alignmentMultiple, capacity),
+          getF(write, byteStringStrategy, hasher));
     }
 
     public UnbufferedWritableByteChannelSessionBuilder unbuffered() {
@@ -99,7 +106,7 @@ final class GapicResumableUploadSessionBuilder {
       private ApiFuture<ResumableWrite> uploadIdFuture;
 
       private BufferedWritableByteChannelSessionBuilder(
-          ByteBuffer buffer,
+          BufferHandle buffer,
           BiFunction<
                   ResumableWrite,
                   SettableApiFuture<WriteObjectResponse>,

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BufferHandleTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BufferHandleTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.storage.BufferHandle.LazyBufferHandle;
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Assert;
+import org.junit.Test;
+
+public final class BufferHandleTest {
+
+  @Test
+  public void lazyBufferHandle_methodsBehaveTheSameAsAnEmptyByteBuffer() {
+    int capacity = 10;
+    ByteBuffer baseline = ByteBuffer.allocate(capacity);
+    LazyBufferHandle handle =
+        new LazyBufferHandle(
+            capacity,
+            i -> {
+              Assert.fail("should not be called");
+              return null;
+            });
+
+    assertThat(handle.remaining()).isEqualTo(baseline.remaining());
+    assertThat(handle.position()).isEqualTo(baseline.position());
+    assertThat(handle.capacity()).isEqualTo(baseline.capacity());
+  }
+
+  @Test
+  public void lazyBufferHandle_afterAllocationOnlyBackingIsReferenced() {
+    int capacity = 10;
+    ByteBuffer baseline = ByteBuffer.allocate(capacity);
+    AtomicBoolean alloc = new AtomicBoolean(false);
+    LazyBufferHandle handle =
+        new LazyBufferHandle(
+            capacity,
+            i -> {
+              alloc.compareAndSet(false, true);
+              return ByteBuffer.allocate(capacity);
+            });
+
+    assertThat(handle.remaining()).isEqualTo(baseline.remaining());
+    assertThat(handle.position()).isEqualTo(baseline.position());
+    assertThat(handle.capacity()).isEqualTo(baseline.capacity());
+
+    byte[] bytes = new byte[] {(byte) 'a', (byte) 'b'};
+    handle.get().put(bytes);
+    assertThat(alloc.get()).isTrue();
+    assertThat(handle.remaining()).isEqualTo(8);
+    assertThat(handle.position()).isEqualTo(2);
+    assertThat(handle.capacity()).isEqualTo(capacity);
+  }
+
+  @Test
+  public void lazyBufferHandle_initIsThreadSafe() throws ExecutionException, InterruptedException {
+    int capacity = 10;
+    ExecutorService exec = Executors.newFixedThreadPool(2);
+    AtomicBoolean alloc = new AtomicBoolean(false);
+    LazyBufferHandle handle =
+        new LazyBufferHandle(
+            capacity,
+            i -> {
+              alloc.compareAndSet(false, true);
+              return ByteBuffer.allocate(capacity);
+            });
+
+    Future<ByteBuffer> f1 = exec.submit(handle::get);
+    Future<ByteBuffer> f2 = exec.submit(handle::get);
+
+    assertThat(f1.get()).isSameInstanceAs(f2.get());
+
+    assertThat(handle.get().capacity()).isEqualTo(capacity);
+  }
+
+  @Test
+  public void eagerBufferHandle_methodsBehaveTheSameAsAnEmptyByteBuffer() {
+    int capacity = 10;
+    ByteBuffer baseline = ByteBuffer.allocate(capacity);
+    BufferHandle handle = BufferHandle.handleOf(baseline);
+
+    assertThat(handle.remaining()).isEqualTo(baseline.remaining());
+    assertThat(handle.position()).isEqualTo(baseline.position());
+    assertThat(handle.capacity()).isEqualTo(baseline.capacity());
+
+    byte[] bytes = new byte[] {(byte) 'a', (byte) 'b'};
+    baseline.put(bytes);
+    assertThat(handle.remaining()).isEqualTo(8);
+    assertThat(handle.position()).isEqualTo(2);
+    assertThat(handle.capacity()).isEqualTo(capacity);
+
+    assertThat(handle.get()).isSameInstanceAs(baseline);
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/DefaultBufferedReadableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/DefaultBufferedReadableByteChannelTest.java
@@ -54,7 +54,7 @@ public final class DefaultBufferedReadableByteChannelTest {
     byte[] bytes = DataGenerator.base64Characters().genBytes(61);
 
     ByteBuffer buf = ByteBuffer.allocate(16);
-    ByteBuffer buffer = ByteBuffer.allocate(3);
+    BufferHandle buffer = BufferHandle.allocate(3);
     try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         UnbufferedReadableByteChannelAdapter adapter =
             new UnbufferedReadableByteChannelAdapter(Channels.newChannel(bais));
@@ -83,7 +83,7 @@ public final class DefaultBufferedReadableByteChannelTest {
     byte[] bytes = readOps.bytes;
 
     ByteBuffer buf = ByteBuffer.allocate(readOps.readSize);
-    ByteBuffer buffer = ByteBuffer.allocate(readOps.bufferSize);
+    BufferHandle buffer = BufferHandle.allocate(readOps.bufferSize);
     try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         UnbufferedReadableByteChannelAdapter adapter =
             new UnbufferedReadableByteChannelAdapter(Channels.newChannel(bais));


### PR DESCRIPTION
Eagar allocation of large buffers can cause significant memory pressure for users
who are processing many objects in parallel or processing small objects. Since our
Buffered Channels are present to smooth out rpc sizes which can have high latencies
we do not want to unnecessarily allocate a buffer.

Buffered Read & Write Channel already minimize unnecessary copies into our buffer,
coupled with this change, if a user is reading/writing buffers the same size as the
configured buffer size we will never actually allocate a buffer thereby saving on
unnecessary memory consumption.
