### PR TITLE
chore: refactor GrpcStorageImpl#read* methods to use more specific channels

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicDownloadSessionBuilder.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicDownloadSessionBuilder.java
@@ -76,7 +76,8 @@ final class GapicDownloadSessionBuilder {
       return new UnbufferedReadableByteChannelSessionBuilder(getF(read, hasher));
     }
 
-    private static BiFunction<Object, SettableApiFuture<Object>, UnbufferedReadableByteChannel>
+    private static BiFunction<
+            ReadObjectRequest, SettableApiFuture<Object>, UnbufferedReadableByteChannel>
         getF(ServerStreamingCallable<ReadObjectRequest, ReadObjectResponse> read, Hasher hasher) {
       return (object, resultFuture) ->
           new GapicUnbufferedReadableByteChannel(resultFuture, read, object, hasher);
@@ -84,46 +85,52 @@ final class GapicDownloadSessionBuilder {
 
     public static final class BufferedReadableByteChannelSessionBuilder {
 
-      private BiFunction<Object, SettableApiFuture<Object>, BufferedReadableByteChannel> f;
-      private Object obj;
+      private BiFunction<ReadObjectRequest, SettableApiFuture<Object>, BufferedReadableByteChannel>
+          f;
+      private ReadObjectRequest request;
 
       private BufferedReadableByteChannelSessionBuilder(
           BufferHandle buffer,
-          BiFunction<Object, SettableApiFuture<Object>, UnbufferedReadableByteChannel> f) {
+          BiFunction<ReadObjectRequest, SettableApiFuture<Object>, UnbufferedReadableByteChannel>
+              f) {
         this.f = f.andThen(c -> new DefaultBufferedReadableByteChannel(buffer, c));
       }
 
-      public BufferedReadableByteChannelSessionBuilder setObject(Object obj) {
-        this.obj = requireNonNull(obj, "obj must be non null");
+      public BufferedReadableByteChannelSessionBuilder setReadObjectRequest(
+          ReadObjectRequest request) {
+        this.request = requireNonNull(request, "request must be non null");
         return this;
       }
 
       public BufferedReadableByteChannelSession<Object> build() {
         return new ChannelSession.BufferedReadSession<>(
-            ApiFutures.immediateFuture(obj),
+            ApiFutures.immediateFuture(request),
             f.andThen(StorageByteChannels.readable()::createSynchronized));
       }
     }
 
     public static final class UnbufferedReadableByteChannelSessionBuilder {
 
-      // TODO: object -> ReadObjectRequest
-      private BiFunction<Object, SettableApiFuture<Object>, UnbufferedReadableByteChannel> f;
-      private Object obj;
+      private BiFunction<
+              ReadObjectRequest, SettableApiFuture<Object>, UnbufferedReadableByteChannel>
+          f;
+      private ReadObjectRequest request;
 
       private UnbufferedReadableByteChannelSessionBuilder(
-          BiFunction<Object, SettableApiFuture<Object>, UnbufferedReadableByteChannel> f) {
+          BiFunction<ReadObjectRequest, SettableApiFuture<Object>, UnbufferedReadableByteChannel>
+              f) {
         this.f = f;
       }
 
-      public UnbufferedReadableByteChannelSessionBuilder setObject(Object obj) {
-        this.obj = requireNonNull(obj, "obj must be non null");
+      public UnbufferedReadableByteChannelSessionBuilder setReadObjectRequest(
+          ReadObjectRequest request) {
+        this.request = requireNonNull(request, "request must be non null");
         return this;
       }
 
       public UnbufferedReadableByteChannelSession<Object> build() {
         return new ChannelSession.UnbufferedReadSession<>(
-            ApiFutures.immediateFuture(obj),
+            ApiFutures.immediateFuture(request),
             f.andThen(StorageByteChannels.readable()::createSynchronized));
       }
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Hasher.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Hasher.java
@@ -31,7 +31,7 @@ interface Hasher {
 
   Crc32cLengthKnown hash(ByteBuffer b);
 
-  void validate(Crc32cValue<?> expected, ByteBuffer b) throws IOException;
+  void validate(Crc32cValue<?> expected, Supplier<ByteBuffer> b) throws IOException;
 
   static Hasher noop() {
     return NoOpHasher.INSTANCE;
@@ -53,7 +53,7 @@ interface Hasher {
     }
 
     @Override
-    public void validate(Crc32cValue<?> expected, ByteBuffer b) {}
+    public void validate(Crc32cValue<?> expected, Supplier<ByteBuffer> b) {}
   }
 
   @Immutable
@@ -69,11 +69,11 @@ interface Hasher {
     }
 
     @Override
-    public void validate(Crc32cValue<?> expected, ByteBuffer b) throws IOException {
+    public void validate(Crc32cValue<?> expected, Supplier<ByteBuffer> b) throws IOException {
       Crc32cLengthKnown actual = hash(b);
       if (actual.getValue() != expected.getValue()) {
         throw new IOException(
-            String.format("Miss-match checksum value. expected %s actual %s", expected, actual));
+            String.format("Mismatch checksum value. Expected %s actual %s", expected, actual));
       }
     }
   }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageV2ProtoUtils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageV2ProtoUtils.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageOrBuilder;
+import com.google.storage.v2.ReadObjectRequest;
+import java.util.regex.Pattern;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+final class StorageV2ProtoUtils {
+
+  private static final String VALIDATION_TEMPLATE = "0 <= offset <= limit (0 <= %s <= %s)";
+
+  private static final Pattern PROTO_TO_STRING_NEW_LINES = Pattern.compile(" *\\n *");
+
+  private StorageV2ProtoUtils() {}
+
+  @NonNull
+  static ReadObjectRequest seekReadObjectRequest(
+      @NonNull ReadObjectRequest request, @Nullable Long offset, @Nullable Long limit) {
+    validate(offset, limit);
+    ReadObjectRequest req = request;
+
+    boolean setOffset = offset != null && (offset > 0 || offset != req.getReadOffset());
+    boolean setLimit = limit != null && (limit < Long.MAX_VALUE || limit != req.getReadLimit());
+    if (setOffset || setLimit) {
+      ReadObjectRequest.Builder b = req.toBuilder();
+      if (setOffset) {
+        b.setReadOffset(offset);
+      }
+      if (setLimit) {
+        b.setReadLimit(limit);
+      }
+      req = b.build();
+    }
+    return req;
+  }
+
+  private static void validate(@Nullable Long offset, @Nullable Long limit) {
+    boolean offsetNull = offset == null;
+    boolean limitNull = limit == null;
+
+    if (offsetNull && limitNull) {
+      return;
+    }
+
+    if (!offsetNull) {
+      checkArgument(0 <= offset, VALIDATION_TEMPLATE, offset, limit);
+    }
+
+    if (!limitNull) {
+      checkArgument(0 <= limit, VALIDATION_TEMPLATE, offset, limit);
+    }
+
+    if (!offsetNull && !limitNull) {
+      checkArgument(offset <= limit, VALIDATION_TEMPLATE, offset, limit);
+    }
+  }
+
+  @NonNull
+  static String fmtProto(@NonNull final MessageOrBuilder msg) {
+    final Message message = resolve(msg);
+    return "{ "
+        + PROTO_TO_STRING_NEW_LINES.matcher(message.toString()).replaceAll(" ").trim()
+        + " }";
+  }
+
+  static Message resolve(@NonNull MessageOrBuilder msg) {
+    final Message message;
+    if (msg instanceof Message) {
+      message = (Message) msg;
+    } else {
+      message = ((Message.Builder) msg).build();
+    }
+    return message;
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageV2ProtoUtilsTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageV2ProtoUtilsTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.cloud.storage.StorageV2ProtoUtils.fmtProto;
+import static com.google.cloud.storage.StorageV2ProtoUtils.seekReadObjectRequest;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.storage.jqwik.StorageArbitraries;
+import com.google.storage.v2.ReadObjectRequest;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.Example;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+public final class StorageV2ProtoUtilsTest {
+
+  @Example
+  void validation_nullOffset_effectiveMin() {
+    seekReadObjectRequest(ReadObjectRequest.getDefaultInstance(), null, 0L);
+    seekReadObjectRequest(ReadObjectRequest.getDefaultInstance(), null, null);
+  }
+
+  @Example
+  void validation_nullLimit_effectiveMax() {
+    seekReadObjectRequest(ReadObjectRequest.getDefaultInstance(), 0L, null);
+    seekReadObjectRequest(ReadObjectRequest.getDefaultInstance(), null, null);
+  }
+
+  @Example
+  void validation_offset_lteq_limit() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> seekReadObjectRequest(ReadObjectRequest.getDefaultInstance(), 3L, 2L));
+    seekReadObjectRequest(ReadObjectRequest.getDefaultInstance(), 0L, 0L);
+    seekReadObjectRequest(ReadObjectRequest.getDefaultInstance(), 1L, 1L);
+  }
+
+  @Example
+  void validation_offset_gteq_0() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> seekReadObjectRequest(ReadObjectRequest.getDefaultInstance(), -1L, null));
+  }
+
+  @Example
+  void validation_limit_gteq_0() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> seekReadObjectRequest(ReadObjectRequest.getDefaultInstance(), null, -1L));
+  }
+
+  @Property(tries = 100_000)
+  void seek(@ForAll("seekCases") SeekCase srr) {
+    Long offset = srr.offset;
+    Long limit = srr.limit;
+
+    // I miss pattern matching...
+    if (offset == null && limit == null) {
+      ReadObjectRequest seek = seekReadObjectRequest(srr.req, offset, limit);
+      assertThat(seek).isSameInstanceAs(srr.req);
+    } else if (offset != null && limit == null) {
+      ReadObjectRequest seek = seekReadObjectRequest(srr.req, offset, limit);
+      assertThat(seek.getReadOffset()).isEqualTo(offset);
+    } else if (offset == null && limit != null) {
+      ReadObjectRequest seek = seekReadObjectRequest(srr.req, offset, limit);
+      assertThat(seek.getReadLimit()).isEqualTo(limit);
+    } else if (offset <= limit) {
+      ReadObjectRequest seek = seekReadObjectRequest(srr.req, offset, limit);
+      assertThat(seek.getReadOffset()).isEqualTo(offset);
+      assertThat(seek.getReadLimit()).isEqualTo(limit);
+    } else {
+      assertThrows(
+          IllegalArgumentException.class, () -> seekReadObjectRequest(srr.req, offset, limit));
+    }
+  }
+
+  @Provide("seekCases")
+  Arbitrary<SeekCase> arbitrarySeekCase() {
+    return Combinators.combine(
+            StorageArbitraries.objects().name(),
+            Arbitraries.longs().greaterOrEqual(0).injectNull(0.6),
+            Arbitraries.longs().greaterOrEqual(0).injectNull(0.6),
+            Arbitraries.longs().greaterOrEqual(0).injectNull(0.3),
+            Arbitraries.longs().greaterOrEqual(0).injectNull(0.3))
+        .as(SeekCase::of);
+  }
+
+  private static final class SeekCase {
+    private final ReadObjectRequest req;
+    private final Long offset;
+    private final Long limit;
+
+    public SeekCase(ReadObjectRequest req, Long offset, Long limit) {
+      this.req = req;
+      this.offset = offset;
+      this.limit = limit;
+    }
+
+    @Override
+    public String toString() {
+      return "SeekReadRequest{"
+          + "req="
+          + fmtProto(req)
+          + ", offset="
+          + offset
+          + ", limit="
+          + limit
+          + '}';
+    }
+
+    private static SeekCase of(
+        String name, Long embedOffset, Long embedLimit, Long offset, Long limit) {
+      ReadObjectRequest.Builder b = ReadObjectRequest.newBuilder().setObject(name);
+      if (embedOffset != null) {
+        b.setReadOffset(embedOffset);
+      }
+      if (embedLimit != null) {
+        b.setReadLimit(embedLimit);
+      }
+      return new SeekCase(b.build(), offset, limit);
+    }
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/jqwik/BucketArbitraryProvider.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/jqwik/BucketArbitraryProvider.java
@@ -37,8 +37,8 @@ public final class BucketArbitraryProvider implements ArbitraryProvider {
     Arbitrary<Bucket> as =
         Combinators.combine(
                 Combinators.combine(
-                        StorageArbitraries.bucketName(),
-                        StorageArbitraries.bucketName(),
+                        StorageArbitraries.buckets().name(),
+                        StorageArbitraries.buckets().name(),
                         StorageArbitraries.buckets().storageClass(),
                         StorageArbitraries.buckets().location(),
                         StorageArbitraries.buckets().locationType(),

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/jqwik/ObjectArbitraryProvider.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/jqwik/ObjectArbitraryProvider.java
@@ -35,13 +35,12 @@ public final class ObjectArbitraryProvider implements ArbitraryProvider {
 
   @Override
   public Set<Arbitrary<?>> provideFor(TypeUsage targetType, SubtypeProvider subtypeProvider) {
-    Arbitrary<String> objectName = StorageArbitraries.randomString();
     Arbitrary<Integer> size = Arbitraries.integers().greaterOrEqual(0);
     Arbitrary<Object> objectArbitrary =
         Combinators.combine(
                 Combinators.combine(
-                        objectName,
-                        StorageArbitraries.bucketName(),
+                        StorageArbitraries.objects().name(),
+                        StorageArbitraries.buckets().name(),
                         StorageArbitraries.generation(),
                         StorageArbitraries.metageneration(),
                         StorageArbitraries.objects().storageClass(),


### PR DESCRIPTION
Update readAllBytes and downloadTo methods to use unbuffered read channel, instead of reader

Update *ReadableByteChannelSessions to take a ReadObjectRequest instead of Object

Update Hasher#validate to be lazy with regard to the ByteBuffer, this ensures no new byte buffer is created if it isn't needed in the case of noop.

Add StorageArbitraries.Objects#name()
Move StorageArbitraries.bucketName() -> StorageArbitraries.Buckets#name()
Add StorageArbitraries.alnum() and cleanup usages in Buckets.name()
