### PR TITLE
docs(sample): upgrade maven-surefire and remove junit-platform-native

### DIFF
--- a/samples/native-image-sample/pom.xml
+++ b/samples/native-image-sample/pom.xml
@@ -117,21 +117,14 @@
           <version>5.8.2</version>
           <scope>test</scope>
         </dependency>
-        <dependency>
-          <groupId>org.graalvm.buildtools</groupId>
-          <artifactId>junit-platform-native</artifactId>
-          <version>0.9.12</version>
-          <scope>test</scope>
-        </dependency>
       </dependencies>
 
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin
-            </artifactId> <!-- Must use older version of surefire plugin for native-image testing. -->
-            <version>2.22.2</version>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.0.0-M7</version>
             <configuration>
               <includes>
                 <include>**/*IT</include>


### PR DESCRIPTION
As described in the official doc, the [junit-native-plugin can be safely removed](https://graalvm.github.io/native-build-tools/latest/index.html#_release_0_9_6) if we are using versions 0.9.6 and later of the ` native-maven-plugin `

maven-surefire-plugin 2.22.2 seemed to have required `junit-platform-native` and removing this dependency resulted in 
```
R] Test configuration file wasn't found. Make sure that test execution wasn't skipped.
```
However, upgrading the surefire plugins and removing `junit-platform-native` results in a successful build. 

To run tests in native image mode, call the following command: `mvn test -Pnative`