### PR TITLE
test: update testbench to support grpc endpoint

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
@@ -229,11 +229,8 @@ final class GrpcConversions {
     Bucket.Builder to = Bucket.newBuilder();
     to.setProject(from.getProject());
     to.setName(BucketName.format(from.getProject(), from.getName()));
-    if (from.getGeneratedId() != null) {
-      to.setBucketId(from.getGeneratedId());
-    } else {
-      to.setBucketId(from.getName());
-    }
+    // TODO: We need to clean up bucketId handling
+    ifNonNull(from.getGeneratedId(), to::setBucketId);
     if (from.getRetentionPeriodDuration() != null) {
       Bucket.RetentionPolicy.Builder retentionPolicyBuilder = to.getRetentionPolicyBuilder();
       ifNonNull(

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
@@ -229,7 +229,11 @@ final class GrpcConversions {
     Bucket.Builder to = Bucket.newBuilder();
     to.setProject(from.getProject());
     to.setName(BucketName.format(from.getProject(), from.getName()));
-    to.setBucketId(from.getGeneratedId());
+    if (from.getGeneratedId() != null) {
+      to.setBucketId(from.getGeneratedId());
+    } else {
+      to.setBucketId(from.getName());
+    }
     if (from.getRetentionPeriodDuration() != null) {
       Bucket.RetentionPolicy.Builder retentionPolicyBuilder = to.getRetentionPolicyBuilder();
       ifNonNull(

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -141,9 +141,9 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
   public Bucket create(BucketInfo bucketInfo, BucketTargetOption... options) {
     final Map<StorageRpc.Option, ?> optionsMap = StorageImpl.optionMap(options);
     GrpcCallContext grpcCallContext = GrpcRequestMetadataSupport.create(optionsMap);
-    CreateBucketRequest.Builder builder =
-        CreateBucketRequest.newBuilder().setBucket(codecs.bucketInfo().encode(bucketInfo));
-    builder.setBucketId(builder.getBucket().getBucketId());
+    com.google.storage.v2.Bucket bucket = codecs.bucketInfo().encode(bucketInfo);
+    CreateBucketRequest.Builder builder = CreateBucketRequest.newBuilder().setBucket(bucket);
+    builder.setBucketId(bucket.getBucketId());
     builder.setParent(ProjectName.format(getOptions().getProjectId()));
     ZOpt.applyAll(
         optionsMap,

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -143,7 +143,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
     GrpcCallContext grpcCallContext = GrpcRequestMetadataSupport.create(optionsMap);
     com.google.storage.v2.Bucket bucket = codecs.bucketInfo().encode(bucketInfo);
     CreateBucketRequest.Builder builder = CreateBucketRequest.newBuilder().setBucket(bucket);
-    builder.setBucketId(bucket.getBucketId());
+    builder.setBucketId(bucketInfo.getName());
     builder.setParent(ProjectName.format(getOptions().getProjectId()));
     ZOpt.applyAll(
         optionsMap,

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -66,6 +66,7 @@ import com.google.storage.v2.ListBucketsRequest;
 import com.google.storage.v2.ListHmacKeysRequest;
 import com.google.storage.v2.ListObjectsRequest;
 import com.google.storage.v2.Object;
+import com.google.storage.v2.ProjectName;
 import com.google.storage.v2.ReadObjectRequest;
 import com.google.storage.v2.StorageClient.ListBucketsPage;
 import com.google.storage.v2.StorageClient.ListBucketsPagedResponse;
@@ -142,6 +143,8 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
     GrpcCallContext grpcCallContext = GrpcRequestMetadataSupport.create(optionsMap);
     CreateBucketRequest.Builder builder =
         CreateBucketRequest.newBuilder().setBucket(codecs.bucketInfo().encode(bucketInfo));
+    builder.setBucketId(builder.getBucket().getBucketId());
+    builder.setParent(ProjectName.format(getOptions().getProjectId()));
     ZOpt.applyAll(
         optionsMap,
         ZOpt.PREDEFINED_ACL.consumeVia(builder::setPredefinedAcl),
@@ -377,7 +380,8 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
     GrpcCallContext grpcCallContext = GrpcRequestMetadataSupport.create(optionsMap);
     String projectId =
         firstNonNull(ZOpt.PROJECT_ID.get(optionsMap), this.getOptions().getProjectId());
-    ListBucketsRequest.Builder builder = ListBucketsRequest.newBuilder().setParent(projectId);
+    ListBucketsRequest.Builder builder =
+        ListBucketsRequest.newBuilder().setParent(ProjectName.format(projectId));
     ZOpt.applyAll(
         optionsMap,
         ZOpt.MAX_RESULTS.mapThenConsumeVia(Long::intValue, builder::setPageSize),

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestBench.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestBench.java
@@ -261,7 +261,10 @@ public final class TestBench implements TestRule {
           success = true;
         } catch (RetryHelperException e) {
           dumpServerLogs(outFile, errFile);
-          throw new IllegalStateException(e.getMessage(), e.getCause());
+          throw new IllegalStateException(
+                  "Failed to connect to server within a reasonable amount of time. Host url: "
+                          + baseUri,
+                  e.getCause());
         } finally {
           process.destroy();
           // wait for the server to shutdown
@@ -359,7 +362,7 @@ public final class TestBench implements TestRule {
   }
 
   public static final class Builder {
-    private static final String DEFAULT_BASE_URI = "http://localhost:9008";
+    private static final String DEFAULT_BASE_URI = "http://localhost:9000";
     private static final String DEFAULT_GRPC_BASE_URI = "http://localhost:9005";
     private static final String DEFAULT_IMAGE_NAME =
         "gcr.io/cloud-devrel-public-resources/storage-testbench";

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestBench.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestBench.java
@@ -363,7 +363,7 @@ public final class TestBench implements TestRule {
     private static final String DEFAULT_GRPC_BASE_URI = "http://localhost:9005";
     private static final String DEFAULT_IMAGE_NAME =
         "gcr.io/cloud-devrel-public-resources/storage-testbench";
-    private static final String DEFAULT_IMAGE_TAG = "v0.26.0";
+    private static final String DEFAULT_IMAGE_TAG = "v0.15.0";
     private static final String DEFAULT_CONTAINER_NAME = "default";
 
     private boolean ignorePullError;

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestBench.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestBench.java
@@ -262,9 +262,9 @@ public final class TestBench implements TestRule {
         } catch (RetryHelperException e) {
           dumpServerLogs(outFile, errFile);
           throw new IllegalStateException(
-                  "Failed to connect to server within a reasonable amount of time. Host url: "
-                          + baseUri,
-                  e.getCause());
+              "Failed to connect to server within a reasonable amount of time. Host url: "
+                  + baseUri,
+              e.getCause());
         } finally {
           process.destroy();
           // wait for the server to shutdown

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestBench.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestBench.java
@@ -179,8 +179,7 @@ public final class TestBench implements TestRule {
         File errFile = errPath.toFile();
         LOGGER.info("Redirecting server stdout to: " + outFile.getAbsolutePath());
         LOGGER.info("Redirecting server stderr to: " + errFile.getAbsolutePath());
-        String dockerImage =
-            dockerImageName; // String.format("%s:%s", dockerImageName, dockerImageTag);
+        String dockerImage = String.format("%s:%s", dockerImageName, dockerImageTag);
         // First try and pull the docker image, this validates docker is available and running
         // on the host, as well as gives time for the image to be downloaded independently of
         // trying to start the container. (Below, when we first start the container we then attempt
@@ -364,7 +363,7 @@ public final class TestBench implements TestRule {
     private static final String DEFAULT_GRPC_BASE_URI = "http://localhost:9005";
     private static final String DEFAULT_IMAGE_NAME =
         "gcr.io/cloud-devrel-public-resources/storage-testbench";
-    private static final String DEFAULT_IMAGE_TAG = "v0.15.0";
+    private static final String DEFAULT_IMAGE_TAG = "v0.26.0";
     private static final String DEFAULT_CONTAINER_NAME = "default";
 
     private boolean ignorePullError;

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
@@ -36,7 +36,9 @@ import org.junit.Test;
 public final class ITGrpcTest {
   private static final Logger LOGGER = Logger.getLogger(ITGrpcTest.class.getName());
 
-  @ClassRule public static final TestBench TEST_BENCH = TestBench.newBuilder().build();
+  @ClassRule
+  public static final TestBench TEST_BENCH =
+      TestBench.newBuilder().setContainerName("it-grpc").build();
 
   @Rule
   public final StorageFixture storageFixture =

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
@@ -27,8 +27,6 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.conformance.retry.TestBench;
 import com.google.cloud.storage.testing.RemoteStorageHelper;
 import java.util.logging.Logger;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -51,20 +49,6 @@ public final class ITGrpcTest {
                   .build());
 
   private Storage storage;
-
-  @Before
-  public void setUp() throws Exception {
-    LOGGER.fine("Running setup...");
-    // ...set up additional stuff.
-    LOGGER.fine("Running setup complete");
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    LOGGER.fine("Running teardown...");
-    // ...tear down stuff.
-    LOGGER.fine("Running teardown complete");
-  }
 
   @Test
   public void testCreateBucket() {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
@@ -53,21 +53,21 @@ public final class ITGrpcTest {
   @Before
   public void setUp() throws Exception {
     LOGGER.fine("Running setup...");
-    storage = storageFixture.getInstance();
+    // ...set up additional stuff.
     LOGGER.fine("Running setup complete");
   }
 
   @After
   public void tearDown() throws Exception {
     LOGGER.fine("Running teardown...");
-    storage.close();
+    // ...tear down stuff.
     LOGGER.fine("Running teardown complete");
   }
 
   @Test
   public void testCreateBucket() {
     final String bucketName = RemoteStorageHelper.generateBucketName();
-    Bucket bucket = storage.create(BucketInfo.of(bucketName));
+    Bucket bucket = storageFixture.getInstance().create(BucketInfo.of(bucketName));
     assertThat(bucket.getName()).isEqualTo(bucketName);
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
@@ -21,19 +21,15 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
-import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageFixture;
 import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.conformance.retry.TestBench;
 import com.google.cloud.storage.testing.RemoteStorageHelper;
-import java.util.logging.Logger;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
 public final class ITGrpcTest {
-  private static final Logger LOGGER = Logger.getLogger(ITGrpcTest.class.getName());
-
   @ClassRule
   public static final TestBench TEST_BENCH =
       TestBench.newBuilder().setContainerName("it-grpc").build();
@@ -47,8 +43,6 @@ public final class ITGrpcTest {
                   .setCredentials(NoCredentials.getInstance())
                   .setProjectId("test-project-id")
                   .build());
-
-  private Storage storage;
 
   @Test
   public void testCreateBucket() {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.it;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.NoCredentials;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageFixture;
+import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.storage.conformance.retry.TestBench;
+import com.google.cloud.storage.testing.RemoteStorageHelper;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class ITGrpcTest {
+  private static final Logger LOGGER = Logger.getLogger(ITGrpcTest.class.getName());
+
+  @ClassRule public static final TestBench TEST_BENCH = TestBench.newBuilder().build();
+
+  @Rule
+  public final StorageFixture storageFixture =
+      StorageFixture.from(
+          () ->
+              StorageOptions.grpc()
+                  .setHost(TEST_BENCH.getGRPCBaseUri())
+                  .setCredentials(NoCredentials.getInstance())
+                  .setProjectId("test-project-id")
+                  .build());
+
+  private Storage storage;
+
+  @Before
+  public void setUp() throws Exception {
+    LOGGER.fine("Running setup...");
+    storage = storageFixture.getInstance();
+    LOGGER.fine("Running setup complete");
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    LOGGER.fine("Running teardown...");
+    storage.close();
+    LOGGER.fine("Running teardown complete");
+  }
+
+  @Test
+  public void testCreateBucket() {
+    final String bucketName = RemoteStorageHelper.generateBucketName();
+    Bucket bucket = storage.create(BucketInfo.of(bucketName));
+    assertThat(bucket.getName()).isEqualTo(bucketName);
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 public final class ITGrpcTest {
   @ClassRule
   public static final TestBench TEST_BENCH =
-      TestBench.newBuilder().setContainerName("it-grpc").build();
+      TestBench.newBuilder().setContainerName("it-grpc").setDockerImageTag("v0.26.0").build();
 
   @Rule
   public final StorageFixture storageFixture =


### PR DESCRIPTION
Support grpc api testing with testbench

blocked until https://github.com/googleapis/storage-testbench/pull/376 is released.