### PR TITLE
test: add BucketFixture

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BucketFixture.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BucketFixture.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.cloud.storage.conformance.retry.CleanupStrategy;
+import com.google.cloud.storage.testing.RemoteStorageHelper;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public final class BucketFixture implements TestRule {
+
+  private static final Logger LOGGER = Logger.getLogger(BucketFixture.class.getName());
+
+  private final Supplier<Storage> storageHandle;
+  private final String bucketNameFmtString;
+  private final CleanupStrategy cleanupStrategy;
+
+  private BucketInfo bucketInfo;
+
+  private BucketFixture(
+      Supplier<Storage> storageHandle,
+      String bucketNameFmtString,
+      CleanupStrategy cleanupStrategy) {
+    this.storageHandle = storageHandle;
+    this.bucketNameFmtString = bucketNameFmtString;
+    this.cleanupStrategy = cleanupStrategy;
+  }
+
+  public BucketInfo getBucketInfo() {
+    return bucketInfo;
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        String bucketName = String.format(bucketNameFmtString, UUID.randomUUID());
+        Storage s = storageHandle.get();
+        Bucket bucket = s.create(BucketInfo.of(bucketName));
+        bucketInfo = bucket;
+        boolean success = false;
+        try {
+          base.evaluate();
+          success = true;
+        } finally {
+          bucketInfo = null;
+          if (bucket != null) {
+            String name = bucket.getName();
+            switch (cleanupStrategy) {
+              case ALWAYS:
+                doCleanup(name, s);
+                break;
+              case ONLY_ON_SUCCESS:
+                if (success) {
+                  doCleanup(name, s);
+                }
+                break;
+              case NEVER:
+                break;
+            }
+          }
+        }
+      }
+    };
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  private void doCleanup(String bucketName, Storage s) {
+    LOGGER.info("Starting bucket cleanup...");
+    try {
+      RemoteStorageHelper.forceDelete(s, bucketName, 5, TimeUnit.MINUTES);
+      LOGGER.info("Bucket cleanup complete");
+    } catch (Exception e) {
+      LOGGER.log(Level.SEVERE, e, () -> "Error during bucket cleanup.");
+    }
+  }
+
+  public static final class Builder {
+    private Supplier<Storage> handle;
+    private String bucketNameFmtString = "gcloud-test-bucket-temp-%s";
+    private CleanupStrategy cleanupStrategy = CleanupStrategy.ALWAYS;
+
+    public Builder setHandle(Supplier<Storage> handle) {
+      this.handle = requireNonNull(handle, "handle must be non null");
+      return this;
+    }
+
+    public Builder setBucketNameFmtString(String bucketNameFmtString) {
+      this.bucketNameFmtString =
+          requireNonNull(bucketNameFmtString, "bucketNameFmtString must be non null");
+      return this;
+    }
+
+    public Builder setCleanupStrategy(CleanupStrategy cleanupStrategy) {
+      this.cleanupStrategy = requireNonNull(cleanupStrategy, "cleanupStrategy must be non null");
+      return this;
+    }
+
+    public BucketFixture build() {
+      return new BucketFixture(
+          requireNonNull(handle, "handle must be non null"), bucketNameFmtString, cleanupStrategy);
+    }
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITDownloadToTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITDownloadToTest.java
@@ -48,6 +48,7 @@ public final class ITDownloadToTest {
   private static final byte[] helloWorldTextBytes = "hello world".getBytes();
   private static final byte[] helloWorldGzipBytes = gzipBytes(helloWorldTextBytes);
 
+  private static Storage storage;
   private static BlobId blobId;
 
   @BeforeClass
@@ -56,17 +57,15 @@ public final class ITDownloadToTest {
 
     BlobInfo blobInfo =
         BlobInfo.newBuilder(blobId).setContentEncoding("gzip").setContentType("text/plain").build();
-
-    storageFixture.getInstance().create(blobInfo, helloWorldGzipBytes);
+    storage = storageFixture.getInstance();
+    storage.create(blobInfo, helloWorldGzipBytes);
   }
 
   @Test
   public void downloadTo_returnRawInputStream_yes() throws IOException {
     Path helloWorldTxtGz = File.createTempFile("helloWorld", ".txt.gz").toPath();
-    storageFixture
-        .getInstance()
-        .downloadTo(
-            blobId, helloWorldTxtGz, Storage.BlobSourceOption.shouldReturnRawInputStream(true));
+    storage.downloadTo(
+        blobId, helloWorldTxtGz, Storage.BlobSourceOption.shouldReturnRawInputStream(true));
 
     byte[] actualTxtGzBytes = Files.readAllBytes(helloWorldTxtGz);
     if (Arrays.equals(actualTxtGzBytes, helloWorldTextBytes)) {
@@ -78,10 +77,8 @@ public final class ITDownloadToTest {
   @Test
   public void downloadTo_returnRawInputStream_no() throws IOException {
     Path helloWorldTxt = File.createTempFile("helloWorld", ".txt").toPath();
-    storageFixture
-        .getInstance()
-        .downloadTo(
-            blobId, helloWorldTxt, Storage.BlobSourceOption.shouldReturnRawInputStream(false));
+    storage.downloadTo(
+        blobId, helloWorldTxt, Storage.BlobSourceOption.shouldReturnRawInputStream(false));
     byte[] actualTxtBytes = Files.readAllBytes(helloWorldTxt);
     assertThat(actualTxtBytes).isEqualTo(helloWorldTextBytes);
   }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
@@ -18,24 +18,29 @@ package com.google.cloud.storage.it;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.api.gax.paging.Page;
 import com.google.cloud.NoCredentials;
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketFixture;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.StorageFixture;
 import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.storage.conformance.retry.CleanupStrategy;
 import com.google.cloud.storage.conformance.retry.TestBench;
 import com.google.cloud.storage.testing.RemoteStorageHelper;
+import com.google.common.collect.ImmutableList;
+import java.util.stream.StreamSupport;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 
 public final class ITGrpcTest {
-  @ClassRule
+  @ClassRule(order = 1)
   public static final TestBench TEST_BENCH =
       TestBench.newBuilder().setContainerName("it-grpc").setDockerImageTag("v0.26.0").build();
 
-  @Rule
-  public final StorageFixture storageFixture =
+  @ClassRule(order = 2)
+  public static final StorageFixture storageFixture =
       StorageFixture.from(
           () ->
               StorageOptions.grpc()
@@ -44,10 +49,41 @@ public final class ITGrpcTest {
                   .setProjectId("test-project-id")
                   .build());
 
+  @ClassRule(order = 3)
+  public static final BucketFixture bucketFixture =
+      BucketFixture.newBuilder()
+          .setBucketNameFmtString("java-storage-gcs-grpc-team-%s")
+          .setCleanupStrategy(CleanupStrategy.ALWAYS)
+          .setHandle(storageFixture::getInstance)
+          .build();
+
   @Test
   public void testCreateBucket() {
     final String bucketName = RemoteStorageHelper.generateBucketName();
     Bucket bucket = storageFixture.getInstance().create(BucketInfo.of(bucketName));
     assertThat(bucket.getName()).isEqualTo(bucketName);
+  }
+
+  @Test
+  public void listBlobs() {
+    BucketInfo bucketInfo = bucketFixture.getBucketInfo();
+    Page<Blob> list = storageFixture.getInstance().list(bucketInfo.getName());
+    ImmutableList<String> bucketNames =
+        StreamSupport.stream(list.iterateAll().spliterator(), false)
+            .map(Blob::getName)
+            .collect(ImmutableList.toImmutableList());
+
+    assertThat(bucketNames).isEmpty();
+  }
+
+  @Test
+  public void listBuckets() {
+    Page<Bucket> list = storageFixture.getInstance().list();
+    ImmutableList<String> bucketNames =
+        StreamSupport.stream(list.iterateAll().spliterator(), false)
+            .map(Bucket::getName)
+            .collect(ImmutableList.toImmutableList());
+
+    assertThat(bucketNames).contains(bucketFixture.getBucketInfo().getName());
   }
 }


### PR DESCRIPTION
Create a JUnit Rule which can manage the lifecycle of a temporary bucket. A bucket will be created by the rule, and then emptied and deleted upon test completion.

Update some of the IT*Test classes to use the new fixture when applicable.

Update bucket name handling in some GrpcStorageImpl methods.

Add simplistic listBlobs and listBuckets tests to ITGrpcTest
