### PR TITLE
test: add regression tests for each Option on our public api

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Blob.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Blob.java
@@ -140,7 +140,10 @@ public class Blob extends BlobInfo {
     /**
      * Returns an option for blob's generation mismatch. If this option is used the request will
      * fail if generation matches.
+     *
+     * @deprecated This option is invalid, and can never result in a valid response from the server.
      */
+    @Deprecated
     public static BlobSourceOption generationNotMatch() {
       return new BlobSourceOption(StorageRpc.Option.IF_GENERATION_NOT_MATCH);
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
@@ -794,7 +794,11 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * blob's generation is taken from a source {@link BlobId} object. When this option is passed to
      * a {@link Storage} method and {@link BlobId#getGeneration()} is {@code null} or no {@link
      * BlobId} is provided an exception is thrown.
+     *
+     * @deprecated This option is invalid, and can never result in a valid response from the server.
+     *     use {@link #generationNotMatch(long)} instead.
      */
+    @Deprecated
     public static BlobSourceOption generationNotMatch() {
       return new BlobSourceOption(StorageRpc.Option.IF_GENERATION_NOT_MATCH, null);
     }
@@ -903,7 +907,11 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * blob's generation is taken from a source {@link BlobId} object. When this option is passed to
      * a {@link Storage} method and {@link BlobId#getGeneration()} is {@code null} or no {@link
      * BlobId} is provided an exception is thrown.
+     *
+     * @deprecated This option is invalid, and can never result in a valid response from the server.
+     *     use {@link #generationNotMatch(long)} instead.
      */
+    @Deprecated
     public static BlobGetOption generationNotMatch() {
       return new BlobGetOption(StorageRpc.Option.IF_GENERATION_NOT_MATCH, (Long) null);
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java
@@ -324,6 +324,7 @@ public class HttpStorageRpc implements StorageRpc {
           .setProjection(DEFAULT_PROJECTION)
           .setPredefinedAcl(Option.PREDEFINED_ACL.getString(options))
           .setPredefinedDefaultObjectAcl(Option.PREDEFINED_DEFAULT_OBJECT_ACL.getString(options))
+          .setUserProject(Option.USER_PROJECT.getString(options))
           .execute();
     } catch (IOException ex) {
       span.setStatus(Status.UNKNOWN.withDescription(ex.getMessage()));
@@ -1463,6 +1464,7 @@ public class HttpStorageRpc implements StorageRpc {
               .setPageToken(Option.PAGE_TOKEN.getString(options))
               .setMaxResults(Option.MAX_RESULTS.getLong(options))
               .setShowDeletedKeys(Option.SHOW_DELETED_KEYS.getBoolean(options))
+              .setUserProject(Option.USER_PROJECT.getString(options))
               .execute();
       return Tuple.<String, Iterable<HmacKeyMetadata>>of(
           hmacKeysMetadata.getNextPageToken(), hmacKeysMetadata.getItems());

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/CSEKSupport.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/CSEKSupport.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.it;
+
+import com.google.common.hash.Hashing;
+import java.security.Key;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Objects;
+import javax.crypto.SecretKey;
+
+/** Supporting class for Customer Supplied Encryption Key related state */
+final class CSEKSupport {
+
+  private final byte[] keyBytes;
+  private final EncryptionKeyTuple tuple;
+  private final Key key;
+
+  private CSEKSupport(byte[] keyBytes, EncryptionKeyTuple tuple) {
+    this.keyBytes = keyBytes;
+    this.tuple = tuple;
+    this.key =
+        new SecretKey() {
+          @Override
+          public String getAlgorithm() {
+            return tuple.algorithm;
+          }
+
+          @Override
+          public String getFormat() {
+            return null;
+          }
+
+          @Override
+          public byte[] getEncoded() {
+            return keyBytes;
+          }
+        };
+  }
+
+  byte[] getKeyBytes() {
+    return keyBytes;
+  }
+
+  EncryptionKeyTuple getTuple() {
+    return tuple;
+  }
+
+  Key getKey() {
+    return key;
+  }
+
+  static CSEKSupport create() {
+    byte[] bytes = new byte[32];
+    new SecureRandom().nextBytes(bytes);
+    String encode = Base64.getEncoder().encodeToString(bytes);
+    String sha256 = Base64.getEncoder().encodeToString(Hashing.sha256().hashBytes(bytes).asBytes());
+    return new CSEKSupport(bytes, new EncryptionKeyTuple("AES256", encode, sha256));
+  }
+
+  static final class EncryptionKeyTuple {
+    private final String algorithm;
+    private final String key;
+    private final String keySha256;
+
+    EncryptionKeyTuple(String algorithm, String key, String keySha256) {
+      this.algorithm = algorithm;
+      this.key = key;
+      this.keySha256 = keySha256;
+    }
+
+    String getAlgorithm() {
+      return algorithm;
+    }
+
+    String getKey() {
+      return key;
+    }
+
+    String getKeySha256() {
+      return keySha256;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof EncryptionKeyTuple)) {
+        return false;
+      }
+      EncryptionKeyTuple that = (EncryptionKeyTuple) o;
+      return Objects.equals(algorithm, that.algorithm)
+          && Objects.equals(key, that.key)
+          && Objects.equals(keySha256, that.keySha256);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(algorithm, key, keySha256);
+    }
+
+    @Override
+    public String toString() {
+      return "EncryptionKeyTuple{"
+          + "algorithm='"
+          + algorithm
+          + '\''
+          + ", key='"
+          + key
+          + '\''
+          + ", keySha256='"
+          + keySha256
+          + '\''
+          + '}';
+    }
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITOptionRegressionTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITOptionRegressionTest.java
@@ -1027,11 +1027,14 @@ public final class ITOptionRegressionTest {
 
   @Test
   public void storage_CopyWriter() {
-    CopyRequest request = CopyRequest.newBuilder()
-        .setSource(o.getBlobId())
-        .setSourceOptions(Storage.BlobSourceOption.generationMatch())
-        .setTarget(BlobId.of(b.getName(), objectName(), 57L), Storage.BlobTargetOption.generationNotMatch())
-        .build();
+    CopyRequest request =
+        CopyRequest.newBuilder()
+            .setSource(o.getBlobId())
+            .setSourceOptions(Storage.BlobSourceOption.generationMatch())
+            .setTarget(
+                BlobId.of(b.getName(), objectName(), 57L),
+                Storage.BlobTargetOption.generationNotMatch())
+            .build();
     CopyWriter copy = s.copy(request);
     requestAuditing.assertQueryParam("ifGenerationNotMatch", "57");
     requestAuditing.assertQueryParam("ifSourceGenerationMatch", o.getGeneration().toString());
@@ -1043,12 +1046,13 @@ public final class ITOptionRegressionTest {
     Blob obj = b.create(objectName(), CONTENT.bytes, BlobTargetOption.doesNotExist());
     requestAuditing.clear();
     Blob updated = obj.toBuilder().setMd5(null).setCrc32c(null).build();
-    ComposeRequest request = ComposeRequest.newBuilder()
-        .addSource(o.getName())
-        .addSource(o.getName())
-        .setTarget(updated)
-        .setTargetOptions(Storage.BlobTargetOption.metagenerationMatch())
-        .build();
+    ComposeRequest request =
+        ComposeRequest.newBuilder()
+            .addSource(o.getName())
+            .addSource(o.getName())
+            .setTarget(updated)
+            .setTargetOptions(Storage.BlobTargetOption.metagenerationMatch())
+            .build();
 
     s.compose(request);
     requestAuditing.assertQueryParam("ifMetagenerationMatch", obj.getMetageneration().toString());

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITOptionRegressionTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITOptionRegressionTest.java
@@ -1,0 +1,1060 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.it;
+
+import static org.junit.Assume.assumeTrue;
+
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.cloud.FieldSelector.Helper;
+import com.google.cloud.NoCredentials;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Bucket.BlobTargetOption;
+import com.google.cloud.storage.Bucket.BlobWriteOption;
+import com.google.cloud.storage.BucketFixture;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.HmacKey.HmacKeyMetadata;
+import com.google.cloud.storage.HmacKey.HmacKeyState;
+import com.google.cloud.storage.ServiceAccount;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobField;
+import com.google.cloud.storage.Storage.BlobGetOption;
+import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.cloud.storage.Storage.BlobSourceOption;
+import com.google.cloud.storage.Storage.BucketField;
+import com.google.cloud.storage.Storage.BucketGetOption;
+import com.google.cloud.storage.Storage.BucketListOption;
+import com.google.cloud.storage.Storage.BucketSourceOption;
+import com.google.cloud.storage.Storage.BucketTargetOption;
+import com.google.cloud.storage.Storage.CreateHmacKeyOption;
+import com.google.cloud.storage.Storage.DeleteHmacKeyOption;
+import com.google.cloud.storage.Storage.GetHmacKeyOption;
+import com.google.cloud.storage.Storage.ListHmacKeysOption;
+import com.google.cloud.storage.Storage.PredefinedAcl;
+import com.google.cloud.storage.Storage.UpdateHmacKeyOption;
+import com.google.cloud.storage.StorageClass;
+import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.StorageFixture;
+import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.storage.conformance.retry.CleanupStrategy;
+import com.google.cloud.storage.conformance.retry.TestBench;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.Hashing;
+import com.google.common.primitives.Ints;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+@SuppressWarnings("ConstantConditions")
+public final class ITOptionRegressionTest {
+  @ClassRule(order = 1)
+  public static final TestBench TEST_BENCH =
+      TestBench.newBuilder().setContainerName("it-options").setDockerImageTag("v0.17.0").build();
+
+  @ClassRule(order = 2)
+  public static final StorageFixture storageFixture =
+      StorageFixture.from(
+          () ->
+              StorageOptions.http()
+                  .setHost(TEST_BENCH.getBaseUri())
+                  .setCredentials(NoCredentials.getInstance())
+                  .setProjectId("test-project-id")
+                  .build());
+
+  @ClassRule(order = 3)
+  public static final BucketFixture bucketFixture =
+      BucketFixture.newBuilder()
+          .setBucketNameFmtString("options-%s")
+          .setCleanupStrategy(CleanupStrategy.NEVER) // just let testbench shutdown
+          .setHandle(storageFixture::getInstance)
+          .build();
+
+  private static final Content CONTENT = Content.of("Hello, World!");
+  private static final Content CONTENT2 = Content.of("Goodbye, World!");
+  private static final CSEKSupport csekSupport = CSEKSupport.create();
+  private static final ServiceAccount SERVICE_ACCOUNT = ServiceAccount.of("x@y.z");
+
+  private static RequestAuditing requestAuditing;
+  private static Storage s;
+  private static Bucket b;
+  private static Blob o;
+  private static Blob e;
+
+  private static int bucketCounter = 0;
+  private static int objectCounter = 0;
+
+  @BeforeClass
+  public static void beforeClass() {
+    requestAuditing = new RequestAuditing();
+    s =
+        storageFixture
+            .getInstance()
+            .getOptions()
+            .toBuilder()
+            .setTransportOptions(requestAuditing)
+            .setRetrySettings(RetrySettings.newBuilder().setMaxAttempts(1).build())
+            .build()
+            .getService();
+    b = s.get(bucketFixture.getBucketInfo().getName());
+    o = s.create(BlobInfo.newBuilder(b, "ddeeffaauulltt").build(), CONTENT.bytes);
+    e =
+        s.create(
+            BlobInfo.newBuilder(b, "encrypteddetpyrcne").build(),
+            CONTENT.bytes,
+            Storage.BlobTargetOption.encryptionKey(csekSupport.getTuple().getKey()));
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    requestAuditing.clear();
+  }
+
+  @Test
+  public void storage_BucketTargetOption_predefinedAcl_PredefinedAcl() {
+    s.create(
+        BlobInfo.newBuilder(b, objectName()).build(),
+        CONTENT.bytes,
+        Storage.BlobTargetOption.predefinedAcl(PredefinedAcl.PUBLIC_READ));
+    requestAuditing.assertQueryParam("predefinedAcl", "publicRead");
+  }
+
+  @Test
+  public void storage_BucketTargetOption_predefinedDefaultObjectAcl_PredefinedAcl() {
+    s.create(
+        BucketInfo.of(bucketName()),
+        BucketTargetOption.predefinedDefaultObjectAcl(PredefinedAcl.PUBLIC_READ));
+    requestAuditing.assertQueryParam("predefinedDefaultObjectAcl", "publicRead");
+  }
+
+  @Test
+  public void storage_BucketTargetOption_metagenerationMatch_() {
+    Bucket bucket = s.create(BucketInfo.of(bucketName()));
+    requestAuditing.clear();
+    Bucket updated = bucket.toBuilder().setLabels(ImmutableMap.of("foo", "bar")).build();
+    s.update(updated, BucketTargetOption.metagenerationMatch());
+    requestAuditing.assertQueryParam(
+        "ifMetagenerationMatch", bucket.getMetageneration().toString());
+  }
+
+  @Test
+  public void storage_BucketTargetOption_metagenerationNotMatch_() {
+    Bucket bucket1 = s.create(BucketInfo.of(bucketName()));
+    Bucket updated = bucket1.toBuilder().setLabels(ImmutableMap.of("foo", "bar")).build();
+    s.update(updated);
+    requestAuditing.clear();
+    s.update(
+        bucket1.toBuilder().setStorageClass(StorageClass.COLDLINE).build(),
+        BucketTargetOption.metagenerationNotMatch());
+    requestAuditing.assertQueryParam("ifMetagenerationNotMatch", "1");
+  }
+
+  @Test
+  public void storage_BucketTargetOption_userProject_String() {
+    s.create(BucketInfo.of(bucketName()), BucketTargetOption.userProject("proj"));
+    requestAuditing.assertQueryParam("userProject", "proj");
+  }
+
+  @Test
+  public void storage_BucketTargetOption_projection_String() {
+    Bucket bucket = s.create(BucketInfo.of(bucketName()));
+    requestAuditing.clear();
+    s.update(bucket, BucketTargetOption.projection("noAcl"));
+    requestAuditing.assertQueryParam("projection", "noAcl");
+  }
+
+  @Test
+  public void storage_BucketSourceOption_metagenerationMatch_long() {
+    s.get(o.getBlobId(), BlobGetOption.metagenerationMatch(o.getMetageneration()));
+    requestAuditing.assertQueryParam("ifMetagenerationMatch", "1");
+  }
+
+  @Test
+  public void storage_BucketSourceOption_metagenerationNotMatch_long() {
+    s.get(o.getBlobId(), BlobGetOption.metagenerationNotMatch(0L));
+    requestAuditing.assertQueryParam("ifMetagenerationNotMatch", "0");
+  }
+
+  @Test
+  public void storage_BucketSourceOption_userProject_String() {
+    s.getIamPolicy(b.getName(), BucketSourceOption.userProject("proj"));
+    requestAuditing.assertQueryParam("userProject", "proj");
+  }
+
+  @Test
+  public void storage_BucketSourceOption_requestedPolicyVersion_long() {
+    s.getIamPolicy(b.getName(), BucketSourceOption.requestedPolicyVersion(3L));
+    requestAuditing.assertQueryParam("optionsRequestedPolicyVersion", "3");
+  }
+
+  @Test
+  public void storage_ListHmacKeysOption_serviceAccount_ServiceAccount() {
+    s.listHmacKeys(ListHmacKeysOption.serviceAccount(SERVICE_ACCOUNT));
+    requestAuditing.assertQueryParam("serviceAccountEmail", SERVICE_ACCOUNT.getEmail());
+  }
+
+  @Test
+  public void storage_ListHmacKeysOption_maxResults_long() {
+    s.listHmacKeys(ListHmacKeysOption.maxResults(1));
+    requestAuditing.assertQueryParam("maxResults", "1");
+  }
+
+  @Test
+  public void storage_ListHmacKeysOption_pageToken_String() {
+    s.listHmacKeys(ListHmacKeysOption.pageToken("asdfghjkl"));
+    requestAuditing.assertQueryParam("pageToken", "asdfghjkl");
+  }
+
+  @Test
+  public void storage_ListHmacKeysOption_showDeletedKeys_boolean() {
+    s.listHmacKeys(ListHmacKeysOption.showDeletedKeys(true));
+    requestAuditing.assertQueryParam("showDeletedKeys", "true");
+  }
+
+  @Test
+  public void storage_ListHmacKeysOption_userProject_String() {
+    s.listHmacKeys(ListHmacKeysOption.userProject("proj"));
+    requestAuditing.assertQueryParam("userProject", "proj");
+  }
+
+  @Test
+  public void storage_ListHmacKeysOption_projectId_String() {
+    s.listHmacKeys(ListHmacKeysOption.projectId("proj"));
+    requestAuditing.assertPathParam("projects", "proj");
+  }
+
+  @Test
+  public void storage_CreateHmacKeyOption_userProject_String() {
+    s.createHmacKey(SERVICE_ACCOUNT, CreateHmacKeyOption.userProject("proj"));
+    requestAuditing.assertQueryParam("userProject", "proj");
+  }
+
+  @Test
+  public void storage_CreateHmacKeyOption_projectId_String() {
+    s.createHmacKey(SERVICE_ACCOUNT, CreateHmacKeyOption.projectId("proj"));
+    requestAuditing.assertPathParam("projects", "proj");
+  }
+
+  @Test
+  public void storage_GetHmacKeyOption_userProject_String() {
+    try {
+      s.getHmacKey("x", GetHmacKeyOption.userProject("proj"));
+    } catch (StorageException ignore) {
+    }
+    requestAuditing.assertQueryParam("userProject", "proj");
+  }
+
+  @Test
+  public void storage_GetHmacKeyOption_projectId_String() {
+    try {
+      s.getHmacKey("x", GetHmacKeyOption.projectId("proj"));
+    } catch (StorageException ignore) {
+    }
+    requestAuditing.assertPathParam("projects", "proj");
+  }
+
+  @Test
+  public void storage_DeleteHmacKeyOption_userProject_String() {
+    HmacKeyMetadata hmacKeyMetadata =
+        HmacKeyMetadata.newBuilder(SERVICE_ACCOUNT).setAccessId("x").setProjectId("proj").build();
+    try {
+      s.deleteHmacKey(hmacKeyMetadata, DeleteHmacKeyOption.userProject("proj"));
+    } catch (StorageException ignore) {
+    }
+    requestAuditing.assertQueryParam("userProject", "proj");
+  }
+
+  @Test
+  public void storage_UpdateHmacKeyOption_userProject_String() {
+    HmacKeyMetadata hmacKeyMetadata =
+        HmacKeyMetadata.newBuilder(SERVICE_ACCOUNT).setAccessId("x").setProjectId("proj").build();
+    try {
+      s.updateHmacKeyState(
+          hmacKeyMetadata, HmacKeyState.INACTIVE, UpdateHmacKeyOption.userProject("proj"));
+    } catch (StorageException ignore) {
+    }
+    requestAuditing.assertQueryParam("userProject", "proj");
+  }
+
+  @Test
+  public void storage_BucketGetOption_metagenerationMatch_long() {
+    s.get(b.getName(), BucketGetOption.metagenerationMatch(b.getMetageneration()));
+    requestAuditing.assertQueryParam("ifMetagenerationMatch", "1");
+  }
+
+  @Test
+  public void storage_BucketGetOption_metagenerationNotMatch_long() {
+    s.get(b.getName(), BucketGetOption.metagenerationNotMatch(0L));
+    requestAuditing.assertQueryParam("ifMetagenerationNotMatch", "0");
+  }
+
+  @Test
+  public void storage_BucketGetOption_userProject_String() {
+    s.get(b.getName(), BucketGetOption.userProject("proj"));
+    requestAuditing.assertQueryParam("userProject", "proj");
+  }
+
+  @Test
+  public void storage_BucketGetOption_fields_BucketField() {
+    String expected = Helper.selector(ImmutableList.copyOf(BucketField.values()));
+    s.get(b.getName(), BucketGetOption.fields(BucketField.values()));
+    requestAuditing.assertQueryParam("fields", expected);
+  }
+
+  @Test
+  public void storage_BlobTargetOption_predefinedAcl_PredefinedAcl() {
+    s.create(
+        BlobInfo.newBuilder(b, objectName()).build(),
+        CONTENT.bytes,
+        Storage.BlobTargetOption.predefinedAcl(PredefinedAcl.PUBLIC_READ));
+    requestAuditing.assertQueryParam("predefinedAcl", "publicRead");
+  }
+
+  @Test
+  public void storage_BlobTargetOption_doesNotExist_() {
+    s.create(
+        BlobInfo.newBuilder(b, objectName()).build(),
+        CONTENT.bytes,
+        Storage.BlobTargetOption.doesNotExist());
+    requestAuditing.assertQueryParam("ifGenerationMatch", "0");
+  }
+
+  @Test
+  public void storage_BlobTargetOption_generationMatch_() {
+    Blob blob = s.create(BlobInfo.newBuilder(b, objectName()).build());
+    requestAuditing.clear();
+    Blob updated = blob.toBuilder().setMetadata(ImmutableMap.of("foo", "bar")).build();
+    s.update(updated, Storage.BlobTargetOption.generationMatch());
+    requestAuditing.assertQueryParam("ifGenerationMatch", blob.getGeneration().toString());
+  }
+
+  @Test
+  public void storage_BlobTargetOption_generationNotMatch_() {
+    Blob blob1 = s.create(BlobInfo.newBuilder(b, objectName()).build());
+    Blob updated = blob1.toBuilder().setMetadata(ImmutableMap.of("foo", "bar")).build();
+    s.create(updated, CONTENT2.bytes);
+    requestAuditing.clear();
+    s.create(updated, CONTENT.bytes, Storage.BlobTargetOption.generationNotMatch());
+    requestAuditing.assertQueryParam("ifGenerationNotMatch", blob1.getGeneration().toString());
+  }
+
+  @Test
+  public void storage_BlobTargetOption_metagenerationMatch_() {
+    Blob blob = s.create(BlobInfo.newBuilder(b, objectName()).build());
+    requestAuditing.clear();
+    Blob updated = blob.toBuilder().setMetadata(ImmutableMap.of("foo", "bar")).build();
+    s.update(updated, Storage.BlobTargetOption.metagenerationMatch());
+    requestAuditing.assertQueryParam("ifMetagenerationMatch", blob.getMetageneration().toString());
+  }
+
+  @Test
+  public void storage_BlobTargetOption_metagenerationNotMatch_() {
+    Blob blob1 = s.create(BlobInfo.newBuilder(b, objectName()).build());
+    Blob updated = blob1.toBuilder().setMetadata(ImmutableMap.of("foo", "bar")).build();
+    s.update(updated);
+    requestAuditing.clear();
+    s.update(
+        blob1.toBuilder().setStorageClass(StorageClass.COLDLINE).build(),
+        Storage.BlobTargetOption.metagenerationNotMatch());
+    requestAuditing.assertQueryParam("ifMetagenerationNotMatch", "1");
+  }
+
+  @Test
+  public void storage_BlobTargetOption_disableGzipContent_() {
+    s.create(
+        BlobInfo.newBuilder(b, objectName()).build(),
+        CONTENT.bytes,
+        Storage.BlobTargetOption.disableGzipContent());
+    requestAuditing.assertNoContentEncoding();
+  }
+
+  @Test
+  public void storage_BlobTargetOption_detectContentType_() {
+    s.create(
+        BlobInfo.newBuilder(b, objectName() + ".txt").build(),
+        CONTENT.bytes,
+        Storage.BlobTargetOption.detectContentType());
+    requestAuditing.assertMultipartContentJsonAndText();
+  }
+
+  @Test
+  public void storage_BlobTargetOption_encryptionKey_Key() {
+    s.create(
+        BlobInfo.newBuilder(b, objectName()).build(),
+        CONTENT.bytes,
+        Storage.BlobTargetOption.encryptionKey(csekSupport.getKey()));
+    requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
+  }
+
+  @Test
+  public void storage_BlobTargetOption_userProject_String() {
+    s.create(
+        BlobInfo.newBuilder(b, objectName()).build(),
+        CONTENT.bytes,
+        Storage.BlobTargetOption.userProject("proj"));
+    requestAuditing.assertQueryParam("userProject", "proj");
+  }
+
+  @Test
+  public void storage_BlobTargetOption_encryptionKey_String() {
+    s.create(
+        BlobInfo.newBuilder(b, objectName()).build(),
+        CONTENT.bytes,
+        Storage.BlobTargetOption.encryptionKey(csekSupport.getTuple().getKey()));
+    requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
+  }
+
+  @Test
+  public void storage_BlobTargetOption_kmsKeyName_String() {
+    s.create(
+        BlobInfo.newBuilder(b, objectName()).build(),
+        CONTENT.bytes,
+        Storage.BlobTargetOption.kmsKeyName("kms-key"));
+    requestAuditing.assertQueryParam("kmsKeyName", "kms-key");
+  }
+
+  @Test
+  public void storage_BlobWriteOption_predefinedAcl_PredefinedAcl() {
+    s.create(
+        BlobInfo.newBuilder(b, objectName()).build(),
+        CONTENT.inputStream(),
+        Storage.BlobWriteOption.predefinedAcl(PredefinedAcl.PUBLIC_READ));
+    requestAuditing.assertQueryParam("predefinedAcl", "publicRead");
+  }
+
+  @Test
+  public void storage_BlobWriteOption_doesNotExist_() {
+    s.create(
+        BlobInfo.newBuilder(b, objectName()).build(),
+        CONTENT.inputStream(),
+        Storage.BlobWriteOption.doesNotExist());
+    requestAuditing.assertQueryParam("ifGenerationMatch", "0");
+  }
+
+  @Test
+  public void storage_BlobWriteOption_generationMatch_() {
+    Blob blob = s.create(BlobInfo.newBuilder(b, objectName()).build());
+    requestAuditing.clear();
+    Blob updated =
+        blob.toBuilder()
+            .setMetadata(ImmutableMap.of("foo", "bar"))
+            .setMd5(null)
+            .setCrc32c(null)
+            .build();
+    s.create(updated, CONTENT2.inputStream(), Storage.BlobWriteOption.generationMatch());
+    requestAuditing.assertQueryParam("ifGenerationMatch", blob.getGeneration().toString());
+  }
+
+  @Test
+  public void storage_BlobWriteOption_generationNotMatch_() {
+    Blob blob1 = s.create(BlobInfo.newBuilder(b, objectName()).build());
+    Blob updated =
+        blob1
+            .toBuilder()
+            .setMetadata(ImmutableMap.of("foo", "bar"))
+            .setMd5(null)
+            .setCrc32c(null)
+            .build();
+    s.create(updated, CONTENT2.bytes);
+    requestAuditing.clear();
+    s.create(updated, CONTENT.inputStream(), Storage.BlobWriteOption.generationNotMatch());
+    requestAuditing.assertQueryParam("ifGenerationNotMatch", blob1.getGeneration().toString());
+  }
+
+  @Test
+  public void storage_BlobWriteOption_metagenerationMatch_() {
+    Blob blob = s.create(BlobInfo.newBuilder(b, objectName()).build());
+    requestAuditing.clear();
+    Blob updated =
+        blob.toBuilder()
+            .setMetadata(ImmutableMap.of("foo", "bar"))
+            .setMd5(null)
+            .setCrc32c(null)
+            .build();
+    s.create(updated, CONTENT2.inputStream(), Storage.BlobWriteOption.metagenerationMatch());
+    requestAuditing.assertQueryParam("ifMetagenerationMatch", blob.getMetageneration().toString());
+  }
+
+  @Test
+  public void storage_BlobWriteOption_metagenerationNotMatch_() {
+    Blob blob1 = s.create(BlobInfo.newBuilder(b, objectName()).build());
+    Blob updated =
+        blob1
+            .toBuilder()
+            .setMetadata(ImmutableMap.of("foo", "bar"))
+            .setMd5(null)
+            .setCrc32c(null)
+            .build();
+    s.update(updated);
+    requestAuditing.clear();
+    s.create(
+        updated.toBuilder().setStorageClass(StorageClass.COLDLINE).build(),
+        CONTENT2.inputStream(),
+        Storage.BlobWriteOption.metagenerationNotMatch());
+    requestAuditing.assertQueryParam("ifMetagenerationNotMatch", "1");
+  }
+
+  @Test
+  public void storage_BlobWriteOption_md5Match_() {
+    BlobInfo info = BlobInfo.newBuilder(b, objectName()).setMd5(CONTENT.md5Base64).build();
+    s.create(info, CONTENT.inputStream(), Storage.BlobWriteOption.md5Match());
+    requestAuditing.assertMultipartJsonField("md5Hash", CONTENT.md5Base64);
+  }
+
+  @Test
+  public void storage_BlobWriteOption_crc32cMatch_() {
+    BlobInfo info = BlobInfo.newBuilder(b, objectName()).setCrc32c(CONTENT.crc32cBase64()).build();
+    s.create(info, CONTENT.inputStream(), Storage.BlobWriteOption.crc32cMatch());
+    requestAuditing.assertMultipartJsonField("crc32c", CONTENT.crc32cBase64());
+  }
+
+  @Test
+  public void storage_BlobWriteOption_encryptionKey_Key() {
+    s.create(
+        BlobInfo.newBuilder(b, objectName()).build(),
+        CONTENT.inputStream(),
+        Storage.BlobWriteOption.encryptionKey(csekSupport.getKey()));
+    requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
+  }
+
+  @Test
+  public void storage_BlobWriteOption_encryptionKey_String() {
+    s.create(
+        BlobInfo.newBuilder(b, objectName()).build(),
+        CONTENT.inputStream(),
+        Storage.BlobWriteOption.encryptionKey(csekSupport.getTuple().getKey()));
+    requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
+  }
+
+  @Test
+  public void storage_BlobWriteOption_kmsKeyName_String() {
+    s.create(
+        BlobInfo.newBuilder(b, objectName()).build(),
+        CONTENT.inputStream(),
+        Storage.BlobWriteOption.kmsKeyName("kms-key"));
+    requestAuditing.assertQueryParam("kmsKeyName", "kms-key");
+  }
+
+  @Test
+  public void storage_BlobWriteOption_userProject_String() {
+    s.create(
+        BlobInfo.newBuilder(b, objectName()).build(),
+        CONTENT.inputStream(),
+        Storage.BlobWriteOption.userProject("proj"));
+    requestAuditing.assertQueryParam("userProject", "proj");
+  }
+
+  @Test
+  public void storage_BlobWriteOption_disableGzipContent_() {
+    s.create(
+        BlobInfo.newBuilder(b, objectName()).build(),
+        CONTENT.inputStream(),
+        Storage.BlobWriteOption.disableGzipContent());
+    requestAuditing.assertNoContentEncoding();
+  }
+
+  @Test
+  public void storage_BlobWriteOption_detectContentType_() {
+    s.create(
+        BlobInfo.newBuilder(b, objectName() + ".txt").build(),
+        CONTENT.inputStream(),
+        Storage.BlobWriteOption.detectContentType());
+    requestAuditing.assertMultipartContentJsonAndText();
+  }
+
+  @Test
+  public void storage_BlobSourceOption_generationMatch_() {
+    s.readAllBytes(o.getBlobId(), BlobSourceOption.generationMatch());
+    requestAuditing.assertQueryParam("ifGenerationMatch", o.getGeneration().toString());
+  }
+
+  @Test
+  public void storage_BlobSourceOption_generationMatch_long() {
+    s.readAllBytes(o.getBlobId(), BlobSourceOption.generationMatch(o.getGeneration()));
+    requestAuditing.assertQueryParam("ifGenerationMatch", o.getGeneration().toString());
+  }
+
+  @Test
+  public void storage_BlobSourceOption_generationNotMatch_() {
+    try {
+      s.readAllBytes(
+          BlobId.of(o.getBucket(), o.getName(), 1L), BlobSourceOption.generationNotMatch());
+    } catch (StorageException ignore) {
+      // this option doesn't make much sense.
+      // The generation which is read from to construct the ifGenerationNotMatch condition comes
+      //   from the BlobId. However, the same generation value is also included as the generation
+      //   query param, thereby leading to a condition that can NEVER be met...
+      //   This test is only here to verify plumbing, but it should be deprecated and removed
+    }
+    requestAuditing.assertQueryParam("ifGenerationNotMatch", "1");
+  }
+
+  @Test
+  public void storage_BlobSourceOption_generationNotMatch_long() {
+    s.readAllBytes(o.getBlobId(), BlobSourceOption.generationNotMatch(0));
+    requestAuditing.assertQueryParam("ifGenerationNotMatch", "0");
+  }
+
+  @Test
+  public void storage_BlobSourceOption_metagenerationMatch_long() {
+    s.readAllBytes(o.getBlobId(), BlobSourceOption.metagenerationMatch(o.getMetageneration()));
+    requestAuditing.assertQueryParam("ifMetagenerationMatch", "1");
+  }
+
+  @Test
+  public void storage_BlobSourceOption_metagenerationNotMatch_long() {
+    s.readAllBytes(o.getBlobId(), BlobSourceOption.metagenerationNotMatch(0));
+    requestAuditing.assertQueryParam("ifMetagenerationNotMatch", "0");
+  }
+
+  @Test
+  public void storage_BlobSourceOption_decryptionKey_Key() {
+    s.readAllBytes(e.getBlobId(), BlobSourceOption.decryptionKey(csekSupport.getKey()));
+    requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
+  }
+
+  @Test
+  public void storage_BlobSourceOption_decryptionKey_String() {
+    s.readAllBytes(e.getBlobId(), BlobSourceOption.decryptionKey(csekSupport.getTuple().getKey()));
+    requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
+  }
+
+  @Test
+  public void storage_BlobSourceOption_userProject_String() {
+    s.readAllBytes(o.getBlobId(), BlobSourceOption.userProject("proj"));
+    requestAuditing.assertQueryParam("userProject", "proj");
+  }
+
+  @Test
+  public void storage_BlobGetOption_generationMatch_() {
+    s.get(o.getBlobId(), BlobGetOption.generationMatch());
+    requestAuditing.assertQueryParam("ifGenerationMatch", o.getGeneration().toString());
+  }
+
+  @Test
+  public void storage_BlobGetOption_generationMatch_long() {
+    s.get(o.getBlobId(), BlobGetOption.generationMatch(o.getGeneration()));
+    requestAuditing.assertQueryParam("ifGenerationMatch", o.getGeneration().toString());
+  }
+
+  @Test
+  public void storage_BlobGetOption_generationNotMatch_() {
+    try {
+      s.get(BlobId.of(o.getBucket(), o.getName(), 1L), BlobGetOption.generationNotMatch());
+    } catch (StorageException ignore) {
+      // this option doesn't make much sense.
+      // The generation which is read from to construct the ifGenerationNotMatch condition comes
+      //   from the BlobId. However, the same generation value is also included as the generation
+      //   query param, thereby leading to a condition that can NEVER be met...
+      //   This test is only here to verify plumbing, but it should be deprecated and removed
+    }
+    requestAuditing.assertQueryParam("ifGenerationNotMatch", "1");
+  }
+
+  @Test
+  public void storage_BlobGetOption_generationNotMatch_long() {
+    s.get(o.getBlobId(), BlobGetOption.generationNotMatch(0));
+    requestAuditing.assertQueryParam("ifGenerationNotMatch", "0");
+  }
+
+  @Test
+  public void storage_BlobGetOption_metagenerationMatch_long() {
+    s.get(o.getBlobId(), BlobGetOption.metagenerationMatch(o.getMetageneration()));
+    requestAuditing.assertQueryParam("ifMetagenerationMatch", "1");
+  }
+
+  @Test
+  public void storage_BlobGetOption_metagenerationNotMatch_long() {
+    s.get(o.getBlobId(), BlobGetOption.metagenerationNotMatch(0));
+    requestAuditing.assertQueryParam("ifMetagenerationNotMatch", "0");
+  }
+
+  @Test
+  public void storage_BlobGetOption_fields_BlobField() {
+    String expected = Helper.selector(ImmutableList.copyOf(BlobField.values()));
+    s.get(o.getBlobId(), BlobGetOption.fields(BlobField.values()));
+    requestAuditing.assertQueryParam("fields", expected);
+  }
+
+  @Test
+  public void storage_BlobGetOption_userProject_String() {
+    s.get(o.getBlobId(), BlobGetOption.userProject("proj"));
+    requestAuditing.assertQueryParam("userProject", "proj");
+  }
+
+  @Test
+  public void storage_BlobGetOption_decryptionKey_Key() {
+    s.get(e.getBlobId(), BlobGetOption.decryptionKey(csekSupport.getKey()));
+    requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
+  }
+
+  @Test
+  public void storage_BlobGetOption_decryptionKey_String() {
+    s.get(e.getBlobId(), BlobGetOption.decryptionKey(csekSupport.getTuple().getKey()));
+    requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
+  }
+
+  @Test
+  public void storage_BucketListOption_pageSize_long() {
+    s.list(BucketListOption.pageSize(1));
+    requestAuditing.assertQueryParam("maxResults", "1");
+  }
+
+  @Test
+  public void storage_BucketListOption_pageToken_String() {
+    s.list(BucketListOption.pageToken("asdfghjkl"));
+    requestAuditing.assertQueryParam("pageToken", "asdfghjkl");
+  }
+
+  @Test
+  public void storage_BucketListOption_prefix_String() {
+    s.list(BucketListOption.prefix("opt"));
+    requestAuditing.assertQueryParam("prefix", "opt");
+  }
+
+  @Test
+  public void storage_BucketListOption_userProject_String() {
+    s.list(BucketListOption.userProject("proj"));
+    requestAuditing.assertQueryParam("userProject", "proj");
+  }
+
+  @Test
+  public void storage_BucketListOption_fields_BucketField() {
+    String expected = Helper.listSelector("items", ImmutableList.copyOf(BucketField.values()));
+    s.list(BucketListOption.fields(BucketField.values()));
+    requestAuditing.assertQueryParam("fields", expected);
+  }
+
+  @Test
+  public void storage_BlobListOption_pageSize_long() {
+    s.list(b.getName(), BlobListOption.pageSize(1));
+    requestAuditing.assertQueryParam("maxResults", "1");
+  }
+
+  @Test
+  public void storage_BlobListOption_pageToken_String() {
+    s.list(b.getName(), BlobListOption.pageToken("asdfghjkl"));
+    requestAuditing.assertQueryParam("pageToken", "asdfghjkl");
+  }
+
+  @Test
+  public void storage_BlobListOption_prefix_String() {
+    s.list(b.getName(), BlobListOption.prefix("obj"));
+    requestAuditing.assertQueryParam("prefix", "obj");
+  }
+
+  @Test
+  public void storage_BlobListOption_currentDirectory_() {
+    s.list(b.getName(), BlobListOption.currentDirectory());
+    requestAuditing.assertQueryParam("delimiter", "/");
+  }
+
+  @Test
+  public void storage_BlobListOption_delimiter_String() {
+    s.list(b.getName(), BlobListOption.delimiter(":"));
+    requestAuditing.assertQueryParam("delimiter", ":");
+  }
+
+  @Test
+  public void storage_BlobListOption_startOffset_String() {
+    s.list(b.getName(), BlobListOption.startOffset("x"));
+    requestAuditing.assertQueryParam("startOffset", "x");
+  }
+
+  @Test
+  public void storage_BlobListOption_endOffset_String() {
+    s.list(b.getName(), BlobListOption.endOffset("x"));
+    requestAuditing.assertQueryParam("endOffset", "x");
+  }
+
+  @Test
+  public void storage_BlobListOption_userProject_String() {
+    s.list(b.getName(), BlobListOption.userProject("proj"));
+    requestAuditing.assertQueryParam("userProject", "proj");
+  }
+
+  @Test
+  public void storage_BlobListOption_versions_boolean() {
+    s.list(b.getName(), BlobListOption.versions(true));
+    requestAuditing.assertQueryParam("versions", "true");
+  }
+
+  @Test
+  public void storage_BlobListOption_fields_BlobField() {
+    String expected =
+        Helper.listSelector(
+            new String[] {"prefixes"}, "items", Collections.emptyList(), BlobField.values());
+    s.list(b.getName(), BlobListOption.fields(BlobField.values()));
+    requestAuditing.assertQueryParam("fields", expected);
+  }
+
+  @Test
+  public void bucket_BucketSourceOption_metagenerationMatch_() {
+    b.exists(Bucket.BucketSourceOption.metagenerationMatch());
+    requestAuditing.assertQueryParam("ifMetagenerationMatch", b.getMetageneration().toString());
+  }
+
+  @Test
+  public void bucket_BucketSourceOption_metagenerationNotMatch_() {
+    Bucket bucket1 = s.create(BucketInfo.of(bucketName()));
+    s.update(bucket1.toBuilder().setStorageClass(StorageClass.COLDLINE).build());
+    requestAuditing.clear();
+    bucket1.exists(Bucket.BucketSourceOption.metagenerationNotMatch());
+    requestAuditing.assertQueryParam("ifMetagenerationNotMatch", b.getMetageneration().toString());
+  }
+
+  @Test
+  public void bucket_BucketSourceOption_userProject_String() {
+    assumeTrue(false);
+  }
+
+  @Test
+  public void bucket_BlobTargetOption_predefinedAcl_PredefinedAcl() {
+    b.create(
+        objectName(), CONTENT.bytes, BlobTargetOption.predefinedAcl(PredefinedAcl.PUBLIC_READ));
+    requestAuditing.assertQueryParam("predefinedAcl", "publicRead");
+  }
+
+  @Test
+  public void bucket_BlobTargetOption_doesNotExist_() {
+    b.create(objectName(), CONTENT.bytes, BlobTargetOption.doesNotExist());
+    requestAuditing.assertQueryParam("ifGenerationMatch", "0");
+  }
+
+  @Test
+  public void bucket_BlobTargetOption_generationMatch_long() {
+    b.create(objectName(), CONTENT.bytes, BlobTargetOption.generationMatch(0));
+    requestAuditing.assertQueryParam("ifGenerationMatch", "0");
+  }
+
+  @Test
+  public void bucket_BlobTargetOption_generationNotMatch_long() {
+    b.create(objectName(), CONTENT.bytes, BlobTargetOption.generationNotMatch(1L));
+    requestAuditing.assertQueryParam("ifGenerationNotMatch", "1");
+  }
+
+  @Test
+  public void bucket_BlobTargetOption_metagenerationMatch_long() {
+    b.create(objectName(), CONTENT.bytes, BlobTargetOption.metagenerationMatch(0));
+    requestAuditing.assertQueryParam("ifMetagenerationMatch", "0");
+  }
+
+  @Test
+  public void bucket_BlobTargetOption_metagenerationNotMatch_long() {
+    b.create(objectName(), CONTENT.bytes, BlobTargetOption.metagenerationNotMatch(1L));
+    requestAuditing.assertQueryParam("ifMetagenerationNotMatch", "1");
+  }
+
+  @Test
+  public void bucket_BlobTargetOption_encryptionKey_Key() {
+    b.create(objectName(), CONTENT.bytes, BlobTargetOption.encryptionKey(csekSupport.getKey()));
+    requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
+  }
+
+  @Test
+  public void bucket_BlobTargetOption_encryptionKey_String() {
+    b.create(
+        objectName(),
+        CONTENT.bytes,
+        BlobTargetOption.encryptionKey(csekSupport.getTuple().getKey()));
+    requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
+  }
+
+  @Test
+  public void bucket_BlobTargetOption_kmsKeyName_String() {
+    b.create(objectName(), CONTENT.bytes, BlobTargetOption.kmsKeyName("kms-key"));
+    requestAuditing.assertQueryParam("kmsKeyName", "kms-key");
+  }
+
+  @Test
+  public void bucket_BlobTargetOption_userProject_String() {
+    b.create(objectName(), CONTENT.bytes, BlobTargetOption.userProject("proj"));
+    requestAuditing.assertQueryParam("userProject", "proj");
+  }
+
+  @Test
+  public void bucket_BlobWriteOption_predefinedAcl_PredefinedAcl() {
+    b.create(
+        objectName(),
+        CONTENT.inputStream(),
+        BlobWriteOption.predefinedAcl(PredefinedAcl.PUBLIC_READ));
+    requestAuditing.assertQueryParam("predefinedAcl", "publicRead");
+  }
+
+  @Test
+  public void bucket_BlobWriteOption_doesNotExist_() {
+    b.create(objectName(), CONTENT.inputStream(), BlobWriteOption.doesNotExist());
+    requestAuditing.assertQueryParam("ifGenerationMatch", "0");
+  }
+
+  @Test
+  public void bucket_BlobWriteOption_generationMatch_long() {
+    b.create(objectName(), CONTENT.inputStream(), BlobWriteOption.generationMatch(0));
+    requestAuditing.assertQueryParam("ifGenerationMatch", "0");
+  }
+
+  @Test
+  public void bucket_BlobWriteOption_generationNotMatch_long() {
+    b.create(objectName(), CONTENT.inputStream(), BlobWriteOption.generationNotMatch(1L));
+    requestAuditing.assertQueryParam("ifGenerationNotMatch", "1");
+  }
+
+  @Test
+  public void bucket_BlobWriteOption_metagenerationMatch_long() {
+    b.create(objectName(), CONTENT.inputStream(), BlobWriteOption.metagenerationMatch(0));
+    requestAuditing.assertQueryParam("ifMetagenerationMatch", "0");
+  }
+
+  @Test
+  public void bucket_BlobWriteOption_metagenerationNotMatch_long() {
+    b.create(objectName(), CONTENT.inputStream(), BlobWriteOption.metagenerationNotMatch(1L));
+    requestAuditing.assertQueryParam("ifMetagenerationNotMatch", "1");
+  }
+
+  @Test
+  public void bucket_BlobWriteOption_md5Match_String() {
+    b.create(objectName(), CONTENT.inputStream(), BlobWriteOption.md5Match(CONTENT.md5Base64));
+    requestAuditing.assertMultipartJsonField("md5Hash", CONTENT.md5Base64);
+  }
+
+  @Test
+  public void bucket_BlobWriteOption_crc32cMatch_String() {
+    b.create(
+        objectName(), CONTENT.inputStream(), BlobWriteOption.crc32cMatch(CONTENT.crc32cBase64()));
+    requestAuditing.assertMultipartJsonField("crc32c", CONTENT.crc32cBase64());
+  }
+
+  @Test
+  public void bucket_BlobWriteOption_encryptionKey_Key() {
+    b.create(
+        objectName(), CONTENT.inputStream(), BlobWriteOption.encryptionKey(csekSupport.getKey()));
+    requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
+  }
+
+  @Test
+  public void bucket_BlobWriteOption_encryptionKey_String() {
+    b.create(
+        objectName(),
+        CONTENT.inputStream(),
+        BlobWriteOption.encryptionKey(csekSupport.getTuple().getKey()));
+    requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
+  }
+
+  @Test
+  public void bucket_BlobWriteOption_userProject_String() {
+    b.create(objectName(), CONTENT.inputStream(), BlobWriteOption.userProject("proj"));
+    requestAuditing.assertQueryParam("userProject", "proj");
+  }
+
+  @Test
+  public void blob_BlobSourceOption_generationMatch_() {
+    o.getContent(Blob.BlobSourceOption.generationMatch());
+    requestAuditing.assertQueryParam("ifGenerationMatch", o.getGeneration().toString());
+  }
+
+  @Test
+  public void blob_BlobSourceOption_generationNotMatch_() {
+    try {
+      o.getContent(Blob.BlobSourceOption.generationNotMatch());
+    } catch (StorageException ignore) {
+      // this option doesn't make much sense.
+      // The generation which is read from to construct the ifGenerationNotMatch condition comes
+      //   from the BlobId. However, the same generation value is also included as the generation
+      //   query param, thereby leading to a condition that can NEVER be met...
+      //   This test is only here to verify plumbing, but it should be deprecated and removed
+    }
+    requestAuditing.assertQueryParam("ifGenerationNotMatch", o.getGeneration().toString());
+  }
+
+  @Test
+  public void blob_BlobSourceOption_metagenerationMatch_() {
+    o.getContent(Blob.BlobSourceOption.metagenerationMatch());
+    requestAuditing.assertQueryParam("ifMetagenerationMatch", o.getMetageneration().toString());
+  }
+
+  @Test
+  public void blob_BlobSourceOption_metagenerationNotMatch_() {
+    Blob blob1 = s.create(BlobInfo.newBuilder(b, objectName()).build());
+    Blob updated = blob1.toBuilder().setMetadata(ImmutableMap.of("foo", "bar")).build();
+    s.update(updated);
+    requestAuditing.clear();
+    blob1.getContent(Blob.BlobSourceOption.metagenerationNotMatch());
+    requestAuditing.assertQueryParam(
+        "ifMetagenerationNotMatch", blob1.getMetageneration().toString());
+  }
+
+  @Test
+  public void blob_BlobSourceOption_decryptionKey_Key() {
+    e.getContent(Blob.BlobSourceOption.decryptionKey(csekSupport.getKey()));
+    requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
+  }
+
+  @Test
+  public void blob_BlobSourceOption_decryptionKey_String() {
+    e.getContent(Blob.BlobSourceOption.decryptionKey(csekSupport.getTuple().getKey()));
+    requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
+  }
+
+  @Test
+  public void blob_BlobSourceOption_userProject_String() {
+    o.getContent(Blob.BlobSourceOption.userProject("proj"));
+    requestAuditing.assertQueryParam("userProject", "proj");
+  }
+
+  private static String bucketName() {
+    return String.format("bucket-%03d", bucketCounter++);
+  }
+
+  private static String objectName() {
+    return String.format("object-%03d", objectCounter++);
+  }
+
+  private static final class Content {
+    private final byte[] bytes;
+    private final int crc32c;
+    private final String md5Base64;
+
+    private Content(byte[] bytes, int crc32c, String md5Base64) {
+      this.bytes = bytes;
+      this.crc32c = crc32c;
+      this.md5Base64 = md5Base64;
+    }
+
+    ByteArrayInputStream inputStream() {
+      return new ByteArrayInputStream(bytes);
+    }
+
+    String crc32cBase64() {
+      return Base64.getEncoder().encodeToString(Ints.toByteArray(crc32c));
+    }
+
+    static Content of(String content) {
+      byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+      int crc32c = Hashing.crc32c().hashBytes(bytes).asInt();
+      String md5Base64 =
+          Base64.getEncoder().encodeToString(Hashing.md5().hashBytes(bytes).asBytes());
+      return new Content(bytes, crc32c, md5Base64);
+    }
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/RequestAuditing.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/RequestAuditing.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.it;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpContent;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.MultipartContent;
+import com.google.api.client.http.MultipartContent.Part;
+import com.google.api.client.http.json.JsonHttpContent;
+import com.google.api.client.json.GenericJson;
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.http.HttpTransportOptions;
+import com.google.cloud.storage.it.CSEKSupport.EncryptionKeyTuple;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+final class RequestAuditing extends HttpTransportOptions {
+
+  private final List<HttpRequest> requests;
+
+  RequestAuditing() {
+    super(HttpTransportOptions.newBuilder());
+    requests = Collections.synchronizedList(new ArrayList<>());
+  }
+
+  @Override
+  public HttpRequestInitializer getHttpRequestInitializer(ServiceOptions<?, ?> serviceOptions) {
+    HttpRequestInitializer delegate = super.getHttpRequestInitializer(serviceOptions);
+    return request -> {
+      requests.add(request);
+      delegate.initialize(request);
+    };
+  }
+
+  public ImmutableList<HttpRequest> getRequests() {
+    return ImmutableList.copyOf(requests);
+  }
+
+  void clear() {
+    requests.clear();
+  }
+
+  void assertQueryParam(String paramName, String expectedValue) {
+    ImmutableList<HttpRequest> requests = getRequests();
+
+    List<String> actual =
+        requests.stream()
+            .map(HttpRequest::getUrl)
+            .distinct() // todo: figure out why requests seem to be recorded twice for blob create
+            .map(u -> (String) u.getFirst(paramName))
+            .collect(Collectors.toList());
+
+    assertThat(actual).isEqualTo(ImmutableList.of(expectedValue));
+  }
+
+  void assertPathParam(String resourceName, String expectedValue) {
+    ImmutableList<HttpRequest> requests = getRequests();
+
+    List<String> actual =
+        requests.stream()
+            .map(HttpRequest::getUrl)
+            .distinct() // todo: figure out why requests seem to be recorded twice for blob create
+            .map(GenericUrl::getRawPath)
+            .map(
+                s -> {
+                  int resourceNameIndex = s.indexOf(resourceName);
+                  if (resourceNameIndex >= 0) {
+                    int valueBegin = resourceNameIndex + resourceName.length() + 1;
+                    int nextSlashIdx = s.indexOf("/", valueBegin);
+
+                    if (nextSlashIdx > valueBegin) {
+                      return s.substring(valueBegin, nextSlashIdx);
+                    } else {
+                      return s.substring(nextSlashIdx + 1);
+                    }
+                  } else {
+                    return null;
+                  }
+                })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+
+    assertThat(actual).isEqualTo(ImmutableList.of(expectedValue));
+  }
+
+  void assertNoContentEncoding() {
+    ImmutableList<HttpRequest> requests = getRequests();
+
+    List<String> actual =
+        requests.stream()
+            .map(HttpRequest::getHeaders)
+            .map(HttpHeaders::getContentType)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+
+    assertThat(actual).isEmpty();
+  }
+
+  void assertEncryptionKeyHeaders(EncryptionKeyTuple tuple) {
+    ImmutableList<HttpRequest> requests = getRequests();
+
+    List<EncryptionKeyTuple> actual =
+        requests.stream()
+            .map(HttpRequest::getHeaders)
+            .map(
+                h ->
+                    new EncryptionKeyTuple(
+                        (String) h.get("x-goog-encryption-algorithm"),
+                        (String) h.get("x-goog-encryption-key"),
+                        (String) h.get("x-goog-encryption-key-sha256")))
+            .collect(Collectors.toList());
+
+    // todo: figure out why requests seem to be recorded twice for blob create
+    assertThat(actual).containsAtLeastElementsIn(ImmutableList.of(tuple));
+  }
+
+  void assertMultipartContentJsonAndText() {
+    List<String> actual =
+        getRequests().stream()
+            .filter(r -> r.getContent() instanceof MultipartContent)
+            .map(r -> (MultipartContent) r.getContent())
+            .flatMap(c -> c.getParts().stream())
+            .map(Part::getContent)
+            .map(HttpContent::getType)
+            .collect(Collectors.toList());
+
+    assertThat(actual).isEqualTo(ImmutableList.of("application/json; charset=UTF-8", "text/plain"));
+  }
+
+  void assertMultipartJsonField(String jsonField, Object expectedValue) {
+    List<Object> collect =
+        getRequests().stream()
+            .filter(r -> r.getContent() instanceof MultipartContent)
+            .map(r -> (MultipartContent) r.getContent())
+            .flatMap(c -> c.getParts().stream())
+            .map(Part::getContent)
+            .filter(content -> "application/json; charset=UTF-8".equals(content.getType()))
+            .filter(c -> c instanceof JsonHttpContent)
+            .map(c -> (JsonHttpContent) c)
+            .map(c -> (GenericJson) c.getData())
+            .map(json -> json.get(jsonField))
+            .collect(Collectors.toList());
+    assertThat(collect).isEqualTo(ImmutableList.of(expectedValue));
+  }
+}


### PR DESCRIPTION
*  add tests for metageneration{Not,}Match(long)
*  add tests for {en,de}cryptionKey({Key,String})
*  add tests for userProject

   * Bucket.BucketSourceOption#userProject is somehow busted, and doesn't work for exists/refresh/delete due to some enum exception

*  add tests for predefined{DefaultObject,}Acl
*  add tests for disableGzipContent()
*  add tests for generation{Not,}Match and doesNotExist
*  add tests for detectContentType
*  add tests for kmsKeyName
*  add tests for projection
*  add tests for requestedPolicyVersion
*  add tests for projectId
*  add tests for list operations
*  add tests for fields(*) options
*  add tests for BlobWriteOption#{md5,crc32c}Match
*  add tests for {meta,}generation{Not,}Match extractors
