### PR TITLE
test: add error handling and retry tests for GapicUnbufferedReadableByteChannel

### DIFF
--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -106,6 +106,10 @@
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-cloud-storage-v2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
       <artifactId>gapic-google-cloud-storage-v2</artifactId>
     </dependency>
 
@@ -249,8 +253,9 @@
               grpc-netty-shaded is a runtime dep, we pull it up to our level to raise its transitive dependencies priority
               that overlap with our pubsub test deps.
               -->
-            <usedDependencies>io.grpc:grpc-netty-shaded,io.grpc:grpc-xds</usedDependencies>
+            <usedDependencies>io.grpc:grpc-xds</usedDependencies>
             <ignoredDependencies>
+              <dependency>io.grpc:grpc-netty-shaded</dependency>
               <!--
               We depend on `net.jqwik:jqwik` which itself has no classes, but depends on each of the other jars.
               In order to not churn on which of the sub apis we happen to be using at this time, we're flagging

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Crc32cValue.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Crc32cValue.java
@@ -49,6 +49,10 @@ abstract class Crc32cValue<Res extends Crc32cValue<Res>> {
 
   public abstract String debugString();
 
+  public boolean eqValue(Crc32cValue<?> other) {
+    return this.getValue() == other.getValue();
+  }
+
   static Crc32cLengthUnknown of(int value) {
     return new Crc32cLengthUnknown(value);
   }
@@ -57,12 +61,8 @@ abstract class Crc32cValue<Res extends Crc32cValue<Res>> {
     return new Crc32cLengthKnown(value, length);
   }
 
-  public static <Res extends Crc32cValue<Res>> Res nullSafeConcat(Res r1, Crc32cLengthKnown r2) {
-    if (r1 == null) {
-      return null;
-    } else {
-      return r1.concat(r2);
-    }
+  static String fmtCrc32cValue(int value1) {
+    return String.format("crc32c{0x%08x}", value1);
   }
 
   static final class Crc32cLengthUnknown extends Crc32cValue<Crc32cLengthUnknown> {
@@ -84,7 +84,7 @@ abstract class Crc32cValue<Res extends Crc32cValue<Res>> {
 
     @Override
     public String toString() {
-      return String.format("crc32c{0x%08x}", value);
+      return Crc32cLengthKnown.fmtCrc32cValue(value);
     }
 
     @Override
@@ -128,7 +128,7 @@ abstract class Crc32cValue<Res extends Crc32cValue<Res>> {
 
     @Override
     public String debugString() {
-      return String.format("crc32c{0x%08x}", value);
+      return fmtCrc32cValue(value);
     }
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicDownloadSessionBuilder.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicDownloadSessionBuilder.java
@@ -37,6 +37,10 @@ final class GapicDownloadSessionBuilder {
     return new GapicDownloadSessionBuilder();
   }
 
+  /**
+   * Any retry capability must be defined within the provided ServerStreamingCallable. The
+   * ultimately produced channel will not do any retries of its own.
+   */
   public ReadableByteChannelSessionBuilder byteChannel(
       ServerStreamingCallable<ReadObjectRequest, ReadObjectResponse> read) {
     return new ReadableByteChannelSessionBuilder(read);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedWritableByteChannel.java
@@ -98,7 +98,7 @@ final class GapicUnbufferedWritableByteChannel<
       long offset = writeCtx.getTotalSentBytes().getAndAdd(contentSize);
       ChecksummedData.Builder checksummedData = ChecksummedData.newBuilder().setContent(b);
       if (crc32c != null) {
-        writeCtx.getCumulativeCrc32c().getAndAccumulate(crc32c, Crc32cValue::nullSafeConcat);
+        writeCtx.getCumulativeCrc32c().getAndAccumulate(crc32c, hasher::nullSafeConcat);
         checksummedData.setCrc32C(crc32c.getValue());
       }
       WriteObjectRequest.Builder builder =

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/FakeServer.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/FakeServer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import com.google.cloud.NoCredentials;
+import com.google.storage.v2.StorageGrpc;
+import com.google.storage.v2.StorageSettings;
+import io.grpc.Server;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
+final class FakeServer implements AutoCloseable {
+
+  private final Server server;
+  private final GrpcStorageOptions grpcStorageOptions;
+
+  FakeServer(Server server, GrpcStorageOptions grpcStorageOptions) {
+    this.server = server;
+    this.grpcStorageOptions = grpcStorageOptions;
+  }
+
+  StorageSettings storageSettings() throws IOException {
+    return grpcStorageOptions.getStorageSettings();
+  }
+
+  @Override
+  public void close() throws InterruptedException {
+    server.shutdownNow().awaitTermination(10, TimeUnit.SECONDS);
+  }
+
+  static FakeServer of(StorageGrpc.StorageImplBase service) throws IOException {
+    InetSocketAddress address = new InetSocketAddress("localhost", 0);
+    Server server = NettyServerBuilder.forAddress(address).addService(service).build();
+    server.start();
+    String endpoint = String.format("%s:%d", address.getHostString(), server.getPort());
+    GrpcStorageOptions grpcStorageOptions =
+        StorageOptions.grpc()
+            .setHost("http://" + endpoint)
+            .setProjectId("test-proj")
+            .setCredentials(NoCredentials.getInstance())
+            .build();
+    return new FakeServer(server, grpcStorageOptions);
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/GapicUnbufferedReadableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/GapicUnbufferedReadableByteChannelTest.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.grpc.GrpcCallContext;
+import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.ApiExceptionFactory;
+import com.google.api.gax.rpc.ErrorDetails;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.cloud.storage.ChannelSession.UnbufferedReadSession;
+import com.google.cloud.storage.UnbufferedReadableByteChannelSession.UnbufferedReadableByteChannel;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.hash.Hashing;
+import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
+import com.google.rpc.DebugInfo;
+import com.google.storage.v2.ChecksummedData;
+import com.google.storage.v2.ContentRange;
+import com.google.storage.v2.Object;
+import com.google.storage.v2.ObjectChecksums;
+import com.google.storage.v2.ReadObjectRequest;
+import com.google.storage.v2.ReadObjectResponse;
+import com.google.storage.v2.StorageClient;
+import com.google.storage.v2.StorageGrpc;
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.Test;
+
+public final class GapicUnbufferedReadableByteChannelTest {
+  private final byte[] bytes = DataGenerator.base64Characters().genBytes(40);
+  private final ByteString data1 = ByteString.copyFrom(bytes, 0, 10);
+  private final ByteString data2 = ByteString.copyFrom(bytes, 10, 10);
+  private final ByteString data3 = ByteString.copyFrom(bytes, 20, 10);
+  private final ByteString data4 = ByteString.copyFrom(bytes, 30, 10);
+
+  private final String objectName = "name";
+  private final Object expectedResult =
+      Object.newBuilder()
+          .setName(objectName)
+          .setGeneration(3L)
+          .setContentType("application/octet-stream")
+          .build();
+
+  private final ReadObjectRequest req1 =
+      ReadObjectRequest.newBuilder().setObject(objectName).setReadOffset(0).build();
+  private final ReadObjectRequest req2 = req1.toBuilder().setReadOffset(20).build();
+  private final ReadObjectResponse resp1 =
+      ReadObjectResponse.newBuilder()
+          .setMetadata(expectedResult)
+          .setContentRange(ContentRange.newBuilder().setStart(0).build())
+          .setObjectChecksums(
+              ObjectChecksums.newBuilder().setCrc32C(Hashing.crc32c().hashBytes(bytes).asInt()))
+          .setChecksummedData(getChecksummedData(data1))
+          .build();
+  private final ReadObjectResponse resp2 =
+      ReadObjectResponse.newBuilder().setChecksummedData(getChecksummedData(data2)).build();
+  private final ReadObjectResponse resp3 =
+      ReadObjectResponse.newBuilder()
+          .setMetadata(expectedResult)
+          .setContentRange(ContentRange.newBuilder().setStart(20).build())
+          .setObjectChecksums(
+              ObjectChecksums.newBuilder().setCrc32C(Hashing.crc32c().hashBytes(bytes).asInt()))
+          .setChecksummedData(getChecksummedData(data3))
+          .build();
+  private final ReadObjectResponse resp4 =
+      ReadObjectResponse.newBuilder().setChecksummedData(getChecksummedData(data4)).build();
+
+  /** Define a Storage service that will always return an error during the first readObject */
+  private final StorageGrpc.StorageImplBase fakeStorage =
+      new StorageGrpc.StorageImplBase() {
+        @Override
+        public void readObject(
+            ReadObjectRequest request, StreamObserver<ReadObjectResponse> responseObserver) {
+          if (request.equals(req1)) {
+            responseObserver.onNext(resp1);
+            responseObserver.onNext(resp2);
+            responseObserver.onError(apiException(Code.DATA_LOSS));
+          } else if (request.equals(req2)) {
+            responseObserver.onNext(resp3);
+            responseObserver.onNext(resp4);
+            responseObserver.onCompleted();
+          } else {
+            responseObserver.onError(apiException(Code.PERMISSION_DENIED));
+          }
+        }
+      };
+
+  @Test
+  public void readRetriesAreProperlyOrdered_readLargerThanMessageSize()
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    try (FakeServer server = FakeServer.of(fakeStorage);
+        StorageClient storageClient = StorageClient.create(server.storageSettings())) {
+
+      UnbufferedReadableByteChannelSession<Object> session =
+          new UnbufferedReadSession<>(
+              ApiFutures.immediateFuture(req1),
+              (start, resultFuture) ->
+                  new GapicUnbufferedReadableByteChannel(
+                      resultFuture,
+                      storageClient
+                          .readObjectCallable()
+                          .withDefaultCallContext(
+                              contextWithRetryForCodes(StatusCode.Code.DATA_LOSS)),
+                      start,
+                      Hasher.noop()));
+      byte[] actualBytes = new byte[40];
+      try (UnbufferedReadableByteChannel c = session.open()) {
+        c.read(ByteBuffer.wrap(actualBytes));
+      }
+      Object actualResult = session.getResult().get(1000, TimeUnit.MILLISECONDS);
+      assertThat(actualResult).isEqualTo(expectedResult);
+      assertThat(actualBytes).isEqualTo(bytes);
+    }
+  }
+
+  @Test
+  public void readRetriesAreProperlyOrdered_readSmallerThanMessageSize()
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    try (FakeServer server = FakeServer.of(fakeStorage);
+        StorageClient storageClient = StorageClient.create(server.storageSettings())) {
+
+      UnbufferedReadableByteChannelSession<Object> session =
+          new UnbufferedReadSession<>(
+              ApiFutures.immediateFuture(req1),
+              (start, resultFuture) ->
+                  new GapicUnbufferedReadableByteChannel(
+                      resultFuture,
+                      storageClient
+                          .readObjectCallable()
+                          .withDefaultCallContext(
+                              contextWithRetryForCodes(StatusCode.Code.DATA_LOSS)),
+                      start,
+                      Hasher.noop()));
+      byte[] actualBytes = new byte[40];
+      List<ByteBuffer> buffers =
+          IntStream.iterate(0, i -> i + 2)
+              .limit(actualBytes.length / 2)
+              .mapToObj(i -> ByteBuffer.wrap(actualBytes, i, 2))
+              .collect(Collectors.toList());
+      try (UnbufferedReadableByteChannel c = session.open()) {
+        for (ByteBuffer buf : buffers) {
+          c.read(buf);
+        }
+      }
+      Object actualResult = session.getResult().get(1000, TimeUnit.MILLISECONDS);
+      assertThat(actualResult).isEqualTo(expectedResult);
+      assertThat(actualBytes).isEqualTo(bytes);
+    }
+  }
+
+  @Test
+  public void ioException_if_generation_changes() throws IOException, InterruptedException {
+    StorageGrpc.StorageImplBase fakeStorage =
+        new StorageGrpc.StorageImplBase() {
+
+          final AtomicInteger invocationCount = new AtomicInteger(0);
+
+          @Override
+          public void readObject(
+              ReadObjectRequest request, StreamObserver<ReadObjectResponse> responseObserver) {
+            int count = invocationCount.getAndIncrement();
+            if (request.equals(req1)) {
+              if (count == 0) {
+                responseObserver.onNext(resp1);
+                responseObserver.onNext(resp2);
+                responseObserver.onError(apiException(Code.DATA_LOSS));
+              }
+            } else if (request.equals(req2)) {
+              ReadObjectResponse.Builder builder = resp3.toBuilder();
+              // increment the generation, as if it had been updated between initial read and retry
+              builder.getMetadataBuilder().setGeneration(expectedResult.getGeneration() + 1);
+              responseObserver.onNext(builder.build());
+              responseObserver.onNext(resp4);
+              responseObserver.onCompleted();
+            } else {
+              responseObserver.onError(apiException(Code.PERMISSION_DENIED));
+            }
+          }
+        };
+
+    try (FakeServer server = FakeServer.of(fakeStorage);
+        StorageClient storageClient = StorageClient.create(server.storageSettings())) {
+
+      UnbufferedReadableByteChannelSession<Object> session =
+          new UnbufferedReadSession<>(
+              ApiFutures.immediateFuture(req1),
+              (start, resultFuture) ->
+                  new GapicUnbufferedReadableByteChannel(
+                      resultFuture,
+                      storageClient
+                          .readObjectCallable()
+                          .withDefaultCallContext(
+                              contextWithRetryForCodes(StatusCode.Code.DATA_LOSS)),
+                      start,
+                      Hasher.noop()));
+      byte[] actualBytes = new byte[40];
+      try (UnbufferedReadableByteChannel c = session.open()) {
+        IOException ioException =
+            assertThrows(IOException.class, () -> c.read(ByteBuffer.wrap(actualBytes)));
+
+        assertThat(ioException).hasMessageThat().containsMatch(".*Generation.*3.*4.*");
+      }
+    }
+  }
+
+  @Test
+  public void ioException_if_crc32c_mismatch_individual_message()
+      throws IOException, InterruptedException {
+    StorageGrpc.StorageImplBase fakeStorage =
+        new StorageGrpc.StorageImplBase() {
+          @Override
+          public void readObject(
+              ReadObjectRequest request, StreamObserver<ReadObjectResponse> responseObserver) {
+            if (request.equals(req1)) {
+              responseObserver.onNext(resp1);
+              ReadObjectResponse.Builder b = resp2.toBuilder();
+              // set a bad checksum value
+              b.getChecksummedDataBuilder().setCrc32C(1);
+              responseObserver.onNext(b.build());
+              responseObserver.onNext(resp3);
+              responseObserver.onNext(resp4);
+              responseObserver.onCompleted();
+            } else {
+              responseObserver.onError(apiException(Code.PERMISSION_DENIED));
+            }
+          }
+        };
+    try (FakeServer server = FakeServer.of(fakeStorage);
+        StorageClient storageClient = StorageClient.create(server.storageSettings())) {
+
+      UnbufferedReadableByteChannelSession<Object> session =
+          new UnbufferedReadSession<>(
+              ApiFutures.immediateFuture(req1),
+              (start, resultFuture) ->
+                  new GapicUnbufferedReadableByteChannel(
+                      resultFuture,
+                      storageClient
+                          .readObjectCallable()
+                          .withDefaultCallContext(
+                              contextWithRetryForCodes(StatusCode.Code.DATA_LOSS)),
+                      start,
+                      Hasher.enabled()));
+      byte[] actualBytes = new byte[40];
+      try (UnbufferedReadableByteChannel c = session.open()) {
+        IOException ioException =
+            assertThrows(IOException.class, () -> c.read(ByteBuffer.wrap(actualBytes)));
+
+        assertThat(ioException).hasMessageThat().contains("Mismatch checksum");
+      }
+    }
+  }
+
+  @Test
+  public void ioException_if_crc32c_mismatch_cumulative() throws IOException, InterruptedException {
+    StorageGrpc.StorageImplBase fakeStorage =
+        new StorageGrpc.StorageImplBase() {
+          @Override
+          public void readObject(
+              ReadObjectRequest request, StreamObserver<ReadObjectResponse> responseObserver) {
+            if (request.equals(req1)) {
+              responseObserver.onNext(resp1);
+              responseObserver.onCompleted();
+            } else {
+              responseObserver.onError(apiException(Code.PERMISSION_DENIED));
+            }
+          }
+        };
+    try (FakeServer server = FakeServer.of(fakeStorage);
+        StorageClient storageClient = StorageClient.create(server.storageSettings())) {
+
+      UnbufferedReadableByteChannelSession<Object> session =
+          new UnbufferedReadSession<>(
+              ApiFutures.immediateFuture(req1),
+              (start, resultFuture) ->
+                  new GapicUnbufferedReadableByteChannel(
+                      resultFuture,
+                      storageClient
+                          .readObjectCallable()
+                          .withDefaultCallContext(
+                              contextWithRetryForCodes(StatusCode.Code.DATA_LOSS)),
+                      start,
+                      Hasher.enabled()));
+      byte[] actualBytes = new byte[40];
+      //noinspection resource
+      UnbufferedReadableByteChannel c = session.open();
+      c.read(ByteBuffer.wrap(actualBytes));
+
+      IOException ioException = assertThrows(IOException.class, c::close);
+      assertThat(ioException).hasMessageThat().contains("Mismatch checksum");
+    }
+  }
+
+  @Test
+  public void overRead_handledProperly() throws IOException, InterruptedException {
+    StorageGrpc.StorageImplBase fakeStorage =
+        new StorageGrpc.StorageImplBase() {
+          @Override
+          public void readObject(
+              ReadObjectRequest request, StreamObserver<ReadObjectResponse> responseObserver) {
+            responseObserver.onNext(resp1);
+            responseObserver.onNext(resp2);
+            responseObserver.onNext(resp3);
+            responseObserver.onNext(resp4);
+            responseObserver.onCompleted();
+          }
+        };
+    try (FakeServer server = FakeServer.of(fakeStorage);
+        StorageClient storageClient = StorageClient.create(server.storageSettings())) {
+
+      UnbufferedReadableByteChannelSession<Object> session =
+          new UnbufferedReadSession<>(
+              ApiFutures.immediateFuture(req1),
+              (start, resultFuture) ->
+                  new GapicUnbufferedReadableByteChannel(
+                      resultFuture,
+                      storageClient
+                          .readObjectCallable()
+                          .withDefaultCallContext(
+                              contextWithRetryForCodes(StatusCode.Code.DATA_LOSS)),
+                      start,
+                      Hasher.enabled()));
+      byte[] actualBytes = new byte[41];
+      //noinspection resource
+      UnbufferedReadableByteChannel c = session.open();
+      ByteBuffer buf = ByteBuffer.wrap(actualBytes);
+      int read1 = c.read(buf);
+      assertThat(read1).isAtLeast(1);
+      int read2 = c.read(buf);
+      assertThat(read2).isEqualTo(-1);
+      assertThrows(ClosedChannelException.class, () -> c.read(buf));
+    }
+  }
+
+  private static ChecksummedData getChecksummedData(ByteString content) {
+    int crc32c = Hashing.crc32c().hashBytes(content.asReadOnlyByteBuffer()).asInt();
+    return ChecksummedData.newBuilder().setContent(content).setCrc32C(crc32c).build();
+  }
+
+  private static ApiException apiException(Code code) {
+    StatusRuntimeException statusRuntimeException = code.toStatus().asRuntimeException();
+    DebugInfo debugInfo =
+        DebugInfo.newBuilder().setDetail("forced failure |~| " + code.name()).build();
+    ErrorDetails errorDetails =
+        ErrorDetails.builder().setRawErrorMessages(ImmutableList.of(Any.pack(debugInfo))).build();
+    return ApiExceptionFactory.createException(
+        statusRuntimeException, GrpcStatusCode.of(code), true, errorDetails);
+  }
+
+  private static GrpcCallContext contextWithRetryForCodes(StatusCode.Code... code) {
+    return GrpcCallContext.createDefault().withRetryableCodes(ImmutableSet.copyOf(code));
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ResultRetryAlgorithmCompatibilityTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ResultRetryAlgorithmCompatibilityTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.gax.retrying.BasicResultRetryAlgorithm;
+import com.google.api.gax.rpc.DataLossException;
+import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import org.junit.Test;
+
+public final class ResultRetryAlgorithmCompatibilityTest {
+  @Test
+  public void validateConversion() {
+    BasicResultRetryAlgorithm<Object> alg =
+        new BasicResultRetryAlgorithm<java.lang.Object>() {
+          @Override
+          public boolean shouldRetry(
+              Throwable previousThrowable, java.lang.Object previousResponse) {
+            return previousThrowable instanceof DataLossException;
+          }
+        };
+    Set<Code> codes = GrpcStorageImpl.resultRetryAlgorithmToCodes(alg);
+
+    assertThat(codes).isEqualTo(ImmutableSet.of(Code.DATA_LOSS));
+  }
+}


### PR DESCRIPTION
### Testing
Add new FakeServer which allows defining an in process grpc storage service rather than trying to fight with mocks.

Add test for GapicUnbufferedReadableByteChannel to verify:
* retries happening at the ServerStream level return sound data
* Generation changing between a resumed read results in an IOException rather than proceeding
* checksum mismatch for an individual ChecksummedData
* checksum mismatch across all cumulative ChecksummedData

#### Refactoring
* Move Crc32cValue#nullSafeConcat into Hasher so that it can be context aware
  whether to actually perform any computation

### Retries

Wire in Automatic Retries for ReadObject operations

The ServerStream provided by gax isn't friendly to decoration for its iterator.
Instead, leverage the built-in stream resumption provided by gax.

In order to provide compatibility with our existing public apis we need to
translate a ResultRetryAlgorithm<?> into a Set<StatusCode.Code> which can
be passed to GrpcCallContext#withRetryableCodes(Set<StatusCode.Code>). To do
this we construct an ApiException for each Code then test against the provided
ResultRetryAlgorithm.

Additionally, a StreamResumptionStrategy must be provided which can construct
and updated request for resume. Unfortunately, at this time this Resumption
Strategy must be set globally at StorageSettings construction time.

One side effect of using gax's built in ServerStream resumption is it only
works with an instance of StorageClient constructed from StorageSettings.
If the StorageClient is constructed from a GrpcStorageStub the retries don't
get wired in. As a consequence, all usage of GrpcStorageStub in GrpcStorageImpl
has been replaced with StorageClient.
