### PR TITLE
test: add first two low level tests for grpc upload

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ByteSizeConstants.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ByteSizeConstants.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+final class ByteSizeConstants {
+
+  static final int _1KiB = 1024;
+  static final int _128KiB = 128 * _1KiB;
+  static final int _256KiB = 256 * _1KiB;
+  static final int _384KiB = 384 * _1KiB;
+  static final int _512KiB = 512 * _1KiB;
+  static final int _1MiB = 1024 * _1KiB;
+  static final int _2MiB = 2 * _1MiB;
+  static final int _15MiB = 15 * _1MiB;
+  static final int _16MiB = 16 * _1MiB;
+  static final int _32MiB = 32 * _1MiB;
+
+  private ByteSizeConstants() {}
+}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcBlobWriteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcBlobWriteChannel.java
@@ -16,8 +16,8 @@
 
 package com.google.cloud.storage;
 
-import static com.google.cloud.storage.GrpcStorageImpl._15MiB;
-import static com.google.cloud.storage.GrpcStorageImpl._256KiB;
+import static com.google.cloud.storage.ByteSizeConstants._15MiB;
+import static com.google.cloud.storage.ByteSizeConstants._256KiB;
 import static com.google.cloud.storage.Utils.todo;
 
 import com.google.api.core.ApiFuture;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.storage;
 
+import static com.google.cloud.storage.ByteSizeConstants._15MiB;
+import static com.google.cloud.storage.ByteSizeConstants._256KiB;
 import static com.google.cloud.storage.Utils.bucketNameCodec;
 import static com.google.cloud.storage.Utils.ifNonNull;
 import static com.google.cloud.storage.Utils.projectNameCodec;
@@ -146,9 +148,6 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
           .map(GrpcStorageImpl::statusCodeFor)
           .map(c -> ApiExceptionFactory.createException(null, c, false))
           .collect(Collectors.toSet());
-
-  static final int _256KiB = 256 * 1024;
-  static final int _15MiB = 15 * 1024 * 1024;
 
   private final StorageClient storageClient;
   private final GrpcConversions codecs;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Hasher.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Hasher.java
@@ -26,10 +26,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 interface Hasher {
 
+  @Nullable
   default Crc32cLengthKnown hash(Supplier<ByteBuffer> b) {
     return hash(b.get());
   }
 
+  @Nullable
   Crc32cLengthKnown hash(ByteBuffer b);
 
   void validate(Crc32cValue<?> expected, Supplier<ByteBuffer> b) throws IOException;
@@ -77,6 +79,7 @@ interface Hasher {
       return Crc32cValue.of(Hashing.crc32c().hashBytes(b).asInt(), remaining);
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Override
     public void validate(Crc32cValue<?> expected, Supplier<ByteBuffer> b) throws IOException {
       Crc32cLengthKnown actual = hash(b);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableWrite.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableWrite.java
@@ -35,12 +35,11 @@ final class ResumableWrite implements WriteObjectRequestBuilderFactory {
   public ResumableWrite(StartResumableWriteRequest req, StartResumableWriteResponse res) {
     this.req = req;
     this.res = res;
-    this.writeRequest =
-        WriteObjectRequest.newBuilder()
-            .setUploadId(res.getUploadId())
-            .setCommonObjectRequestParams(req.getCommonObjectRequestParams())
-            // REVIEW: how does kms come into play here?
-            .build();
+    WriteObjectRequest.Builder b = WriteObjectRequest.newBuilder().setUploadId(res.getUploadId());
+    if (req.hasCommonObjectRequestParams()) {
+      b.setCommonObjectRequestParams(req.getCommonObjectRequestParams());
+    }
+    this.writeRequest = b.build();
   }
 
   public StartResumableWriteRequest getReq() {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageException.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageException.java
@@ -88,7 +88,11 @@ public final class StorageException extends BaseHttpServiceException {
   }
 
   private static StorageException getStorageException(Throwable t) {
-    return new StorageException(UNKNOWN_CODE, t.getMessage(), t.getCause());
+    // unwrap a RetryHelperException if that is what is being translated
+    if (t instanceof RetryHelperException) {
+      return new StorageException(UNKNOWN_CODE, t.getMessage(), t.getCause());
+    }
+    return new StorageException(UNKNOWN_CODE, t.getMessage(), t);
   }
 
   /**

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ChunkSegmenterTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ChunkSegmenterTest.java
@@ -41,8 +41,8 @@ final class ChunkSegmenterTest {
     System.out.println("td = " + td);
 
     ChunkSegment[] data =
-        ChunkSegmenter.segmentBuffers(
-            td.buffers, Hasher.noop(), ByteStringStrategy.noCopy(), td.chunkSize);
+        new ChunkSegmenter(Hasher.noop(), ByteStringStrategy.noCopy(), td.chunkSize)
+            .segmentBuffers(td.buffers);
 
     long dataTotalSize = Arrays.stream(data).mapToLong(d -> d.getB().size()).sum();
     Optional<Crc32cLengthKnown> reduce =

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/GapicUnbufferedWritableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/GapicUnbufferedWritableByteChannelTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.core.SettableApiFuture;
+import com.google.cloud.storage.WriteCtx.WriteObjectRequestBuilderFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ByteString;
+import com.google.storage.v2.Object;
+import com.google.storage.v2.StartResumableWriteRequest;
+import com.google.storage.v2.StartResumableWriteResponse;
+import com.google.storage.v2.StorageClient;
+import com.google.storage.v2.StorageGrpc.StorageImplBase;
+import com.google.storage.v2.WriteObjectRequest;
+import com.google.storage.v2.WriteObjectResponse;
+import com.google.storage.v2.WriteObjectSpec;
+import io.grpc.Status.Code;
+import io.grpc.stub.CallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.junit.Test;
+
+public final class GapicUnbufferedWritableByteChannelTest {
+
+  ChunkSegmenter segmenter = new ChunkSegmenter(Hasher.noop(), ByteStringStrategy.copy(), 10, 5);
+
+  @Test
+  public void directUpload() throws IOException, InterruptedException, ExecutionException {
+    Object obj = Object.newBuilder().setBucket("buck").setName("obj").build();
+    WriteObjectSpec spec = WriteObjectSpec.newBuilder().setResource(obj).build();
+
+    byte[] bytes = DataGenerator.base64Characters().genBytes(40);
+    WriteObjectRequest req1 =
+        WriteObjectRequest.newBuilder()
+            .setWriteObjectSpec(spec)
+            .setChecksummedData(TestUtils.getChecksummedData(ByteString.copyFrom(bytes, 0, 10)))
+            .build();
+    WriteObjectRequest req2 =
+        WriteObjectRequest.newBuilder()
+            .setWriteOffset(10)
+            .setChecksummedData(TestUtils.getChecksummedData(ByteString.copyFrom(bytes, 10, 10)))
+            .build();
+    WriteObjectRequest req3 =
+        WriteObjectRequest.newBuilder()
+            .setWriteOffset(20)
+            .setChecksummedData(TestUtils.getChecksummedData(ByteString.copyFrom(bytes, 20, 10)))
+            .build();
+    WriteObjectRequest req4 =
+        WriteObjectRequest.newBuilder()
+            .setWriteOffset(30)
+            .setChecksummedData(TestUtils.getChecksummedData(ByteString.copyFrom(bytes, 30, 10)))
+            .build();
+    WriteObjectRequest req5 =
+        WriteObjectRequest.newBuilder().setWriteOffset(40).setFinishWrite(true).build();
+
+    WriteObjectResponse resp =
+        WriteObjectResponse.newBuilder().setResource(obj.toBuilder().setSize(40)).build();
+
+    WriteObjectRequest base = WriteObjectRequest.newBuilder().setWriteObjectSpec(spec).build();
+    WriteObjectRequestBuilderFactory reqFactory = base::toBuilder;
+
+    StorageImplBase service =
+        new DirectWriteService(
+            ImmutableMap.of(ImmutableList.of(req1, req2, req3, req4, req5), resp));
+    try (FakeServer fake = FakeServer.of(service);
+        StorageClient sc = StorageClient.create(fake.storageSettings())) {
+      SettableApiFuture<WriteObjectResponse> result = SettableApiFuture.create();
+      try (GapicUnbufferedWritableByteChannel<?> c =
+          new GapicUnbufferedWritableByteChannel<>(
+              result,
+              segmenter,
+              reqFactory,
+              WriteFlushStrategy.fsyncOnClose(sc.writeObjectCallable()))) {
+        c.write(ByteBuffer.wrap(bytes));
+      }
+      assertThat(result.get()).isEqualTo(resp);
+    }
+  }
+
+  @Test
+  public void resumableUpload() throws IOException, InterruptedException, ExecutionException {
+    String uploadId = "upload-id";
+
+    Object obj = Object.newBuilder().setBucket("buck").setName("obj").build();
+    WriteObjectSpec spec = WriteObjectSpec.newBuilder().setResource(obj).build();
+
+    StartResumableWriteRequest startReq =
+        StartResumableWriteRequest.newBuilder().setWriteObjectSpec(spec).build();
+    StartResumableWriteResponse startResp =
+        StartResumableWriteResponse.newBuilder().setUploadId(uploadId).build();
+
+    byte[] bytes = DataGenerator.base64Characters().genBytes(40);
+    WriteObjectRequest req1 =
+        WriteObjectRequest.newBuilder()
+            .setUploadId(uploadId)
+            .setChecksummedData(TestUtils.getChecksummedData(ByteString.copyFrom(bytes, 0, 10)))
+            .build();
+    WriteObjectRequest req2 =
+        WriteObjectRequest.newBuilder()
+            .setUploadId(uploadId)
+            .setWriteOffset(10)
+            .setChecksummedData(TestUtils.getChecksummedData(ByteString.copyFrom(bytes, 10, 10)))
+            .build();
+    WriteObjectRequest req3 =
+        WriteObjectRequest.newBuilder()
+            .setUploadId(uploadId)
+            .setWriteOffset(20)
+            .setChecksummedData(TestUtils.getChecksummedData(ByteString.copyFrom(bytes, 20, 10)))
+            .build();
+    WriteObjectRequest req4 =
+        WriteObjectRequest.newBuilder()
+            .setUploadId(uploadId)
+            .setWriteOffset(30)
+            .setChecksummedData(TestUtils.getChecksummedData(ByteString.copyFrom(bytes, 30, 10)))
+            .build();
+    WriteObjectRequest req5 =
+        WriteObjectRequest.newBuilder()
+            .setUploadId(uploadId)
+            .setWriteOffset(40)
+            .setFinishWrite(true)
+            .build();
+
+    WriteObjectResponse resp1 = WriteObjectResponse.newBuilder().setPersistedSize(10).build();
+    WriteObjectResponse resp2 = WriteObjectResponse.newBuilder().setPersistedSize(20).build();
+    WriteObjectResponse resp3 = WriteObjectResponse.newBuilder().setPersistedSize(30).build();
+    WriteObjectResponse resp4 = WriteObjectResponse.newBuilder().setPersistedSize(40).build();
+    WriteObjectResponse resp5 =
+        WriteObjectResponse.newBuilder().setResource(obj.toBuilder().setSize(40)).build();
+
+    WriteObjectRequestBuilderFactory reqFactory = new ResumableWrite(startReq, startResp);
+
+    ImmutableMap<List<WriteObjectRequest>, WriteObjectResponse> writes =
+        ImmutableMap.<List<WriteObjectRequest>, WriteObjectResponse>builder()
+            .put(ImmutableList.of(req1), resp1)
+            .put(ImmutableList.of(req2), resp2)
+            .put(ImmutableList.of(req3), resp3)
+            .put(ImmutableList.of(req4), resp4)
+            .put(ImmutableList.of(req5), resp5)
+            .build();
+    StorageImplBase service = new DirectWriteService(writes);
+    try (FakeServer fake = FakeServer.of(service);
+        StorageClient sc = StorageClient.create(fake.storageSettings())) {
+      SettableApiFuture<WriteObjectResponse> result = SettableApiFuture.create();
+      try (GapicUnbufferedWritableByteChannel<?> c =
+          new GapicUnbufferedWritableByteChannel<>(
+              result,
+              segmenter,
+              reqFactory,
+              WriteFlushStrategy.fsyncEveryFlush(sc.writeObjectCallable()))) {
+        ImmutableList<ByteBuffer> buffers = TestUtils.subDivide(bytes, 10);
+        for (ByteBuffer buf : buffers) {
+          c.write(buf);
+        }
+      }
+      assertThat(result.get()).isEqualTo(resp5);
+    }
+  }
+
+  private static class DirectWriteService extends StorageImplBase {
+    private final ImmutableMap<List<WriteObjectRequest>, WriteObjectResponse> writes;
+
+    private ImmutableList.Builder<WriteObjectRequest> requests;
+
+    private DirectWriteService(ImmutableMap<List<WriteObjectRequest>, WriteObjectResponse> writes) {
+      this.writes = writes;
+      this.requests = new ImmutableList.Builder<>();
+    }
+
+    @Override
+    public StreamObserver<WriteObjectRequest> writeObject(StreamObserver<WriteObjectResponse> obs) {
+      return new Adapter() {
+        @Override
+        public void onNext(WriteObjectRequest value) {
+          requests.add(value);
+        }
+
+        @Override
+        public void onError(Throwable t) {}
+
+        @Override
+        public void onCompleted() {
+          ImmutableList<WriteObjectRequest> build = requests.build();
+          if (writes.containsKey(build)) {
+            requests = new ImmutableList.Builder<>();
+            obs.onNext(writes.get(build));
+            obs.onCompleted();
+          } else {
+            obs.onError(
+                TestUtils.apiException(Code.PERMISSION_DENIED, "Unexpected request chain."));
+          }
+        }
+      };
+    }
+  }
+
+  private abstract static class Adapter extends CallStreamObserver<WriteObjectRequest> {
+
+    private Adapter() {}
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public void setOnReadyHandler(Runnable onReadyHandler) {}
+
+    @Override
+    public void disableAutoInboundFlowControl() {}
+
+    @Override
+    public void request(int count) {}
+
+    @Override
+    public void setMessageCompression(boolean enable) {}
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/TransportCompatibilityTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/TransportCompatibilityTest.java
@@ -31,12 +31,13 @@ public final class TransportCompatibilityTest {
 
   @Test
   public void verifyUnsupportedMethodsGenerateMeaningfulException() {
-    Storage s =
+    GrpcStorageOptions options =
         StorageOptions.grpc()
             .setProjectId("blank")
             .setCredentials(NoCredentials.getInstance())
-            .build()
-            .getService();
+            .build();
+    @SuppressWarnings("resource")
+    Storage s = new GrpcStorageImpl(options, null);
     ImmutableList<String> messages =
         Stream.<Supplier<?>>of(
                 s::batch,


### PR DESCRIPTION
two new tests that validate correct request packing and response handling when
performing a direct or resumable upload.

### Refactorings

#### ByteSizeConstants
Create a constants class to keep track of the common byte size values used
throughout the library.

#### GapicUnbufferedWritableByteChannel
Reduce the surface area on the constructor, moving Write callable, Hasher,
ByteStringStrategy, etc. out since GapicUnbufferedWritableByteChannel itself
doesn't use them.

Change ChunkSegmenter to no longer be static, instead taking a handle the
Hasher, ByteStringStrategy and maxSegmentSize which are necessary for later
computations of segmentBuffers.

Change FlusherFactory to no longer take the write callable, instead any
dependency is expected to be bound into the state of the factory. Flushers will
now maintain a handle to the write callable when they are constructed.

#### Hasher
Annotate Hasher#hash(*) methods as nullable to ensure the return value is
checked before dereferencing (via intellij warning, and eventually error prone
when we can wire that in).

#### TestUtils#subDivide(byte[], int)
Create utility method to subdivide a byte array into N ByteBuffers, each with a
window over the provided byte[] with a maximum limit of int bytes.
