### PR TITLE
test: add grpc integration tests for simplistic object read/write

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
@@ -825,7 +825,10 @@ final class GrpcConversions {
     if (from.hasCustomerEncryption()) {
       toBuilder.setCustomerEncryption(customerEncryptionCodec.decode(from.getCustomerEncryption()));
     }
-    ifNonNull(from.getStorageClass(), StorageClass::valueOf, toBuilder::setStorageClass);
+    String storageClass = from.getStorageClass();
+    if (!storageClass.isEmpty()) {
+      toBuilder.setStorageClass(StorageClass.valueOf(storageClass));
+    }
     if (from.hasUpdateStorageClassTime()) {
       toBuilder.setTimeStorageClassUpdatedOffsetDateTime(
           timestampCodec.decode(from.getUpdateStorageClassTime()));
@@ -836,7 +839,7 @@ final class GrpcConversions {
     if (from.hasEventBasedHold()) {
       toBuilder.setEventBasedHold(from.getEventBasedHold());
     }
-    ifNonNull(from.getTemporaryHold(), toBuilder::setTemporaryHold);
+    toBuilder.setTemporaryHold(from.getTemporaryHold());
     if (from.hasRetentionExpireTime()) {
       toBuilder.setRetentionExpirationTimeOffsetDateTime(
           timestampCodec.decode(from.getRetentionExpireTime()));

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -381,7 +381,9 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
     GrpcCallContext grpcCallContext =
         opts.grpcMetadataMapper().apply(GrpcCallContext.createDefault());
     GetObjectRequest.Builder builder =
-        GetObjectRequest.newBuilder().setBucket(blob.getBucket()).setObject(blob.getName());
+        GetObjectRequest.newBuilder()
+            .setBucket(bucketNameCodec.encode(blob.getBucket()))
+            .setObject(blob.getName());
     GetObjectRequest req = opts.getObjectsRequest().apply(builder).build();
     return Retrying.run(
         getOptions(),

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BucketFixture.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BucketFixture.java
@@ -18,13 +18,21 @@ package com.google.cloud.storage;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.conformance.retry.CleanupStrategy;
-import com.google.cloud.storage.testing.RemoteStorageHelper;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -94,7 +102,30 @@ public final class BucketFixture implements TestRule {
   private void doCleanup(String bucketName, Storage s) {
     LOGGER.info("Starting bucket cleanup...");
     try {
-      RemoteStorageHelper.forceDelete(s, bucketName, 5, TimeUnit.MINUTES);
+      // TODO: probe bucket existence, a bad test could have deleted the bucket
+      Page<Blob> page1 = s.list(bucketName);
+
+      int availableProcessors = Runtime.getRuntime().availableProcessors();
+      ListeningExecutorService exec =
+          MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(2 * availableProcessors));
+
+      List<ListenableFuture<DeleteResult>> futures =
+          StreamSupport.stream(page1.iterateAll().spliterator(), false)
+              .map(b -> exec.submit(() -> new DeleteResult(b.getName(), b.delete())))
+              .collect(Collectors.toList());
+
+      List<DeleteResult> deleteResults = Futures.allAsList(futures).get(5, TimeUnit.MINUTES);
+      List<DeleteResult> failedDeletes =
+          deleteResults.stream().filter(r -> !r.success).collect(Collectors.toList());
+      failedDeletes.forEach(
+          r -> LOGGER.warning(String.format("Failed to delete object %s/%s", bucketName, r.name)));
+
+      if (failedDeletes.isEmpty()) {
+        s.delete(bucketName);
+      } else {
+        LOGGER.warning("Unable to delete bucket due to previous failed object deletes");
+      }
+      exec.shutdown();
       LOGGER.info("Bucket cleanup complete");
     } catch (Exception e) {
       LOGGER.log(Level.SEVERE, e, () -> "Error during bucket cleanup.");
@@ -125,6 +156,16 @@ public final class BucketFixture implements TestRule {
     public BucketFixture build() {
       return new BucketFixture(
           requireNonNull(handle, "handle must be non null"), bucketNameFmtString, cleanupStrategy);
+    }
+  }
+
+  private static final class DeleteResult {
+    private final String name;
+    private final boolean success;
+
+    DeleteResult(String name, boolean success) {
+      this.name = name;
+      this.success = success;
     }
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
@@ -203,7 +203,7 @@ public final class ITGrpcTest {
   }
 
   @Test
-  public void objectCreate_storage_create() {
+  public void objectWrite_storage_create() {
     BucketInfo bucketInfo = bucketFixture.getBucketInfo();
     BlobInfo info = BlobInfo.newBuilder(bucketInfo, testName.getMethodName()).build();
     byte[] content = "Hello, World!".getBytes(StandardCharsets.UTF_8);
@@ -213,7 +213,7 @@ public final class ITGrpcTest {
   }
 
   @Test
-  public void objectCreate_storage_create_stream() {
+  public void objectWrite_storage_create_stream() {
     BucketInfo bucketInfo = bucketFixture.getBucketInfo();
     BlobInfo info = BlobInfo.newBuilder(bucketInfo, testName.getMethodName()).build();
     byte[] content = "Hello, World!".getBytes(StandardCharsets.UTF_8);
@@ -226,7 +226,7 @@ public final class ITGrpcTest {
   }
 
   @Test
-  public void objectCreate_storage_writer() throws IOException {
+  public void objectWrite_storage_writer() throws IOException {
     BucketInfo bucketInfo = bucketFixture.getBucketInfo();
     BlobInfo info = BlobInfo.newBuilder(bucketInfo, testName.getMethodName()).build();
     byte[] content = "Hello, World!".getBytes(StandardCharsets.UTF_8);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
@@ -20,7 +20,9 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.gax.paging.Page;
 import com.google.cloud.NoCredentials;
+import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketFixture;
 import com.google.cloud.storage.BucketInfo;
@@ -28,6 +30,10 @@ import com.google.cloud.storage.HmacKey;
 import com.google.cloud.storage.HmacKey.HmacKeyMetadata;
 import com.google.cloud.storage.HmacKey.HmacKeyState;
 import com.google.cloud.storage.ServiceAccount;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.cloud.storage.Storage.BlobTargetOption;
+import com.google.cloud.storage.Storage.BlobWriteOption;
 import com.google.cloud.storage.Storage.CreateHmacKeyOption;
 import com.google.cloud.storage.Storage.ListHmacKeysOption;
 import com.google.cloud.storage.StorageFixture;
@@ -36,10 +42,17 @@ import com.google.cloud.storage.conformance.retry.CleanupStrategy;
 import com.google.cloud.storage.conformance.retry.TestBench;
 import com.google.cloud.storage.testing.RemoteStorageHelper;
 import com.google.common.collect.ImmutableList;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 public final class ITGrpcTest {
   @ClassRule(order = 1)
@@ -64,6 +77,8 @@ public final class ITGrpcTest {
           .setHandle(storageFixture::getInstance)
           .build();
 
+  @Rule public final TestName testName = new TestName();
+
   @Test
   public void testCreateBucket() {
     final String bucketName = RemoteStorageHelper.generateBucketName();
@@ -74,13 +89,30 @@ public final class ITGrpcTest {
   @Test
   public void listBlobs() {
     BucketInfo bucketInfo = bucketFixture.getBucketInfo();
-    Page<Blob> list = storageFixture.getInstance().list(bucketInfo.getName());
-    ImmutableList<String> bucketNames =
+    byte[] content = "Hello, World!".getBytes(StandardCharsets.UTF_8);
+    String prefix = testName.getMethodName();
+    List<Blob> blobs =
+        IntStream.rangeClosed(1, 10)
+            .mapToObj(i -> String.format("%s/%02d", prefix, i))
+            .map(n -> BlobInfo.newBuilder(bucketInfo, n).build())
+            .map(
+                info ->
+                    storageFixture
+                        .getInstance()
+                        .create(info, content, BlobTargetOption.doesNotExist()))
+            .collect(ImmutableList.toImmutableList());
+
+    List<String> expected =
+        blobs.stream().map(Blob::getName).collect(ImmutableList.toImmutableList());
+
+    Page<Blob> list =
+        storageFixture.getInstance().list(bucketInfo.getName(), BlobListOption.prefix(prefix));
+    ImmutableList<String> actual =
         StreamSupport.stream(list.iterateAll().spliterator(), false)
             .map(Blob::getName)
             .collect(ImmutableList.toImmutableList());
 
-    assertThat(bucketNames).isEmpty();
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -155,5 +187,54 @@ public final class ITGrpcTest {
     HmacKey hmacKey = storageFixture.getInstance().createHmacKey(serviceAccount);
     storageFixture.getInstance().updateHmacKeyState(hmacKey.getMetadata(), HmacKeyState.INACTIVE);
     storageFixture.getInstance().deleteHmacKey(hmacKey.getMetadata());
+  }
+
+  @Test
+  public void object_writeGetRead() {
+    Storage s = storageFixture.getInstance();
+    BlobInfo info = BlobInfo.newBuilder(bucketFixture.getBucketInfo(), "writeGetRead").build();
+    byte[] content = "hello, world".getBytes(StandardCharsets.UTF_8);
+    s.create(info, content, BlobTargetOption.doesNotExist());
+
+    Blob blob = s.get(info.getBlobId());
+
+    byte[] actualContent = blob.getContent();
+    assertThat(actualContent).isEqualTo(content);
+  }
+
+  @Test
+  public void objectCreate_storage_create() {
+    BucketInfo bucketInfo = bucketFixture.getBucketInfo();
+    BlobInfo info = BlobInfo.newBuilder(bucketInfo, testName.getMethodName()).build();
+    byte[] content = "Hello, World!".getBytes(StandardCharsets.UTF_8);
+    Blob blob = storageFixture.getInstance().create(info, content, BlobTargetOption.doesNotExist());
+    byte[] actual = blob.getContent();
+    assertThat(actual).isEqualTo(content);
+  }
+
+  @Test
+  public void objectCreate_storage_create_stream() {
+    BucketInfo bucketInfo = bucketFixture.getBucketInfo();
+    BlobInfo info = BlobInfo.newBuilder(bucketInfo, testName.getMethodName()).build();
+    byte[] content = "Hello, World!".getBytes(StandardCharsets.UTF_8);
+    Blob blob =
+        storageFixture
+            .getInstance()
+            .create(info, new ByteArrayInputStream(content), BlobWriteOption.doesNotExist());
+    byte[] actual = blob.getContent();
+    assertThat(actual).isEqualTo(content);
+  }
+
+  @Test
+  public void objectCreate_storage_writer() throws IOException {
+    BucketInfo bucketInfo = bucketFixture.getBucketInfo();
+    BlobInfo info = BlobInfo.newBuilder(bucketInfo, testName.getMethodName()).build();
+    byte[] content = "Hello, World!".getBytes(StandardCharsets.UTF_8);
+    try (WriteChannel c =
+        storageFixture.getInstance().writer(info, BlobWriteOption.doesNotExist())) {
+      c.write(ByteBuffer.wrap(content));
+    }
+    byte[] actual = storageFixture.getInstance().readAllBytes(info.getBlobId());
+    assertThat(actual).isEqualTo(content);
   }
 }


### PR DESCRIPTION
Update BucketFixture to provide its own implementation of bulk object delete.
The method in RemoteStorageHelper relies upon batch methods which aren't
supported for grpc.

