### PR TITLE
chore: update retry compatibility to work via StorageException

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BackwardCompatibilityUtils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BackwardCompatibilityUtils.java
@@ -126,12 +126,13 @@ final class BackwardCompatibilityUtils {
       case UNAVAILABLE:
         return 503;
         // 504 Gateway Timeout
+      case DEADLINE_EXCEEDED:
+        return 504;
         // TODO
 
       case ABORTED: // ?
       case CANCELLED: // ?
       case UNKNOWN: // ?
-      case DEADLINE_EXCEEDED: // ?
       case DATA_LOSS: // ?
       default:
         return 0;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -146,10 +146,11 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
    * walking overhead for every Code for every invocation of read, construct the set of exceptions
    * only once and keep in this value.
    */
-  private static final Set<ApiException> CODE_API_EXCEPTIONS =
+  private static final Set<StorageException> CODE_API_EXCEPTIONS =
       Arrays.stream(StatusCode.Code.values())
           .map(GrpcStorageImpl::statusCodeFor)
           .map(c -> ApiExceptionFactory.createException(null, c, false))
+          .map(StorageException::asStorageException)
           .collect(Collectors.toSet());
 
   private final StorageClient storageClient;
@@ -1254,7 +1255,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
   static Set<StatusCode.Code> resultRetryAlgorithmToCodes(ResultRetryAlgorithm<?> alg) {
     return CODE_API_EXCEPTIONS.stream()
         .filter(e -> alg.shouldRetry(e, null))
-        .map(e -> e.getStatusCode().getCode())
+        .map(e -> e.apiExceptionCause.getStatusCode().getCode())
         .collect(Collectors.toSet());
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BackwardCompatibilityUtilsTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BackwardCompatibilityUtilsTest.java
@@ -112,7 +112,7 @@ public final class BackwardCompatibilityUtilsTest {
     expected.put(Code.ABORTED, 0);
     expected.put(Code.CANCELLED, 0);
     expected.put(Code.UNKNOWN, 0);
-    expected.put(Code.DEADLINE_EXCEEDED, 0);
+    expected.put(Code.DEADLINE_EXCEEDED, 504);
     expected.put(Code.DATA_LOSS, 0);
 
     EnumMap<Code, Integer> actual = new EnumMap<>(Code.class);


### PR DESCRIPTION
For grpc retries, we need to do things in terms of StorageException in order to
be compatible with the existing StorageRetryStrategy behaviors which are built
around inspecting json type errors.
