### PR TITLE
chore: update WriteFlushStrategy to inject bucket id

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedWritableByteChannel.java
@@ -57,7 +57,10 @@ final class GapicUnbufferedWritableByteChannel<
 
     this.writeCtx = new WriteCtx<>(requestFactory);
     this.flusher =
-        flusherFactory.newFlusher(writeCtx.getConfirmedBytes()::addAndGet, resultFuture::set);
+        flusherFactory.newFlusher(
+            requestFactory.bucketName(),
+            writeCtx.getConfirmedBytes()::addAndGet,
+            resultFuture::set);
   }
 
   @Override

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableWrite.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableWrite.java
@@ -24,6 +24,7 @@ import com.google.storage.v2.StartResumableWriteResponse;
 import com.google.storage.v2.WriteObjectRequest;
 import java.util.Objects;
 import java.util.function.Function;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class ResumableWrite implements WriteObjectRequestBuilderFactory {
 
@@ -53,6 +54,14 @@ final class ResumableWrite implements WriteObjectRequestBuilderFactory {
   @Override
   public WriteObjectRequest.Builder newBuilder() {
     return writeRequest.toBuilder();
+  }
+
+  @Override
+  public @Nullable String bucketName() {
+    if (req.hasWriteObjectSpec() && req.getWriteObjectSpec().hasResource()) {
+      return req.getWriteObjectSpec().getResource().getBucket();
+    }
+    return null;
   }
 
   @Override

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/WriteCtx.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/WriteCtx.java
@@ -23,6 +23,7 @@ import com.google.cloud.storage.WriteCtx.WriteObjectRequestBuilderFactory;
 import com.google.storage.v2.WriteObjectRequest;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class WriteCtx<RequestFactoryT extends WriteObjectRequestBuilderFactory> {
 
@@ -74,9 +75,11 @@ final class WriteCtx<RequestFactoryT extends WriteObjectRequestBuilderFactory> {
         + '}';
   }
 
-  @FunctionalInterface
   interface WriteObjectRequestBuilderFactory {
     WriteObjectRequest.Builder newBuilder();
+
+    @Nullable
+    String bucketName();
 
     static SimpleWriteObjectRequestBuilderFactory simple(WriteObjectRequest req) {
       return new SimpleWriteObjectRequestBuilderFactory(req);
@@ -94,6 +97,14 @@ final class WriteCtx<RequestFactoryT extends WriteObjectRequestBuilderFactory> {
     @Override
     public WriteObjectRequest.Builder newBuilder() {
       return req.toBuilder();
+    }
+
+    @Override
+    public @Nullable String bucketName() {
+      if (req.hasWriteObjectSpec() && req.getWriteObjectSpec().hasResource()) {
+        return req.getWriteObjectSpec().getResource().getBucket();
+      }
+      return null;
     }
 
     @Override

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/GapicUnbufferedWritableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/GapicUnbufferedWritableByteChannelTest.java
@@ -77,7 +77,7 @@ public final class GapicUnbufferedWritableByteChannelTest {
         WriteObjectResponse.newBuilder().setResource(obj.toBuilder().setSize(40)).build();
 
     WriteObjectRequest base = WriteObjectRequest.newBuilder().setWriteObjectSpec(spec).build();
-    WriteObjectRequestBuilderFactory reqFactory = base::toBuilder;
+    WriteObjectRequestBuilderFactory reqFactory = WriteObjectRequestBuilderFactory.simple(base);
 
     StorageImplBase service =
         new DirectWriteService(

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/WriteFlushStrategyTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/WriteFlushStrategyTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.api.gax.rpc.ClientStreamingCallable;
+import com.google.cloud.storage.WriteFlushStrategy.Flusher;
+import com.google.cloud.storage.WriteFlushStrategy.FlusherFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.storage.v2.WriteObjectRequest;
+import com.google.storage.v2.WriteObjectResponse;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.junit.Test;
+
+public final class WriteFlushStrategyTest {
+  private static final Map<String, List<String>> expectedHeaderNonNullNonEmpty =
+      ImmutableMap.of("x-goog-request-params", ImmutableList.of("bucket=bucket-name"));
+  private static final Map<String, List<String>> expectedHeaderNonNullEmpty = ImmutableMap.of();
+  private static final Map<String, List<String>> expectedHeaderNull = ImmutableMap.of();
+
+  @Test
+  public void bucketNameAddedToXGoogRequestParams_nonNull_nonEmpty_fsyncEveryFlush() {
+    doTest(WriteFlushStrategy::fsyncEveryFlush, "bucket-name", expectedHeaderNonNullNonEmpty);
+  }
+
+  @Test
+  public void bucketNameAddedToXGoogRequestParams_nonNull_nonEmpty_fsyncOnClose() {
+    doTest(WriteFlushStrategy::fsyncOnClose, "bucket-name", expectedHeaderNonNullNonEmpty);
+  }
+
+  @Test
+  public void bucketNameNotAddedToXGoogRequestParams_nonNull_empty_fsyncEveryFlush() {
+    doTest(WriteFlushStrategy::fsyncEveryFlush, "", expectedHeaderNonNullEmpty);
+  }
+
+  @Test
+  public void bucketNameNotAddedToXGoogRequestParams_nonNull_empty_fsyncOnClose() {
+    doTest(WriteFlushStrategy::fsyncOnClose, "", expectedHeaderNonNullEmpty);
+  }
+
+  @Test
+  public void bucketNameNotAddedToXGoogRequestParams_null_fsyncEveryFlush() {
+    doTest(WriteFlushStrategy::fsyncEveryFlush, null, expectedHeaderNull);
+  }
+
+  @Test
+  public void bucketNameNotAddedToXGoogRequestParams_null_fsyncOnClose() {
+    doTest(WriteFlushStrategy::fsyncOnClose, null, expectedHeaderNull);
+  }
+
+  private static void doTest(
+      Function<ClientStreamingCallable<WriteObjectRequest, WriteObjectResponse>, FlusherFactory> ff,
+      String bucketName,
+      Map<String, List<String>> expectedHeader) {
+    AtomicLong c = new AtomicLong(0);
+    AtomicReference<WriteObjectResponse> ref = new AtomicReference<>();
+    AtomicReference<Map<String, List<String>>> actualHeader = new AtomicReference<>();
+    ClientStreamingCallable<WriteObjectRequest, WriteObjectResponse> write =
+        new ClientStreamingCallable<WriteObjectRequest, WriteObjectResponse>() {
+          @Override
+          public ApiStreamObserver<WriteObjectRequest> clientStreamingCall(
+              ApiStreamObserver<WriteObjectResponse> responseObserver, ApiCallContext context) {
+            Map<String, List<String>> extraHeaders = context.getExtraHeaders();
+            actualHeader.compareAndSet(null, extraHeaders);
+            return new ApiStreamObserver<WriteObjectRequest>() {
+              @Override
+              public void onNext(WriteObjectRequest value) {}
+
+              @Override
+              public void onError(Throwable t) {}
+
+              @Override
+              public void onCompleted() {
+                responseObserver.onCompleted();
+              }
+            };
+          }
+        };
+    FlusherFactory factory = ff.apply(write);
+    Flusher flusher = factory.newFlusher(bucketName, c::addAndGet, ref::set);
+    flusher.flush(Collections.emptyList());
+    flusher.close(null);
+    assertThat(actualHeader.get()).isEqualTo(expectedHeader);
+  }
+}


### PR DESCRIPTION
Update WriteFlushStrategy to inject bucket id into x-goog-request-params upon opening the stream.

Fixes [b/238792234](http://b/238792234)