### PR TITLE
test: add new classes to SerializationTest

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -158,7 +158,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
   private final GrpcRetryAlgorithmManager retryAlgorithmManager;
   private final SyntaxDecoders syntaxDecoders;
 
-  @Deprecated private final transient ProjectId defaultProjectId;
+  @Deprecated private final ProjectId defaultProjectId;
 
   GrpcStorageImpl(GrpcStorageOptions options, StorageClient storageClient) {
     super(options);
@@ -173,6 +173,9 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
   public void close() throws Exception {
     try (StorageClient s = storageClient) {
       s.shutdownNow();
+      org.threeten.bp.Duration terminationAwaitDuration =
+          getOptions().getTerminationAwaitDuration();
+      s.awaitTermination(terminationAwaitDuration.toMillis(), TimeUnit.MILLISECONDS);
     }
   }
 
@@ -1026,6 +1029,10 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
   @Override
   public GrpcStorageOptions getOptions() {
     return (GrpcStorageOptions) super.getOptions();
+  }
+
+  boolean isClosed() {
+    return storageClient.isShutdown();
   }
 
   private Blob getBlob(ApiFuture<WriteObjectResponse> result) {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpStorageOptions.java
@@ -33,6 +33,7 @@ import com.google.cloud.storage.spi.v1.HttpStorageRpc;
 import com.google.cloud.storage.spi.v1.StorageRpc;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
+import java.io.Serializable;
 import java.util.Set;
 
 // non-final because of mocking frameworks
@@ -239,7 +240,8 @@ public class HttpStorageOptions extends StorageOptions {
    * @see HttpStorageDefaults#getDefaultServiceFactory()
    */
   @InternalApi
-  public static class HttpStorageFactory implements StorageFactory {
+  public static class HttpStorageFactory implements StorageFactory, Serializable {
+    private static final long serialVersionUID = -509515936479640159L;
 
     /**
      * Internal implementation detail, only public to allow for {@link java.io.Serializable}.
@@ -253,6 +255,7 @@ public class HttpStorageOptions extends StorageOptions {
      * @deprecated instead use {@link HttpStorageDefaults#getDefaultServiceFactory()
      *     HttpStorageOptions.defaults().getDefaultServiceFactory()}
      */
+    // this class needs to be public due to ServiceOptions forName'ing it in it's readObject method
     @InternalApi
     @Deprecated
     @SuppressWarnings("DeprecatedIsStillUsed")
@@ -280,7 +283,8 @@ public class HttpStorageOptions extends StorageOptions {
    * @see HttpStorageDefaults#getDefaultRpcFactory()
    */
   @InternalApi
-  public static class HttpStorageRpcFactory implements StorageRpcFactory {
+  public static class HttpStorageRpcFactory implements StorageRpcFactory, Serializable {
+    private static final long serialVersionUID = -7487671939555953705L;
 
     /**
      * Internal implementation detail, only public to allow for {@link java.io.Serializable}.
@@ -294,6 +298,7 @@ public class HttpStorageOptions extends StorageOptions {
      * @deprecated instead use {@link HttpStorageDefaults#getDefaultRpcFactory()
      *     HttpStorageOptions.defaults().getDefaultRpcFactory()}
      */
+    // this class needs to be public due to ServiceOptions forName'ing it in it's readObject method
     @InternalApi
     @Deprecated
     @SuppressWarnings("DeprecatedIsStillUsed")

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
@@ -3743,6 +3743,10 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
   @TransportCompatibility({Transport.HTTP})
   boolean deleteNotification(String bucket, String notificationId);
 
+  /**
+   * @throws InterruptedException thrown if interrupted while awaiting termination of underlying
+   *     resources
+   */
   @Override
   default void close() throws Exception {}
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITStorageLifecycleTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITStorageLifecycleTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.NoCredentials;
+import com.google.cloud.storage.conformance.retry.TestBench;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * The interaction of {@link com.google.cloud.ServiceOptions} instance caching has differing
+ * behavior depending on whether {@link StorageOptions#grpc()} or {@link StorageOptions#http()} are
+ * used.
+ *
+ * <p>Define some tests to ensue we are correctly integrating with the caching lifecycle
+ */
+// Not in com.google.cloud.storage.it because we're testing package local things
+public final class ITStorageLifecycleTest {
+  @ClassRule(order = 1)
+  public static final TestBench TEST_BENCH =
+      TestBench.newBuilder().setContainerName("lifecycle-test").build();
+
+  @Test
+  public void grpc() throws Exception {
+    GrpcStorageOptions options =
+        StorageOptions.grpc()
+            .setHost(TEST_BENCH.getGRPCBaseUri())
+            .setCredentials(NoCredentials.getInstance())
+            .setProjectId("test-project-id")
+            .build();
+
+    Storage service1 = options.getService();
+    Storage service2 = options.getService();
+
+    // ensure both instances are the same
+    assertThat(service2).isSameInstanceAs(service1);
+
+    // make sure and RPCs can be done
+    List<Bucket> buckets1 =
+        StreamSupport.stream(service1.list().iterateAll().spliterator(), false)
+            .collect(Collectors.toList());
+    assertThat(buckets1).isEmpty();
+    List<Bucket> buckets2 =
+        StreamSupport.stream(service2.list().iterateAll().spliterator(), false)
+            .collect(Collectors.toList());
+    assertThat(buckets2).isEmpty();
+
+    // close the instance
+    service1.close();
+
+    // expect a new instance to be returned
+    Storage service3 = options.getService();
+
+    assertThat(service3).isNotSameInstanceAs(service1);
+    // make sure and RPCs can be done
+    List<Bucket> buckets3 =
+        StreamSupport.stream(service3.list().iterateAll().spliterator(), false)
+            .collect(Collectors.toList());
+    assertThat(buckets3).isEmpty();
+  }
+
+  @Test
+  public void http() throws Exception {
+    HttpStorageOptions options =
+        StorageOptions.http()
+            .setHost(TEST_BENCH.getBaseUri())
+            .setCredentials(NoCredentials.getInstance())
+            .setProjectId("test-project-id")
+            .build();
+
+    Storage service1 = options.getService();
+    Storage service2 = options.getService();
+
+    // ensure both instances are the same
+    assertThat(service2).isSameInstanceAs(service1);
+    // make sure and RPCs can be done
+    List<Bucket> buckets1 =
+        StreamSupport.stream(service1.list().iterateAll().spliterator(), false)
+            .collect(Collectors.toList());
+    assertThat(buckets1).isEmpty();
+    List<Bucket> buckets2 =
+        StreamSupport.stream(service2.list().iterateAll().spliterator(), false)
+            .collect(Collectors.toList());
+    assertThat(buckets2).isEmpty();
+
+    service1.close(); // this should be a no-op for http
+
+    // expect the original instance to still be returned
+    Storage service3 = options.getService();
+
+    assertThat(service3).isSameInstanceAs(service1);
+    // make sure and RPCs can be done
+    List<Bucket> buckets3 =
+        StreamSupport.stream(service3.list().iterateAll().spliterator(), false)
+            .collect(Collectors.toList());
+    assertThat(buckets3).isEmpty();
+  }
+}


### PR DESCRIPTION
* Update SerializationTest lifecycle to account for the fact that instances of
  Storage now have `.close()`
* Add each new UnifiedOpt to the list of serializable things
* Add explicit HttpStorageOptions and GrpcStorageOptions to list of serializable
  things
* Update GrpcStorageOptions to integrate with ServiceOptions caching of service
  instances
* Add new test to ensure proper integration with ServiceOptions caching of service
  instances

