### PR TITLE
fix: Fix bugs discovered by ITBucketLifecycleTest

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
@@ -29,6 +29,7 @@ import com.google.cloud.storage.Acl.Role;
 import com.google.cloud.storage.BlobInfo.CustomerEncryption;
 import com.google.cloud.storage.BucketInfo.CustomPlacementConfig;
 import com.google.cloud.storage.BucketInfo.LifecycleRule;
+import com.google.cloud.storage.BucketInfo.LifecycleRule.AbortIncompleteMPUAction;
 import com.google.cloud.storage.BucketInfo.PublicAccessPrevention;
 import com.google.cloud.storage.Conversions.Codec;
 import com.google.cloud.storage.HmacKey.HmacKeyState;
@@ -588,6 +589,10 @@ final class GrpcConversions {
         lifecycleAction =
             BucketInfo.LifecycleRule.LifecycleAction.newSetStorageClassAction(
                 StorageClass.valueOf(action.getStorageClass()));
+        break;
+      case AbortIncompleteMPUAction.TYPE:
+        lifecycleAction =
+            BucketInfo.LifecycleRule.LifecycleAction.newAbortIncompleteMPUploadAction();
         break;
       default:
         BucketInfo.log.warning(

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -1296,7 +1296,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
   }
 
   private FieldMask updateMaskGenerator(Message message) {
-    //TODO: Filter based on API behavior and not a list
+    // TODO: Filter based on API behavior and not a list
     return FieldMask.newBuilder()
         .addAllPaths(
             message.getAllFields().entrySet().stream()

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -1296,6 +1296,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
   }
 
   private FieldMask updateMaskGenerator(Message message) {
+    //TODO: Filter based on API behavior and not a list
     return FieldMask.newBuilder()
         .addAllPaths(
             message.getAllFields().entrySet().stream()

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -62,6 +62,7 @@ import com.google.cloud.storage.UnifiedOpts.ObjectSourceOpt;
 import com.google.cloud.storage.UnifiedOpts.ObjectTargetOpt;
 import com.google.cloud.storage.UnifiedOpts.Opts;
 import com.google.cloud.storage.UnifiedOpts.ProjectId;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.BaseEncoding;
 import com.google.common.io.ByteStreams;
@@ -458,7 +459,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
     UpdateBucketRequest req =
         opts.updateBucketsRequest()
             .apply(builder)
-            .setUpdateMask(fieldMaskGenerator(bucket))
+            .setUpdateMask(updateMaskGenerator(bucket))
             .build();
 
     return Retrying.run(
@@ -478,7 +479,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
     UpdateObjectRequest req =
         opts.updateObjectsRequest()
             .apply(builder)
-            .setUpdateMask(fieldMaskGenerator(object))
+            .setUpdateMask(updateMaskGenerator(object))
             .build();
     return Retrying.run(
         getOptions(),
@@ -1294,12 +1295,13 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
         .build();
   }
 
-  private FieldMask fieldMaskGenerator(Message message) {
+  private FieldMask updateMaskGenerator(Message message) {
     return FieldMask.newBuilder()
         .addAllPaths(
             message.getAllFields().entrySet().stream()
                 .filter(x -> x.getValue() != null)
                 .map(e -> e.getKey().getName())
+                .filter(f -> updateFields().contains(f))
                 .collect(Collectors.toList()))
         .build();
   }
@@ -1356,5 +1358,23 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
       default:
         throw new IllegalStateException("Unrecognized status code: " + code);
     }
+  }
+
+  private static ImmutableList<String> updateFields() {
+    return ImmutableList.of(
+        "cors",
+        "default_event_based_hold",
+        "retention_policy",
+        "versioning",
+        "billing",
+        "iam_config",
+        "encryption",
+        "lifecycle",
+        "logging",
+        "website",
+        "acl",
+        "default_object_acl",
+        "storage_class",
+        "rpo");
   }
 }


### PR DESCRIPTION
This PR adds the GRPC Client to ITBucketLifecycleTest as well as fixes some bugs that were uncovered by getting this test running.

1. The way we were generating the field mask was not correct for GRPC. GRPC does not allow you to specify immutable fields in the fieldmask. We must filter these values out.
2. Adding AbortMPULifecycle Action to the Lifecycle rules codec.
