### PR TITLE
feat: implement automatic retry for resumable uploads

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedWritableByteChannel.java
@@ -23,6 +23,7 @@ import com.google.cloud.storage.UnbufferedWritableByteChannelSession.UnbufferedW
 import com.google.cloud.storage.WriteCtx.WriteObjectRequestBuilderFactory;
 import com.google.cloud.storage.WriteFlushStrategy.Flusher;
 import com.google.cloud.storage.WriteFlushStrategy.FlusherFactory;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import com.google.storage.v2.ChecksummedData;
 import com.google.storage.v2.ObjectChecksums;
@@ -58,9 +59,7 @@ final class GapicUnbufferedWritableByteChannel<
     this.writeCtx = new WriteCtx<>(requestFactory);
     this.flusher =
         flusherFactory.newFlusher(
-            requestFactory.bucketName(),
-            writeCtx.getConfirmedBytes()::addAndGet,
-            resultFuture::set);
+            requestFactory.bucketName(), writeCtx.getConfirmedBytes()::set, resultFuture::set);
   }
 
   @Override
@@ -156,5 +155,10 @@ final class GapicUnbufferedWritableByteChannel<
       flusher.close(null);
     }
     open = false;
+  }
+
+  @VisibleForTesting
+  WriteCtx<RequestFactoryT> getWriteCtx() {
+    return writeCtx;
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -300,6 +300,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
       session =
           channelSessionBuilder
               .resumable()
+              .withRetryConfig(getOptions(), retryAlgorithmManager.idempotent())
               .buffered(Buffers.allocateAligned(bufferSize, _256KiB))
               .setStartAsync(start)
               .build();
@@ -346,6 +347,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
             .setHasher(Hasher.enabled())
             .setByteStringStrategy(ByteStringStrategy.noCopy())
             .resumable()
+            .withRetryConfig(getOptions(), retryAlgorithmManager.idempotent())
             .buffered(Buffers.allocateAligned(bufferSize, _256KiB))
             .setStartAsync(start)
             .build();
@@ -715,6 +717,8 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
     WriteObjectRequest req = getWriteObjectRequest(blobInfo, opts);
     return new GrpcBlobWriteChannel(
         storageClient.writeObjectCallable(),
+        getOptions(),
+        retryAlgorithmManager.idempotent(),
         () ->
             ResumableMedia.gapic()
                 .write()

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Retrying.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Retrying.java
@@ -19,6 +19,8 @@ package com.google.cloud.storage;
 import static com.google.cloud.RetryHelper.runWithRetries;
 
 import com.google.api.core.ApiClock;
+import com.google.api.core.NanoClock;
+import com.google.api.gax.retrying.BasicResultRetryAlgorithm;
 import com.google.api.gax.retrying.ResultRetryAlgorithm;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.RetryHelper.RetryHelperException;
@@ -95,6 +97,15 @@ final class Retrying {
     }
   }
 
+  static ResultRetryAlgorithm<?> neverRetry() {
+    return new BasicResultRetryAlgorithm<Object>() {
+      @Override
+      public boolean shouldRetry(Throwable previousThrowable, Object previousResponse) {
+        return false;
+      }
+    };
+  }
+
   /**
    * Rather than requiring a full set of {@link StorageOptions} to be passed specify what we
    * actually need and have StorageOptions implement this interface.
@@ -104,5 +115,19 @@ final class Retrying {
     RetrySettings getRetrySettings();
 
     ApiClock getClock();
+
+    static RetryingDependencies attemptOnce() {
+      return new RetryingDependencies() {
+        @Override
+        public RetrySettings getRetrySettings() {
+          return RetrySettings.newBuilder().setMaxAttempts(1).build();
+        }
+
+        @Override
+        public ApiClock getClock() {
+          return NanoClock.getDefaultClock();
+        }
+      };
+    }
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/TestUtils.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/TestUtils.java
@@ -16,13 +16,17 @@
 
 package com.google.cloud.storage;
 
+import com.google.api.core.ApiClock;
+import com.google.api.core.NanoClock;
 import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.ApiExceptionFactory;
 import com.google.api.gax.rpc.ErrorDetails;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.cloud.storage.Crc32cValue.Crc32cLengthKnown;
+import com.google.cloud.storage.Retrying.RetryingDependencies;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Any;
@@ -107,5 +111,19 @@ public final class TestUtils {
           .filter(Buffer::hasRemaining)
           .collect(ImmutableList.toImmutableList());
     }
+  }
+
+  static RetryingDependencies defaultRetryingDeps() {
+    return new RetryingDependencies() {
+      @Override
+      public RetrySettings getRetrySettings() {
+        return StorageOptions.getDefaultRetrySettings();
+      }
+
+      @Override
+      public ApiClock getClock() {
+        return NanoClock.getDefaultClock();
+      }
+    };
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/WriteFlushStrategyTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/WriteFlushStrategyTest.java
@@ -21,6 +21,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.ApiStreamObserver;
 import com.google.api.gax.rpc.ClientStreamingCallable;
+import com.google.cloud.storage.Retrying.RetryingDependencies;
 import com.google.cloud.storage.WriteFlushStrategy.Flusher;
 import com.google.cloud.storage.WriteFlushStrategy.FlusherFactory;
 import com.google.common.collect.ImmutableList;
@@ -43,7 +44,12 @@ public final class WriteFlushStrategyTest {
 
   @Test
   public void bucketNameAddedToXGoogRequestParams_nonNull_nonEmpty_fsyncEveryFlush() {
-    doTest(WriteFlushStrategy::fsyncEveryFlush, "bucket-name", expectedHeaderNonNullNonEmpty);
+    doTest(
+        write ->
+            WriteFlushStrategy.fsyncEveryFlush(
+                write, RetryingDependencies.attemptOnce(), Retrying.neverRetry()),
+        "bucket-name",
+        expectedHeaderNonNullNonEmpty);
   }
 
   @Test
@@ -53,7 +59,12 @@ public final class WriteFlushStrategyTest {
 
   @Test
   public void bucketNameNotAddedToXGoogRequestParams_nonNull_empty_fsyncEveryFlush() {
-    doTest(WriteFlushStrategy::fsyncEveryFlush, "", expectedHeaderNonNullEmpty);
+    doTest(
+        write ->
+            WriteFlushStrategy.fsyncEveryFlush(
+                write, RetryingDependencies.attemptOnce(), Retrying.neverRetry()),
+        "",
+        expectedHeaderNonNullEmpty);
   }
 
   @Test
@@ -63,7 +74,12 @@ public final class WriteFlushStrategyTest {
 
   @Test
   public void bucketNameNotAddedToXGoogRequestParams_null_fsyncEveryFlush() {
-    doTest(WriteFlushStrategy::fsyncEveryFlush, null, expectedHeaderNull);
+    doTest(
+        write ->
+            WriteFlushStrategy.fsyncEveryFlush(
+                write, RetryingDependencies.attemptOnce(), Retrying.neverRetry()),
+        null,
+        expectedHeaderNull);
   }
 
   @Test


### PR DESCRIPTION
Plumb through the necessary items to allow retrying to take place in WriteStrategy.FlushOnEveryFlusher#flush.
Update corresponding builders along with this to pass through the necessary items.

### Refactorings
* Move {Unbuffered,Buffered}{Direct,Resumable}UploadBuilder classes to be nested in their logical "parent builders" to allow closing over fields set at the higher level
* Move GrpcTransformPageDecoratorTest.java#retryingDeps -> TestUtils#defaultRetryingDeps
