### PR TITLE
chore: cleanup outstanding use of todo() method

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicCopyWriter.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicCopyWriter.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.storage;
 
-import static com.google.cloud.storage.Utils.todo;
-
 import com.google.api.gax.retrying.ResultRetryAlgorithm;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.RestorableState;
@@ -86,6 +84,6 @@ final class GapicCopyWriter extends CopyWriter {
 
   @Override
   public RestorableState<CopyWriter> capture() {
-    return todo();
+    return GrpcStorageImpl.throwHttpJsonOnly(CopyWriter.class, "capture");
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcBlobReadChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcBlobReadChannel.java
@@ -17,7 +17,6 @@
 package com.google.cloud.storage;
 
 import static com.google.cloud.storage.StorageV2ProtoUtils.seekReadObjectRequest;
-import static com.google.cloud.storage.Utils.todo;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -94,7 +93,7 @@ final class GrpcBlobReadChannel implements ReadChannel {
 
   @Override
   public RestorableState<ReadChannel> capture() {
-    return todo();
+    return GrpcStorageImpl.throwHttpJsonOnly(ReadChannel.class, "capture");
   }
 
   @Override

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcBlobWriteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcBlobWriteChannel.java
@@ -18,7 +18,6 @@ package com.google.cloud.storage;
 
 import static com.google.cloud.storage.ByteSizeConstants._15MiB;
 import static com.google.cloud.storage.ByteSizeConstants._256KiB;
-import static com.google.cloud.storage.Utils.todo;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.rpc.ClientStreamingCallable;
@@ -66,7 +65,7 @@ final class GrpcBlobWriteChannel implements WriteChannel {
 
   @Override
   public RestorableState<WriteChannel> capture() {
-    return todo();
+    return GrpcStorageImpl.throwHttpJsonOnly(WriteChannel.class, "capture");
   }
 
   @Override

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
@@ -22,7 +22,6 @@ import static com.google.cloud.storage.Utils.ifNonNull;
 import static com.google.cloud.storage.Utils.lift;
 import static com.google.cloud.storage.Utils.projectNameCodec;
 import static com.google.cloud.storage.Utils.toImmutableListOf;
-import static com.google.cloud.storage.Utils.todo;
 
 import com.google.cloud.Binding;
 import com.google.cloud.Condition;
@@ -72,7 +71,6 @@ final class GrpcConversions {
       Codec.of(this::bucketAclEncode, this::bucketAclDecode);
   private final Codec<HmacKey.HmacKeyMetadata, HmacKeyMetadata> hmacKeyMetadataCodec =
       Codec.of(this::hmacKeyMetadataEncode, this::hmacKeyMetadataDecode);
-  private final Codec<?, ?> hmacKeyCodec = Codec.of(Utils::todo, Utils::todo);
   private final Codec<ServiceAccount, com.google.storage.v2.ServiceAccount> serviceAccountCodec =
       Codec.of(this::serviceAccountEncode, this::serviceAccountDecode);
   private final Codec<Cors, Bucket.Cors> corsCodec = Codec.of(this::corsEncode, this::corsDecode);
@@ -91,7 +89,8 @@ final class GrpcConversions {
       Codec.of(this::blobIdEncode, this::blobIdDecode);
   private final Codec<BlobInfo, Object> blobInfoCodec =
       Codec.of(this::blobInfoEncode, this::blobInfoDecode);
-  private final Codec<?, ?> notificationInfoCodec = Codec.of(Utils::todo, Utils::todo);
+  private final Codec<NotificationInfo, com.google.storage.v2.Notification> notificationInfoCodec =
+      Codec.of(this::notificationEncode, this::notificationDecode);
   private final Codec<Policy, com.google.iam.v1.Policy> policyCodec =
       Codec.of(this::policyEncode, this::policyDecode);
   private final Codec<Binding, com.google.iam.v1.Binding> bindingCodec =
@@ -149,10 +148,6 @@ final class GrpcConversions {
     return hmacKeyMetadataCodec;
   }
 
-  Codec<?, ?> hmacKey() {
-    return todo();
-  }
-
   Codec<ServiceAccount, com.google.storage.v2.ServiceAccount> serviceAccount() {
     return serviceAccountCodec;
   }
@@ -189,8 +184,8 @@ final class GrpcConversions {
     return blobInfoCodec;
   }
 
-  Codec<?, ?> notificationInfo() {
-    return todo();
+  Codec<NotificationInfo, com.google.storage.v2.Notification> notificationInfo() {
+    return notificationInfoCodec;
   }
 
   Codec<Policy, com.google.iam.v1.Policy> policyCodec() {
@@ -860,6 +855,14 @@ final class GrpcConversions {
     return toBuilder.build();
   }
 
+  private com.google.storage.v2.Notification notificationEncode(NotificationInfo from) {
+    return todo();
+  }
+
+  private NotificationInfo notificationDecode(com.google.storage.v2.Notification from) {
+    return todo();
+  }
+
   private com.google.iam.v1.Policy policyEncode(Policy from) {
     com.google.iam.v1.Policy.Builder to = com.google.iam.v1.Policy.newBuilder();
     ifNonNull(from.getEtag(), ByteString::copyFromUtf8, to::setEtag);
@@ -922,5 +925,9 @@ final class GrpcConversions {
 
   private String crc32cEncode(int from) {
     return BaseEncoding.base64().encode(Ints.toByteArray(from));
+  }
+
+  private static <T> T todo() {
+    throw new IllegalStateException("Not yet implemented");
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -160,10 +160,10 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
           .map(StorageException::asStorageException)
           .collect(Collectors.toSet());
 
-  private final StorageClient storageClient;
-  private final GrpcConversions codecs;
-  private final GrpcRetryAlgorithmManager retryAlgorithmManager;
-  private final SyntaxDecoders syntaxDecoders;
+  final StorageClient storageClient;
+  final GrpcConversions codecs;
+  final GrpcRetryAlgorithmManager retryAlgorithmManager;
+  final SyntaxDecoders syntaxDecoders;
 
   @Deprecated private final ProjectId defaultProjectId;
 
@@ -1273,15 +1273,19 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
     }
   }
 
-  private <T> T throwHttpJsonOnly(String methodName) {
+  static <T> T throwHttpJsonOnly(String methodName) {
+    return throwHttpJsonOnly(Storage.class, methodName);
+  }
+
+  static <T> T throwHttpJsonOnly(Class<?> clazz, String methodName) {
     String message =
         String.format(
             "%s#%s is only supported for HTTP_JSON transport. Please use StorageOptions.http() to construct a compatible instance.",
-            Storage.class.getName(), methodName);
+            clazz.getName(), methodName);
     throw new UnsupportedOperationException(message);
   }
 
-  private <T> T throwNotYetImplemented(String methodName) {
+  static <T> T throwNotYetImplemented(String methodName) {
     String message =
         String.format(
             "%s#%s is not yet implemented for GRPC transport. Please use StorageOptions.http() to construct a compatible instance in the interim.",

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
@@ -17,7 +17,6 @@
 package com.google.cloud.storage;
 
 import static com.google.cloud.storage.Utils.projectNameCodec;
-import static com.google.cloud.storage.Utils.todo;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.api.gax.grpc.GrpcCallContext;
@@ -1255,11 +1254,6 @@ final class UnifiedOpts {
 
     private ReturnRawInputStream(boolean val) {
       super(StorageRpc.Option.RETURN_RAW_INPUT_STREAM, val);
-    }
-
-    @Override
-    public Mapper<GetObjectRequest.Builder> getObject() {
-      return todo();
     }
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Utils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Utils.java
@@ -211,14 +211,6 @@ final class Utils {
     return l -> l.stream().map(f).collect(ImmutableList.toImmutableList());
   }
 
-  static final <T> T todo() {
-    throw new IllegalStateException("Not yet implemented");
-  }
-
-  static final <T1, T2> T2 todo(T1 t1) {
-    throw new IllegalStateException("Not yet implemented");
-  }
-
   /**
    * Convenience method to resolve the first non-null {@code T} from an array of suppliers.
    *

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
@@ -66,10 +66,6 @@ public final class PackagePrivateMethodWorkarounds {
     };
   }
 
-  public static <T> T todo() {
-    return Utils.todo();
-  }
-
   public static <T> void ifNonNull(@Nullable T t, Consumer<T> c) {
     Utils.ifNonNull(t, c);
   }


### PR DESCRIPTION
Only remaining use is for notification codec, which will be cleaned up at a later point

For `RestorabeState<*> capture()` methods raise an error that they are currently
only supported for HTTP. gRPC channel configuration isn't something that is
Serializable. We'll need to figure out how we'll want to provide a Serializable
thing that can try and capture the boostrapping that takes place.
