### PR TITLE
build(fix): update maven config for dependency enforcement of google-http-client-gson

### DIFF
--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -35,7 +35,6 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-gson</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.api-client</groupId>
@@ -274,6 +273,12 @@
               <dependency>net.jqwik:jqwik-engine</dependency>
               <dependency>net.jqwik:jqwik-time</dependency>
               <dependency>net.jqwik:jqwik-web</dependency>
+              <!--
+              We're only using google-http-client-gson in our tests, however if we scope it to test that will
+              break flatten plugins resolution where google-http-client-gson is needed in order for
+              google-api-client to be able to bootstrap.
+              -->
+              <dependency>com.google.http-client:google-http-client-gson</dependency>
             </ignoredDependencies>
           </configuration>
         </plugin>

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/GapicReadTimeoutTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/GapicReadTimeoutTest.java
@@ -130,7 +130,10 @@ public final class GapicReadTimeoutTest {
         ReadObjectResponse actualResponse2 = iter.next();
         boolean hasNext = iter.hasNext();
         Stopwatch stop = started.stop();
-        assertThat(stop.elapsed(TimeUnit.MILLISECONDS)).isAtLeast(sleepDurationMillis);
+        // reduce our expectation by 1% to allow for the fact that sleep can sometimes be slightly
+        // less than the stated amount.
+        long minimumElapsedTime = sleepDurationMillis - (long) (sleepDurationMillis * 0.01);
+        assertThat(stop.elapsed(TimeUnit.MILLISECONDS)).isAtLeast(minimumElapsedTime);
         assertThat(actualResponse1).isEqualTo(resp1);
         assertThat(actualResponse2).isEqualTo(resp2);
         assertThat(hasNext).isFalse();


### PR DESCRIPTION
In #1615 we started using GsonFactory in some of our tests, as a result dependency enforcement required us to acknowledge the new dependency. Since we were using it in tests, I set the scope to `test`. Setting the scope to `test` actually breaks the transitive dependency resolution performed by the flatten plugin. This results in google-http-client-gson being exclude entirely from the resulting pom and causing downstream consumers to receive a NoClassDefFoundError.

Now, instead of setting the scope to `test` we're explicitly stating that the dependency enforcement plugin should ignore google-http-client-gson.

Related to #1615

