### PR TITLE
deps: test building with newer protobuf version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-bom</artifactId>
+        <version>3.19.5</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
         <version>${google.cloud.shared-dependencies.version}</version>


### PR DESCRIPTION
Testing building this branch with protobuf. Dependency tree:\n```\n[INFO] Scanning for projects...
[INFO] Inspecting build with total of 2 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 2 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] Storage Parent                                                     [pom]
[INFO] Google Cloud Storage                                               [jar]
[INFO] 
[INFO] ------------< com.google.cloud:google-cloud-storage-parent >------------
[INFO] Building Storage Parent 1.113.14-sp.5-SNAPSHOT                     [1/2]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ google-cloud-storage-parent ---
[INFO] com.google.cloud:google-cloud-storage-parent:pom:1.113.14-sp.5-SNAPSHOT
[INFO] 
[INFO] ---------------< com.google.cloud:google-cloud-storage >----------------
[INFO] Building Google Cloud Storage 1.113.14-sp.5-SNAPSHOT               [2/2]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.2:tree (default-cli) @ google-cloud-storage ---
[INFO] com.google.cloud:google-cloud-storage:jar:1.113.14-sp.5-SNAPSHOT
[INFO] +- com.google.guava:guava:jar:30.1-android:compile
[INFO] |  +- com.google.guava:failureaccess:jar:1.0.1:compile
[INFO] |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[INFO] |  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] |  +- org.checkerframework:checker-compat-qual:jar:2.5.5:compile
[INFO] |  +- com.google.errorprone:error_prone_annotations:jar:2.5.1:compile
[INFO] |  \- com.google.j2objc:j2objc-annotations:jar:1.3:compile
[INFO] +- com.google.http-client:google-http-client:jar:1.39.0:compile
[INFO] |  \- io.opencensus:opencensus-contrib-http-util:jar:0.28.0:compile
[INFO] +- com.google.http-client:google-http-client-jackson2:jar:1.39.0:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.12.2:compile
[INFO] +- com.google.api-client:google-api-client:jar:1.31.3:compile
[INFO] |  +- com.google.oauth-client:google-oauth-client:jar:1.31.4:compile
[INFO] |  +- com.google.http-client:google-http-client-gson:jar:1.39.0:compile
[INFO] |  \- com.google.http-client:google-http-client-apache-v2:jar:1.39.0:compile
[INFO] +- com.google.apis:google-api-services-storage:jar:v1-rev20210127-1.31.0:compile
[INFO] +- com.google.code.gson:gson:jar:2.8.9:compile
[INFO] +- com.google.cloud:google-cloud-core:jar:1.94.3:compile
[INFO] |  +- com.google.auto.value:auto-value-annotations:jar:1.7.4:compile
[INFO] |  \- com.google.api.grpc:proto-google-common-protos:jar:2.1.0:compile
[INFO] +- com.google.cloud:google-cloud-core-http:jar:1.94.3:compile
[INFO] |  +- com.google.http-client:google-http-client-appengine:jar:1.39.0:compile
[INFO] |  \- com.google.api:gax-httpjson:jar:0.79.0:compile
[INFO] +- com.google.api:gax:jar:1.62.0:compile
[INFO] +- com.google.auth:google-auth-library-credentials:jar:0.24.1:compile
[INFO] +- com.google.auth:google-auth-library-oauth2-http:jar:0.24.1:compile
[INFO] +- com.google.api:api-common:jar:1.10.1:compile
[INFO] |  \- javax.annotation:javax.annotation-api:jar:1.3.2:compile
[INFO] +- io.opencensus:opencensus-api:jar:0.28.0:compile
[INFO] |  \- io.grpc:grpc-context:jar:1.36.0:compile
[INFO] +- com.google.api.grpc:proto-google-iam-v1:jar:1.0.10:compile
[INFO] +- com.google.protobuf:protobuf-java:jar:3.19.5:compile
[INFO] +- com.google.protobuf:protobuf-java-util:jar:3.19.5:compile
[INFO] +- org.threeten:threetenbp:jar:1.5.0:compile
[INFO] +- junit:junit:jar:4.13.2:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- io.grpc:grpc-api:jar:1.36.0:test
[INFO] |  \- org.codehaus.mojo:animal-sniffer-annotations:jar:1.20:test
[INFO] +- io.grpc:grpc-netty-shaded:jar:1.36.0:test
[INFO] |  \- io.grpc:grpc-core:jar:1.36.0:test
[INFO] |     +- com.google.android:annotations:jar:4.1.1.4:test
[INFO] |     \- io.perfmark:perfmark-api:jar:0.23.0:test
[INFO] +- io.grpc:grpc-auth:jar:1.36.0:test
[INFO] +- io.grpc:grpc-stub:jar:1.36.0:test
[INFO] +- com.google.api.grpc:grpc-google-cloud-kms-v1:jar:0.88.0:test
[INFO] |  +- io.grpc:grpc-protobuf:jar:1.36.0:test
[INFO] |  \- io.grpc:grpc-protobuf-lite:jar:1.36.0:test
[INFO] +- com.google.api.grpc:proto-google-cloud-kms-v1:jar:0.88.0:test
[INFO] +- com.google.api.grpc:grpc-google-iam-v1:jar:1.0.10:test
[INFO] +- com.google.cloud:google-cloud-core:test-jar:tests:1.94.3:test
[INFO] +- com.google.truth:truth:jar:1.0.1:test
[INFO] |  \- com.googlecode.java-diff-utils:diffutils:jar:1.3.0:test
[INFO] +- org.easymock:easymock:jar:3.6:test
[INFO] |  \- org.objenesis:objenesis:jar:2.6:test
[INFO] +- org.mockito:mockito-core:jar:2.28.2:test
[INFO] |  +- net.bytebuddy:byte-buddy:jar:1.9.10:test
[INFO] |  \- net.bytebuddy:byte-buddy-agent:jar:1.9.10:test
[INFO] +- com.google.cloud:google-cloud-conformance-tests:jar:0.0.11:test
[INFO] |  +- com.google.api.grpc:proto-google-cloud-firestore-v1:jar:1.33.0:test
[INFO] |  \- com.google.api.grpc:proto-google-cloud-bigtable-v2:jar:1.11.0:test
[INFO] +- org.apache.httpcomponents:httpclient:jar:4.5.13:test
[INFO] |  +- commons-logging:commons-logging:jar:1.2:test
[INFO] |  \- commons-codec:commons-codec:jar:1.15:test
[INFO] +- org.apache.httpcomponents:httpmime:jar:4.5.13:test
[INFO] \- org.apache.httpcomponents:httpcore:jar:4.4.14:test
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Storage Parent 1.113.14-sp.5-SNAPSHOT:
[INFO] 
[INFO] Storage Parent ..................................... SUCCESS [  0.591 s]
[INFO] Google Cloud Storage ............................... SUCCESS [  0.230 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.601 s
[INFO] Finished at: 2022-09-21T17:33:51-04:00
[INFO] ------------------------------------------------------------------------\n```