### PR TITLE
chore: wire automatic retries into direct uploads for GrpcStorageImpl

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ByteSizeConstants.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ByteSizeConstants.java
@@ -25,7 +25,6 @@ final class ByteSizeConstants {
   static final int _512KiB = 512 * _1KiB;
   static final int _1MiB = 1024 * _1KiB;
   static final int _2MiB = 2 * _1MiB;
-  static final int _15MiB = 15 * _1MiB;
   static final int _16MiB = 16 * _1MiB;
   static final int _32MiB = 32 * _1MiB;
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUploadSessionBuilder.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUploadSessionBuilder.java
@@ -42,11 +42,14 @@ final class GapicUploadSessionBuilder {
   ApiFuture<ResumableWrite> resumableWrite(
       UnaryCallable<StartResumableWriteRequest, StartResumableWriteResponse> x,
       WriteObjectRequest writeObjectRequest) {
-    StartResumableWriteRequest req =
-        StartResumableWriteRequest.newBuilder()
-            .setCommonObjectRequestParams(writeObjectRequest.getCommonObjectRequestParams())
-            .setWriteObjectSpec(writeObjectRequest.getWriteObjectSpec())
-            .build();
+    StartResumableWriteRequest.Builder b = StartResumableWriteRequest.newBuilder();
+    if (writeObjectRequest.hasWriteObjectSpec()) {
+      b.setWriteObjectSpec(writeObjectRequest.getWriteObjectSpec());
+    }
+    if (writeObjectRequest.hasCommonObjectRequestParams()) {
+      b.setCommonObjectRequestParams(writeObjectRequest.getCommonObjectRequestParams());
+    }
+    StartResumableWriteRequest req = b.build();
     return ApiFutures.transform(
         x.futureCall(req), (resp) -> new ResumableWrite(req, resp), MoreExecutors.directExecutor());
   }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcBlobWriteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcBlobWriteChannel.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.storage;
 
-import static com.google.cloud.storage.ByteSizeConstants._15MiB;
+import static com.google.cloud.storage.ByteSizeConstants._16MiB;
 import static com.google.cloud.storage.ByteSizeConstants._256KiB;
 
 import com.google.api.core.ApiFuture;
@@ -38,7 +38,7 @@ final class GrpcBlobWriteChannel implements WriteChannel {
 
   private final LazyWriteChannel lazyWriteChannel;
 
-  private int chunkSize = _15MiB;
+  private int chunkSize = _16MiB;
 
   GrpcBlobWriteChannel(
       ClientStreamingCallable<WriteObjectRequest, WriteObjectResponse> write,

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/GapicUnbufferedWritableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/GapicUnbufferedWritableByteChannelTest.java
@@ -247,7 +247,7 @@ public final class GapicUnbufferedWritableByteChannelTest {
                   new BasicResultRetryAlgorithm<Object>() {
                     @Override
                     public boolean shouldRetry(Throwable t, Object ignore) {
-                      return t instanceof DataLossException;
+                      return TestUtils.findThrowable(DataLossException.class, t) != null;
                     }
                   }))) {
         writeCtx = c.getWriteCtx();
@@ -275,18 +275,18 @@ public final class GapicUnbufferedWritableByteChannelTest {
     assertThat(writeCtx.getConfirmedBytes().get()).isEqualTo(40);
   }
 
-  private static class DirectWriteService extends StorageImplBase {
+  static class DirectWriteService extends StorageImplBase {
     private final BiConsumer<StreamObserver<WriteObjectResponse>, List<WriteObjectRequest>> c;
 
     private ImmutableList.Builder<WriteObjectRequest> requests;
 
-    private DirectWriteService(
+    DirectWriteService(
         BiConsumer<StreamObserver<WriteObjectResponse>, List<WriteObjectRequest>> c) {
       this.c = c;
       this.requests = new ImmutableList.Builder<>();
     }
 
-    private DirectWriteService(ImmutableMap<List<WriteObjectRequest>, WriteObjectResponse> writes) {
+    DirectWriteService(ImmutableMap<List<WriteObjectRequest>, WriteObjectResponse> writes) {
       this(
           (obs, build) -> {
             if (writes.containsKey(build)) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/GrpcStorageImplUploadRetryTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/GrpcStorageImplUploadRetryTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.cloud.storage.ByteSizeConstants._2MiB;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.storage.GapicUnbufferedWritableByteChannelTest.DirectWriteService;
+import com.google.cloud.storage.Storage.BlobTargetOption;
+import com.google.cloud.storage.Storage.BlobWriteOption;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import com.google.storage.v2.ChecksummedData;
+import com.google.storage.v2.Object;
+import com.google.storage.v2.ObjectChecksums;
+import com.google.storage.v2.StartResumableWriteRequest;
+import com.google.storage.v2.StartResumableWriteResponse;
+import com.google.storage.v2.WriteObjectRequest;
+import com.google.storage.v2.WriteObjectResponse;
+import com.google.storage.v2.WriteObjectSpec;
+import io.grpc.Status.Code;
+import io.grpc.stub.StreamObserver;
+import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Verify some simplistic retries can take place and that we're constructing {@link
+ * WriteObjectRequest}s as expected.
+ */
+public final class GrpcStorageImplUploadRetryTest {
+  private static final int objectContentSize = 64;
+  private static final byte[] bytes = DataGenerator.base64Characters().genBytes(objectContentSize);
+
+  @Rule public final TemporaryFolder tmpDir = new TemporaryFolder();
+
+  private Path baseDir;
+
+  @Before
+  public void setUp() throws Exception {
+    baseDir = tmpDir.getRoot().toPath();
+  }
+
+  @Test
+  public void create_bytes() throws Exception {
+    Direct.FakeService service = Direct.FakeService.create();
+
+    try (FakeServer server = FakeServer.of(service);
+        Storage s = server.getGrpcStorageOptions().getService()) {
+      BlobInfo info = BlobInfo.newBuilder("buck", "obj").build();
+      s.create(info, bytes, BlobTargetOption.doesNotExist());
+    }
+
+    assertThat(service.returnError.get()).isFalse();
+  }
+
+  @Test
+  public void create_inputStream() throws Exception {
+    Resumable.FakeService service = Resumable.FakeService.create();
+    try (TmpFile tmpFile = DataGenerator.base64Characters().tempFile(baseDir, objectContentSize);
+        FakeServer server = FakeServer.of(service);
+        Storage s = server.getGrpcStorageOptions().getService();
+        InputStream in = Channels.newInputStream(tmpFile.reader())) {
+      BlobInfo info = BlobInfo.newBuilder("buck", "obj").build();
+      s.create(info, in, BlobWriteOption.doesNotExist());
+    }
+
+    assertThat(service.returnError.get()).isFalse();
+  }
+
+  @Test
+  public void createFrom_path_smallerThanBufferSize() throws Exception {
+    Direct.FakeService service = Direct.FakeService.create();
+
+    try (TmpFile tmpFile = DataGenerator.base64Characters().tempFile(baseDir, objectContentSize);
+        FakeServer server = FakeServer.of(service);
+        Storage s = server.getGrpcStorageOptions().getService()) {
+      BlobInfo info = BlobInfo.newBuilder("buck", "obj").build();
+      s.createFrom(info, tmpFile.getPath(), _2MiB, BlobWriteOption.doesNotExist());
+    }
+
+    assertThat(service.returnError.get()).isFalse();
+  }
+
+  @Test
+  public void createFrom_path_largerThanBufferSize() throws Exception {
+    Resumable.FakeService service = Resumable.FakeService.create();
+    try (TmpFile tmpFile = DataGenerator.base64Characters().tempFile(baseDir, objectContentSize);
+        FakeServer server = FakeServer.of(service);
+        Storage s = server.getGrpcStorageOptions().getService()) {
+      BlobInfo info = BlobInfo.newBuilder("buck", "obj").build();
+      s.createFrom(info, tmpFile.getPath(), 16, BlobWriteOption.doesNotExist());
+    }
+
+    assertThat(service.returnError.get()).isFalse();
+  }
+
+  @Test
+  public void createFrom_inputStream() throws Exception {
+    Resumable.FakeService service = Resumable.FakeService.create();
+    try (TmpFile tmpFile = DataGenerator.base64Characters().tempFile(baseDir, objectContentSize);
+        FakeServer server = FakeServer.of(service);
+        Storage s = server.getGrpcStorageOptions().getService();
+        InputStream in = Channels.newInputStream(tmpFile.reader())) {
+      BlobInfo info = BlobInfo.newBuilder("buck", "obj").build();
+      s.createFrom(info, in, BlobWriteOption.doesNotExist());
+    }
+
+    assertThat(service.returnError.get()).isFalse();
+  }
+
+  private static final class Direct {
+    private static final Object obj =
+        Object.newBuilder().setBucket("projects/_/buckets/buck").setName("obj").build();
+    private static final WriteObjectSpec spec =
+        WriteObjectSpec.newBuilder().setResource(obj).setIfGenerationMatch(0).build();
+
+    private static final ChecksummedData checksummedData =
+        TestUtils.getChecksummedData(ByteString.copyFrom(bytes), Hasher.enabled());
+    private static final WriteObjectRequest req1 =
+        WriteObjectRequest.newBuilder()
+            .setWriteObjectSpec(spec)
+            .setChecksummedData(checksummedData)
+            .setObjectChecksums(ObjectChecksums.newBuilder().setCrc32C(checksummedData.getCrc32C()))
+            .setFinishWrite(true)
+            .build();
+    private static final WriteObjectResponse resp1 =
+        WriteObjectResponse.newBuilder()
+            .setResource(obj.toBuilder().setSize(objectContentSize))
+            .build();
+
+    private static final class FakeService extends DirectWriteService {
+      private final AtomicBoolean returnError;
+
+      private FakeService(AtomicBoolean returnError) {
+        super(
+            (obs, reqs) -> {
+              if (reqs.equals(ImmutableList.of(req1))) {
+                if (returnError.get()) {
+                  returnError.compareAndSet(true, false);
+                  obs.onError(TestUtils.apiException(Code.INTERNAL, "should retry"));
+                } else {
+                  obs.onNext(resp1);
+                  obs.onCompleted();
+                }
+              } else {
+                obs.onError(
+                    TestUtils.apiException(Code.PERMISSION_DENIED, "Unexpected request chain."));
+              }
+            });
+        this.returnError = returnError;
+      }
+
+      // a bit of constructor lifecycle hackery to appease the compiler
+      // Even though the thing past to super() is a lazy function, the closing over of the outer
+      // fields happens earlier than they are available. To side step this fact, we provide the
+      // AtomicBoolean as a constructor argument which can be closed over without issue, and then
+      // bind it to the class field after super().
+      static Direct.FakeService create() {
+        return new Direct.FakeService(new AtomicBoolean(true));
+      }
+    }
+  }
+
+  private static final class Resumable {
+
+    private static final String uploadId = "upload-id";
+
+    private static final Object obj =
+        Object.newBuilder().setBucket("projects/_/buckets/buck").setName("obj").build();
+    private static final WriteObjectSpec spec =
+        WriteObjectSpec.newBuilder().setResource(obj).setIfGenerationMatch(0).build();
+
+    private static final StartResumableWriteRequest startReq =
+        StartResumableWriteRequest.newBuilder().setWriteObjectSpec(spec).build();
+    private static final StartResumableWriteResponse startResp =
+        StartResumableWriteResponse.newBuilder().setUploadId(uploadId).build();
+
+    private static final ChecksummedData checksummedData =
+        TestUtils.getChecksummedData(ByteString.copyFrom(bytes), Hasher.enabled());
+    private static final WriteObjectRequest req1 =
+        WriteObjectRequest.newBuilder()
+            .setUploadId(uploadId)
+            .setChecksummedData(checksummedData)
+            .setObjectChecksums(ObjectChecksums.newBuilder().setCrc32C(checksummedData.getCrc32C()))
+            .setFinishWrite(true)
+            .build();
+    private static final WriteObjectResponse resp1 =
+        WriteObjectResponse.newBuilder()
+            .setResource(obj.toBuilder().setSize(objectContentSize))
+            .build();
+
+    private static final class FakeService extends DirectWriteService {
+      private final AtomicBoolean returnError;
+
+      private FakeService(AtomicBoolean returnError) {
+        super(
+            (obs, reqs) -> {
+              if (reqs.equals(ImmutableList.of(req1))) {
+                if (returnError.get()) {
+                  returnError.compareAndSet(true, false);
+                  obs.onError(TestUtils.apiException(Code.INTERNAL, "should retry"));
+                } else {
+                  obs.onNext(resp1);
+                  obs.onCompleted();
+                }
+              } else {
+                obs.onError(
+                    TestUtils.apiException(Code.PERMISSION_DENIED, "Unexpected request chain."));
+              }
+            });
+        this.returnError = returnError;
+      }
+
+      @Override
+      public void startResumableWrite(
+          StartResumableWriteRequest request, StreamObserver<StartResumableWriteResponse> obs) {
+        if (request.equals(startReq)) {
+          obs.onNext(startResp);
+          obs.onCompleted();
+        } else {
+          obs.onError(TestUtils.apiException(Code.PERMISSION_DENIED, "Unexpected request chain."));
+        }
+      }
+
+      // a bit of constructor lifecycle hackery to appease the compiler
+      // Even though the thing past to super() is a lazy function, the closing over of the outer
+      // fields happens earlier than they are available. To side step this fact, we provide the
+      // AtomicBoolean as a constructor argument which can be closed over without issue, and then
+      // bind it to the class field after super().
+      static FakeService create() {
+        return new FakeService(new AtomicBoolean(true));
+      }
+    }
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/GrpcStorageImplUploadRetryTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/GrpcStorageImplUploadRetryTest.java
@@ -48,6 +48,7 @@ import org.junit.rules.TemporaryFolder;
  * WriteObjectRequest}s as expected.
  */
 public final class GrpcStorageImplUploadRetryTest {
+  private static final String FORMATTED_BUCKET_NAME = "projects/_/buckets/buck";
   private static final int objectContentSize = 64;
   private static final byte[] bytes = DataGenerator.base64Characters().genBytes(objectContentSize);
 
@@ -130,7 +131,7 @@ public final class GrpcStorageImplUploadRetryTest {
 
   private static final class Direct {
     private static final Object obj =
-        Object.newBuilder().setBucket("projects/_/buckets/buck").setName("obj").build();
+        Object.newBuilder().setBucket(FORMATTED_BUCKET_NAME).setName("obj").build();
     private static final WriteObjectSpec spec =
         WriteObjectSpec.newBuilder().setResource(obj).setIfGenerationMatch(0).build();
 
@@ -186,7 +187,7 @@ public final class GrpcStorageImplUploadRetryTest {
     private static final String uploadId = "upload-id";
 
     private static final Object obj =
-        Object.newBuilder().setBucket("projects/_/buckets/buck").setName("obj").build();
+        Object.newBuilder().setBucket(FORMATTED_BUCKET_NAME).setName("obj").build();
     private static final WriteObjectSpec spec =
         WriteObjectSpec.newBuilder().setResource(obj).setIfGenerationMatch(0).build();
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/GrpcTransformPageDecoratorTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/GrpcTransformPageDecoratorTest.java
@@ -272,7 +272,7 @@ public class GrpcTransformPageDecoratorTest {
     public boolean shouldRetry(Throwable prevThrowable, Object prevResponse)
         throws CancellationException {
       shouldRetryCallCount.incrementAndGet();
-      return prevThrowable instanceof ShouldRetryException;
+      return TestUtils.findThrowable(ShouldRetryException.class, prevThrowable) != null;
     }
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/TestUtils.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/TestUtils.java
@@ -44,6 +44,7 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public final class TestUtils {
 
@@ -125,5 +126,25 @@ public final class TestUtils {
         return NanoClock.getDefaultClock();
       }
     };
+  }
+
+  /**
+   * Search {@code t} for an instance of {@code T} either directly or via a cause
+   *
+   * @return The found instance of T or null if not found.
+   */
+  @Nullable
+  public static <T extends Throwable> T findThrowable(Class<T> c, Throwable t) {
+    T found = null;
+    Throwable tmp = t;
+    while (tmp != null) {
+      if (c.isInstance(tmp)) {
+        found = c.cast(tmp);
+        break;
+      } else {
+        tmp = tmp.getCause();
+      }
+    }
+    return found;
   }
 }


### PR DESCRIPTION
* com.google.cloud.storage.GrpcStorageImpl.create(com.google.cloud.storage.BlobInfo, byte[], int, int, com.google.cloud.storage.Storage.BlobTargetOption...)
* com.google.cloud.storage.GrpcStorageImpl.createFrom(com.google.cloud.storage.BlobInfo, java.nio.file.Path, int, com.google.cloud.storage.Storage.BlobWriteOption...)

Set default chunkSize to 16MiB instead of 15MiB. While 15MiB is evenly divisible by 256KiB, 16MiB is also evenly divisible by 2MiB the max number of bytes that can be provided in a WriteObjectRequest.

