### PR TITLE
fix: treat writing to a resumable session as idempotent

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpRetryAlgorithmManager.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpRetryAlgorithmManager.java
@@ -235,9 +235,9 @@ final class HttpRetryAlgorithmManager implements Serializable {
 
   public ResultRetryAlgorithm<?> getForResumableUploadSessionWrite(
       Map<StorageRpc.Option, ?> optionsMap) {
-    return optionsMap.containsKey(StorageRpc.Option.IF_GENERATION_MATCH)
-        ? retryStrategy.getIdempotentHandler()
-        : retryStrategy.getNonidempotentHandler();
+    // writing to a resumable upload session is always idempotent once it's active
+    // even if the start of the session wasn't idempotent our incremental writes can be.
+    return retryStrategy.getIdempotentHandler();
   }
 
   public ResultRetryAlgorithm<?> getForServiceAccountGet(String pb) {


### PR DESCRIPTION
Once a resumable session has been created writing to it can be treated as idempotent as finalization of the session is what will again validate any preconditions provided when starting the session. Update our handling to enable automatic retries for session writes.