### PR TITLE
feat: wire through read_mask for GrpcStorageImpl methods related to Blob and Bucket

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Blob.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Blob.java
@@ -18,6 +18,7 @@ package com.google.cloud.storage;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.api.core.BetaApi;
 import com.google.auth.ServiceAccountSigner;
 import com.google.auth.ServiceAccountSigner.SigningException;
 import com.google.cloud.ReadChannel;
@@ -475,8 +476,7 @@ public class Blob extends BlobInfo {
     }
 
     @Override
-    BlobInfo.Builder setRetentionExpirationTimeOffsetDateTime(
-        OffsetDateTime retentionExpirationTime) {
+    Builder setRetentionExpirationTimeOffsetDateTime(OffsetDateTime retentionExpirationTime) {
       infoBuilder.setRetentionExpirationTimeOffsetDateTime(retentionExpirationTime);
       return this;
     }
@@ -484,6 +484,191 @@ public class Blob extends BlobInfo {
     @Override
     public Blob build() {
       return new Blob(storage, infoBuilder);
+    }
+
+    @Override
+    BlobId getBlobId() {
+      return infoBuilder.getBlobId();
+    }
+
+    @Override
+    Builder clearBlobId() {
+      infoBuilder.clearBlobId();
+      return this;
+    }
+
+    @Override
+    Builder clearGeneratedId() {
+      infoBuilder.clearGeneratedId();
+      return this;
+    }
+
+    @Override
+    Builder clearContentType() {
+      infoBuilder.clearContentType();
+      return this;
+    }
+
+    @Override
+    Builder clearContentEncoding() {
+      infoBuilder.clearContentEncoding();
+      return this;
+    }
+
+    @Override
+    Builder clearContentDisposition() {
+      infoBuilder.clearContentDisposition();
+      return this;
+    }
+
+    @Override
+    Builder clearContentLanguage() {
+      infoBuilder.clearContentLanguage();
+      return this;
+    }
+
+    @Override
+    Builder clearComponentCount() {
+      infoBuilder.clearComponentCount();
+      return this;
+    }
+
+    @Override
+    Builder clearCacheControl() {
+      infoBuilder.clearCacheControl();
+      return this;
+    }
+
+    @Override
+    Builder clearAcl() {
+      infoBuilder.clearAcl();
+      return this;
+    }
+
+    @Override
+    Builder clearOwner() {
+      infoBuilder.clearOwner();
+      return this;
+    }
+
+    @Override
+    Builder clearSize() {
+      infoBuilder.clearSize();
+      return this;
+    }
+
+    @Override
+    Builder clearEtag() {
+      infoBuilder.clearEtag();
+      return this;
+    }
+
+    @Override
+    Builder clearSelfLink() {
+      infoBuilder.clearSelfLink();
+      return this;
+    }
+
+    @Override
+    Builder clearMd5() {
+      infoBuilder.clearMd5();
+      return this;
+    }
+
+    @Override
+    Builder clearCrc32c() {
+      infoBuilder.clearCrc32c();
+      return this;
+    }
+
+    @Override
+    Builder clearCustomTime() {
+      infoBuilder.clearCustomTime();
+      return this;
+    }
+
+    @Override
+    Builder clearMediaLink() {
+      infoBuilder.clearMediaLink();
+      return this;
+    }
+
+    @Override
+    Builder clearMetadata() {
+      infoBuilder.clearMetadata();
+      return this;
+    }
+
+    @Override
+    Builder clearMetageneration() {
+      infoBuilder.clearMetageneration();
+      return this;
+    }
+
+    @Override
+    Builder clearDeleteTime() {
+      infoBuilder.clearDeleteTime();
+      return this;
+    }
+
+    @Override
+    Builder clearUpdateTime() {
+      infoBuilder.clearUpdateTime();
+      return this;
+    }
+
+    @Override
+    Builder clearCreateTime() {
+      infoBuilder.clearCreateTime();
+      return this;
+    }
+
+    @Override
+    Builder clearIsDirectory() {
+      infoBuilder.clearIsDirectory();
+      return this;
+    }
+
+    @Override
+    Builder clearCustomerEncryption() {
+      infoBuilder.clearCustomerEncryption();
+      return this;
+    }
+
+    @Override
+    Builder clearStorageClass() {
+      infoBuilder.clearStorageClass();
+      return this;
+    }
+
+    @Override
+    Builder clearTimeStorageClassUpdated() {
+      infoBuilder.clearTimeStorageClassUpdated();
+      return this;
+    }
+
+    @Override
+    Builder clearKmsKeyName() {
+      infoBuilder.clearKmsKeyName();
+      return this;
+    }
+
+    @Override
+    Builder clearEventBasedHold() {
+      infoBuilder.clearEventBasedHold();
+      return this;
+    }
+
+    @Override
+    Builder clearTemporaryHold() {
+      infoBuilder.clearTemporaryHold();
+      return this;
+    }
+
+    @Override
+    Builder clearRetentionExpirationTime() {
+      infoBuilder.clearRetentionExpirationTime();
+      return this;
     }
   }
 
@@ -975,6 +1160,12 @@ public class Blob extends BlobInfo {
   @Override
   public final int hashCode() {
     return Objects.hash(super.hashCode(), options);
+  }
+
+  /** Drop the held {@link Storage} instance. */
+  @BetaApi
+  public BlobInfo asBlobInfo() {
+    return this.toBuilder().infoBuilder.build();
   }
 
   private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobInfo.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobInfo.java
@@ -404,10 +404,72 @@ public class BlobInfo implements Serializable {
 
     /** Creates a {@code BlobInfo} object. */
     public abstract BlobInfo build();
+
+    abstract BlobId getBlobId();
+
+    abstract Builder clearBlobId();
+
+    abstract Builder clearGeneratedId();
+
+    abstract Builder clearContentType();
+
+    abstract Builder clearContentEncoding();
+
+    abstract Builder clearContentDisposition();
+
+    abstract Builder clearContentLanguage();
+
+    abstract Builder clearComponentCount();
+
+    abstract Builder clearCacheControl();
+
+    abstract Builder clearAcl();
+
+    abstract Builder clearOwner();
+
+    abstract Builder clearSize();
+
+    abstract Builder clearEtag();
+
+    abstract Builder clearSelfLink();
+
+    abstract Builder clearMd5();
+
+    abstract Builder clearCrc32c();
+
+    abstract Builder clearCustomTime();
+
+    abstract Builder clearMediaLink();
+
+    abstract Builder clearMetadata();
+
+    abstract Builder clearMetageneration();
+
+    abstract Builder clearDeleteTime();
+
+    abstract Builder clearUpdateTime();
+
+    abstract Builder clearCreateTime();
+
+    abstract Builder clearIsDirectory();
+
+    abstract Builder clearCustomerEncryption();
+
+    abstract Builder clearStorageClass();
+
+    abstract Builder clearTimeStorageClassUpdated();
+
+    abstract Builder clearKmsKeyName();
+
+    abstract Builder clearEventBasedHold();
+
+    abstract Builder clearTemporaryHold();
+
+    abstract Builder clearRetentionExpirationTime();
   }
 
   static final class BuilderImpl extends Builder {
-    private final String hexDecimalValues = "0123456789abcdef";
+    private static final String hexDecimalValues = "0123456789abcdef";
     private BlobId blobId;
     private String generatedId;
     private String contentType;
@@ -849,6 +911,191 @@ public class BlobInfo implements Serializable {
     public BlobInfo build() {
       checkNotNull(blobId);
       return new BlobInfo(this);
+    }
+
+    @Override
+    BlobId getBlobId() {
+      return blobId;
+    }
+
+    @Override
+    Builder clearBlobId() {
+      this.blobId = null;
+      return this;
+    }
+
+    @Override
+    Builder clearGeneratedId() {
+      this.generatedId = null;
+      return this;
+    }
+
+    @Override
+    Builder clearContentType() {
+      this.contentType = null;
+      return this;
+    }
+
+    @Override
+    Builder clearContentEncoding() {
+      this.contentEncoding = null;
+      return this;
+    }
+
+    @Override
+    Builder clearContentDisposition() {
+      this.contentDisposition = null;
+      return this;
+    }
+
+    @Override
+    Builder clearContentLanguage() {
+      this.contentLanguage = null;
+      return this;
+    }
+
+    @Override
+    Builder clearComponentCount() {
+      this.componentCount = null;
+      return this;
+    }
+
+    @Override
+    Builder clearCacheControl() {
+      this.cacheControl = null;
+      return this;
+    }
+
+    @Override
+    Builder clearAcl() {
+      this.acl = null;
+      return this;
+    }
+
+    @Override
+    Builder clearOwner() {
+      this.owner = null;
+      return this;
+    }
+
+    @Override
+    Builder clearSize() {
+      this.size = null;
+      return this;
+    }
+
+    @Override
+    Builder clearEtag() {
+      this.etag = null;
+      return this;
+    }
+
+    @Override
+    Builder clearSelfLink() {
+      this.selfLink = null;
+      return this;
+    }
+
+    @Override
+    Builder clearMd5() {
+      this.md5 = null;
+      return this;
+    }
+
+    @Override
+    Builder clearCrc32c() {
+      this.crc32c = null;
+      return this;
+    }
+
+    @Override
+    Builder clearCustomTime() {
+      this.customTime = null;
+      return this;
+    }
+
+    @Override
+    Builder clearMediaLink() {
+      this.mediaLink = null;
+      return this;
+    }
+
+    @Override
+    Builder clearMetadata() {
+      this.metadata = null;
+      return this;
+    }
+
+    @Override
+    Builder clearMetageneration() {
+      this.metageneration = null;
+      return this;
+    }
+
+    @Override
+    Builder clearDeleteTime() {
+      this.deleteTime = null;
+      return this;
+    }
+
+    @Override
+    Builder clearUpdateTime() {
+      this.updateTime = null;
+      return this;
+    }
+
+    @Override
+    Builder clearCreateTime() {
+      this.createTime = null;
+      return this;
+    }
+
+    @Override
+    Builder clearIsDirectory() {
+      this.isDirectory = null;
+      return this;
+    }
+
+    @Override
+    Builder clearCustomerEncryption() {
+      this.customerEncryption = null;
+      return this;
+    }
+
+    @Override
+    Builder clearStorageClass() {
+      this.storageClass = null;
+      return this;
+    }
+
+    @Override
+    Builder clearTimeStorageClassUpdated() {
+      this.timeStorageClassUpdated = null;
+      return this;
+    }
+
+    @Override
+    Builder clearKmsKeyName() {
+      this.kmsKeyName = null;
+      return this;
+    }
+
+    @Override
+    Builder clearEventBasedHold() {
+      this.eventBasedHold = null;
+      return this;
+    }
+
+    @Override
+    Builder clearTemporaryHold() {
+      this.temporaryHold = null;
+      return this;
+    }
+
+    @Override
+    Builder clearRetentionExpirationTime() {
+      this.retentionExpirationTime = null;
+      return this;
     }
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Bucket.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Bucket.java
@@ -18,6 +18,7 @@ package com.google.cloud.storage;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.api.core.BetaApi;
 import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Acl.Entity;
 import com.google.cloud.storage.Storage.BlobGetOption;
@@ -598,6 +599,186 @@ public class Bucket extends BucketInfo {
     public Bucket build() {
       return new Bucket(storage, infoBuilder);
     }
+
+    @Override
+    Builder clearGeneratedId() {
+      infoBuilder.clearGeneratedId();
+      return this;
+    }
+
+    @Override
+    Builder clearProject() {
+      infoBuilder.clearProject();
+      return this;
+    }
+
+    @Override
+    Builder clearName() {
+      infoBuilder.clearName();
+      return this;
+    }
+
+    @Override
+    Builder clearOwner() {
+      infoBuilder.clearOwner();
+      return this;
+    }
+
+    @Override
+    Builder clearSelfLink() {
+      infoBuilder.clearSelfLink();
+      return this;
+    }
+
+    @Override
+    Builder clearRequesterPays() {
+      infoBuilder.clearRequesterPays();
+      return this;
+    }
+
+    @Override
+    Builder clearVersioningEnabled() {
+      infoBuilder.clearVersioningEnabled();
+      return this;
+    }
+
+    @Override
+    Builder clearIndexPage() {
+      infoBuilder.clearIndexPage();
+      return this;
+    }
+
+    @Override
+    Builder clearNotFoundPage() {
+      infoBuilder.clearNotFoundPage();
+      return this;
+    }
+
+    @Override
+    Builder clearLifecycleRules() {
+      infoBuilder.clearLifecycleRules();
+      return this;
+    }
+
+    @Override
+    Builder clearRpo() {
+      infoBuilder.clearRpo();
+      return this;
+    }
+
+    @Override
+    Builder clearStorageClass() {
+      infoBuilder.clearStorageClass();
+      return this;
+    }
+
+    @Override
+    Builder clearLocation() {
+      infoBuilder.clearLocation();
+      return this;
+    }
+
+    @Override
+    Builder clearEtag() {
+      infoBuilder.clearEtag();
+      return this;
+    }
+
+    @Override
+    Builder clearCreateTime() {
+      infoBuilder.clearCreateTime();
+      return this;
+    }
+
+    @Override
+    Builder clearUpdateTime() {
+      infoBuilder.clearUpdateTime();
+      return this;
+    }
+
+    @Override
+    Builder clearMetageneration() {
+      infoBuilder.clearMetageneration();
+      return this;
+    }
+
+    @Override
+    Builder clearCors() {
+      infoBuilder.clearCors();
+      return this;
+    }
+
+    @Override
+    Builder clearAcl() {
+      infoBuilder.clearAcl();
+      return this;
+    }
+
+    @Override
+    Builder clearDefaultAcl() {
+      infoBuilder.clearDefaultAcl();
+      return this;
+    }
+
+    @Override
+    Builder clearLabels() {
+      infoBuilder.clearLabels();
+      return this;
+    }
+
+    @Override
+    Builder clearDefaultKmsKeyName() {
+      infoBuilder.clearDefaultKmsKeyName();
+      return this;
+    }
+
+    @Override
+    Builder clearDefaultEventBasedHold() {
+      infoBuilder.clearDefaultEventBasedHold();
+      return this;
+    }
+
+    @Override
+    Builder clearRetentionEffectiveTime() {
+      infoBuilder.clearRetentionEffectiveTime();
+      return this;
+    }
+
+    @Override
+    Builder clearRetentionPolicyIsLocked() {
+      infoBuilder.clearRetentionPolicyIsLocked();
+      return this;
+    }
+
+    @Override
+    Builder clearRetentionPeriod() {
+      infoBuilder.clearRetentionPeriod();
+      return this;
+    }
+
+    @Override
+    Builder clearIamConfiguration() {
+      infoBuilder.clearIamConfiguration();
+      return this;
+    }
+
+    @Override
+    Builder clearLocationType() {
+      infoBuilder.clearLocationType();
+      return this;
+    }
+
+    @Override
+    Builder clearLogging() {
+      infoBuilder.clearLogging();
+      return this;
+    }
+
+    @Override
+    Builder clearCustomPlacementConfig() {
+      infoBuilder.clearCustomPlacementConfig();
+      return this;
+    }
   }
 
   Bucket(Storage storage, BucketInfo.BuilderImpl infoBuilder) {
@@ -1168,6 +1349,12 @@ public class Bucket extends BucketInfo {
   @Override
   public final int hashCode() {
     return Objects.hash(super.hashCode(), options);
+  }
+
+  /** Drop the held {@link Storage} instance. */
+  @BetaApi
+  public BucketInfo asBucketInfo() {
+    return this.toBuilder().infoBuilder.build();
   }
 
   private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BucketInfo.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BucketInfo.java
@@ -327,6 +327,15 @@ public class BucketInfo implements Serializable {
         return new IamConfiguration(this);
       }
     }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("isUniformBucketLevelAccessEnabled", isUniformBucketLevelAccessEnabled)
+          .add("uniformBucketLevelAccessLockedTime", uniformBucketLevelAccessLockedTime)
+          .add("publicAccessPrevention", publicAccessPrevention)
+          .toString();
+    }
   }
 
   /**
@@ -1429,6 +1438,66 @@ public class BucketInfo implements Serializable {
 
     /** Creates a {@code BucketInfo} object. */
     public abstract BucketInfo build();
+
+    abstract Builder clearGeneratedId();
+
+    abstract Builder clearProject();
+
+    abstract Builder clearName();
+
+    abstract Builder clearOwner();
+
+    abstract Builder clearSelfLink();
+
+    abstract Builder clearRequesterPays();
+
+    abstract Builder clearVersioningEnabled();
+
+    abstract Builder clearIndexPage();
+
+    abstract Builder clearNotFoundPage();
+
+    abstract Builder clearLifecycleRules();
+
+    abstract Builder clearRpo();
+
+    abstract Builder clearStorageClass();
+
+    abstract Builder clearLocation();
+
+    abstract Builder clearEtag();
+
+    abstract Builder clearCreateTime();
+
+    abstract Builder clearUpdateTime();
+
+    abstract Builder clearMetageneration();
+
+    abstract Builder clearCors();
+
+    abstract Builder clearAcl();
+
+    abstract Builder clearDefaultAcl();
+
+    abstract Builder clearLabels();
+
+    abstract Builder clearDefaultKmsKeyName();
+
+    abstract Builder clearDefaultEventBasedHold();
+
+    abstract Builder clearRetentionEffectiveTime();
+
+    abstract Builder clearRetentionPolicyIsLocked();
+
+    abstract Builder clearRetentionPeriod();
+
+    abstract Builder clearIamConfiguration();
+
+    abstract Builder clearLocationType();
+
+    abstract Builder clearLogging();
+
+    abstract Builder clearCustomPlacementConfig();
   }
 
   static final class BuilderImpl extends Builder {
@@ -1862,6 +1931,186 @@ public class BucketInfo implements Serializable {
     public BucketInfo build() {
       checkNotNull(name);
       return new BucketInfo(this);
+    }
+
+    @Override
+    BuilderImpl clearGeneratedId() {
+      this.generatedId = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearProject() {
+      this.project = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearName() {
+      this.name = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearOwner() {
+      this.owner = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearSelfLink() {
+      this.selfLink = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearRequesterPays() {
+      this.requesterPays = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearVersioningEnabled() {
+      this.versioningEnabled = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearIndexPage() {
+      this.indexPage = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearNotFoundPage() {
+      this.notFoundPage = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearLifecycleRules() {
+      this.lifecycleRules = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearRpo() {
+      this.rpo = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearStorageClass() {
+      this.storageClass = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearLocation() {
+      this.location = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearEtag() {
+      this.etag = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearCreateTime() {
+      this.createTime = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearUpdateTime() {
+      this.updateTime = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearMetageneration() {
+      this.metageneration = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearCors() {
+      this.cors = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearAcl() {
+      this.acl = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearDefaultAcl() {
+      this.defaultAcl = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearLabels() {
+      this.labels = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearDefaultKmsKeyName() {
+      this.defaultKmsKeyName = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearDefaultEventBasedHold() {
+      this.defaultEventBasedHold = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearRetentionEffectiveTime() {
+      this.retentionEffectiveTime = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearRetentionPolicyIsLocked() {
+      this.retentionPolicyIsLocked = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearRetentionPeriod() {
+      this.retentionPeriod = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearIamConfiguration() {
+      this.iamConfiguration = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearLocationType() {
+      this.locationType = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearLogging() {
+      this.logging = null;
+      return this;
+    }
+
+    @Override
+    BuilderImpl clearCustomPlacementConfig() {
+      this.customPlacementConfig = null;
+      return this;
     }
 
     private Builder clearDeleteLifecycleRules() {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Conversions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Conversions.java
@@ -39,6 +39,10 @@ final class Conversions {
   interface Decoder<From, To> {
     To decode(From f);
 
+    default <R> Decoder<From, R> andThen(Decoder<To, R> d) {
+      return f -> d.decode(this.decode(f));
+    }
+
     static <X> Decoder<X, X> identity() {
       return (x) -> x;
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
@@ -460,7 +460,7 @@ final class GrpcConversions {
       int idx = from.indexOf('-', 8);
       String team = from.substring(8, idx);
       String projectId = from.substring(idx + 1);
-      return new Acl.Project(Acl.Project.ProjectRole.valueOf(team), projectId);
+      return new Acl.Project(Acl.Project.ProjectRole.valueOf(team.toUpperCase()), projectId);
     }
     return new Acl.RawEntity(from);
   }
@@ -532,10 +532,10 @@ final class GrpcConversions {
 
     BucketInfo.IamConfiguration.Builder to = BucketInfo.IamConfiguration.newBuilder();
     ifNonNull(ubla.getEnabled(), to::setIsUniformBucketLevelAccessEnabled);
-    ifNonNull(
-        ubla.getLockTime(),
-        timestampCodec::decode,
-        to::setUniformBucketLevelAccessLockedTimeOffsetDateTime);
+    if (ubla.hasLockTime()) {
+      to.setUniformBucketLevelAccessLockedTimeOffsetDateTime(
+          timestampCodec.decode(ubla.getLockTime()));
+    }
     if (!from.getPublicAccessPrevention().isEmpty()) {
       to.setPublicAccessPrevention(PublicAccessPrevention.parse(from.getPublicAccessPrevention()));
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/TransportCompatibility.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/TransportCompatibility.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  * <p>Not all operations are compatible with all transports.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
 @Documented
 @Inherited
 @interface TransportCompatibility {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
@@ -731,7 +731,7 @@ final class UnifiedOpts {
      * However, refactoring the whole model pipeline for both json and grpc is going to be a large
      * change.
      */
-    Decoder<Blob, Blob> clearBlobFields() {
+    Decoder<Blob, Blob> clearUnselectedBlobFields() {
       return b -> {
         if (val.isEmpty()) {
           return b;
@@ -754,7 +754,7 @@ final class UnifiedOpts {
      * However, refactoring the whole model pipeline for both json and grpc is going to be a large
      * change.
      */
-    Decoder<Bucket, Bucket> clearBucketFields() {
+    Decoder<Bucket, Bucket> clearUnselectedBucketFields() {
       return b -> {
         if (val.isEmpty()) {
           return b;
@@ -2205,14 +2205,14 @@ final class UnifiedOpts {
     Decoder<Blob, Blob> clearBlobFields() {
       return filterTo(Fields.class)
           .findFirst()
-          .map(Fields::clearBlobFields)
+          .map(Fields::clearUnselectedBlobFields)
           .orElse(Decoder.identity());
     }
 
     Decoder<Bucket, Bucket> clearBucketFields() {
       return filterTo(Fields.class)
           .findFirst()
-          .map(Fields::clearBucketFields)
+          .map(Fields::clearUnselectedBucketFields)
           .orElse(Decoder.identity());
     }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
@@ -18,17 +18,24 @@ package com.google.cloud.storage;
 
 import static com.google.cloud.storage.Utils.projectNameCodec;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Predicates.not;
 
 import com.google.api.gax.grpc.GrpcCallContext;
+import com.google.cloud.storage.Conversions.Decoder;
+import com.google.cloud.storage.Storage.BlobField;
+import com.google.cloud.storage.Storage.BucketField;
 import com.google.cloud.storage.spi.v1.StorageRpc;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
 import com.google.iam.v1.GetIamPolicyRequest;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.FieldMask;
 import com.google.storage.v2.CommonObjectRequestParams;
 import com.google.storage.v2.ComposeObjectRequest;
 import com.google.storage.v2.CreateBucketRequest;
@@ -56,9 +63,12 @@ import java.security.Key;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
+import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.crypto.spec.SecretKeySpec;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -366,9 +376,7 @@ final class UnifiedOpts {
     return new EndOffset(s);
   }
 
-  @Deprecated
-  static Fields fields(String s) {
-    // TODO: do we care if the string provided is empty?
+  static Fields fields(ImmutableSet<NamedField> s) {
     return new Fields(s);
   }
 
@@ -661,13 +669,209 @@ final class UnifiedOpts {
     }
   }
 
-  static final class Fields extends RpcOptVal<String>
+  static final class Fields extends RpcOptVal<ImmutableSet<NamedField>>
       implements ObjectSourceOpt, ObjectListOpt, BucketSourceOpt, BucketListOpt {
-    private static final long serialVersionUID = -6861404961336468409L;
 
-    private Fields(String val) {
+    /**
+     * Apiary and gRPC have differing handling of where the field selector is evaluated relative to
+     * the request. For Apiary, it's from the root response document; for gRPC it's from the
+     * collection of results.
+     *
+     * <p>In our current case, this means we exclude some fields when we know it is being consumed
+     * for a gRPC message. Unfortunately, we don't know if the constructed Fields instance is for
+     * use with gRPC when it is instantiated so we must define here.
+     */
+    private static final ImmutableSet<String> grpcExcludedFields =
+        ImmutableSet.of("nextPageToken", "prefixes", "selfLink", "mediaLink", "kind", "id");
+
+    private static final long serialVersionUID = -320337719611149532L;
+
+    private Fields(ImmutableSet<NamedField> val) {
       super(StorageRpc.Option.FIELDS, val);
     }
+
+    @Override
+    public Mapper<ImmutableMap.Builder<StorageRpc.Option, Object>> mapper() {
+      return b -> {
+        String collect =
+            val.stream().map(NamedField::getApiaryName).collect(Collectors.joining(","));
+        return b.put(StorageRpc.Option.FIELDS, collect);
+      };
+    }
+
+    @Override
+    public Mapper<GetBucketRequest.Builder> getBucket() {
+      return b -> b.setReadMask(FieldMask.newBuilder().addAllPaths(getPaths()).build());
+    }
+
+    @Override
+    public Mapper<ListBucketsRequest.Builder> listBuckets() {
+      return b -> b.setReadMask(FieldMask.newBuilder().addAllPaths(getPaths()).build());
+    }
+
+    @Override
+    public Mapper<GetObjectRequest.Builder> getObject() {
+      return b -> b.setReadMask(FieldMask.newBuilder().addAllPaths(getPaths()).build());
+    }
+
+    @Override
+    public Mapper<ListObjectsRequest.Builder> listObjects() {
+      return b -> b.setReadMask(FieldMask.newBuilder().addAllPaths(getPaths()).build());
+    }
+
+    @Override
+    public Mapper<ReadObjectRequest.Builder> readObject() {
+      return b -> b.setReadMask(FieldMask.newBuilder().addAllPaths(getPaths()).build());
+    }
+
+    /**
+     * Define a decoder which can clear out any fields which may have not been selected.
+     *
+     * <p>This approach, isn't ideal at the backside after decoding has already taken place.
+     * However, refactoring the whole model pipeline for both json and grpc is going to be a large
+     * change.
+     */
+    Decoder<Blob, Blob> clearBlobFields() {
+      return b -> {
+        if (val.isEmpty()) {
+          return b;
+        } else {
+          Set<String> names = getPaths();
+          Blob.Builder bldr = b.toBuilder();
+          blobInfoFieldClearers.entrySet().stream()
+              .filter(e -> !names.contains(e.getKey()))
+              .map(Entry::getValue)
+              .forEach(m -> m.apply(bldr));
+          return bldr.build();
+        }
+      };
+    }
+
+    /**
+     * Define a decoder which can clear out any fields which may have not been selected.
+     *
+     * <p>This approach, isn't ideal at the backside after decoding has already taken place.
+     * However, refactoring the whole model pipeline for both json and grpc is going to be a large
+     * change.
+     */
+    Decoder<Bucket, Bucket> clearBucketFields() {
+      return b -> {
+        if (val.isEmpty()) {
+          return b;
+        } else {
+          Set<String> names = getPaths();
+          Bucket.Builder bldr = b.toBuilder();
+          bucketInfoFieldClearers.entrySet().stream()
+              .filter(e -> !names.contains(e.getKey()))
+              .map(Entry::getValue)
+              .forEach(m -> m.apply(bldr));
+          return bldr.build();
+        }
+      };
+    }
+
+    private Set<String> getPaths() {
+      //noinspection Guava
+      return val.stream()
+          .map(NamedField::stripPrefix)
+          .map(NamedField::getGrpcName)
+          .filter(not(grpcExcludedFields::contains))
+          .collect(Collectors.toSet());
+    }
+
+    // It'd be preferable to define these clearing mappers in the fields themselves, however today
+    // the fields are enums and require interfaces in order to extend anything which in turn makes
+    // things public.
+    //
+    // To avoid putting more things on the public api that will hopefully take a different form
+    // in the medium term, we define them here.
+    private static final ImmutableMap<String, Mapper<BlobInfo.Builder>> blobInfoFieldClearers =
+        ImmutableMap.<String, Mapper<BlobInfo.Builder>>builder()
+            .put(BlobField.ACL.getGrpcName(), BlobInfo.Builder::clearAcl)
+            .put(BlobField.CACHE_CONTROL.getGrpcName(), BlobInfo.Builder::clearCacheControl)
+            .put(BlobField.COMPONENT_COUNT.getGrpcName(), BlobInfo.Builder::clearComponentCount)
+            .put(
+                BlobField.CONTENT_DISPOSITION.getGrpcName(),
+                BlobInfo.Builder::clearContentDisposition)
+            .put(BlobField.CONTENT_ENCODING.getGrpcName(), BlobInfo.Builder::clearContentEncoding)
+            .put(BlobField.CONTENT_LANGUAGE.getGrpcName(), BlobInfo.Builder::clearContentLanguage)
+            .put(BlobField.CONTENT_TYPE.getGrpcName(), BlobInfo.Builder::clearContentType)
+            .put(BlobField.CRC32C.getGrpcName(), BlobInfo.Builder::clearCrc32c)
+            .put(
+                BlobField.CUSTOMER_ENCRYPTION.getGrpcName(),
+                BlobInfo.Builder::clearCustomerEncryption)
+            .put(BlobField.CUSTOM_TIME.getGrpcName(), BlobInfo.Builder::clearCustomTime)
+            .put(BlobField.ETAG.getGrpcName(), BlobInfo.Builder::clearEtag)
+            .put(BlobField.EVENT_BASED_HOLD.getGrpcName(), BlobInfo.Builder::clearEventBasedHold)
+            .put(
+                BlobField.GENERATION.getGrpcName(),
+                b -> {
+                  BlobId current = b.getBlobId();
+                  return b.setBlobId(BlobId.of(current.getBucket(), current.getName()));
+                })
+            .put(BlobField.ID.getGrpcName(), BlobInfo.Builder::clearGeneratedId)
+            .put(BlobField.KMS_KEY_NAME.getGrpcName(), BlobInfo.Builder::clearKmsKeyName)
+            .put(BlobField.MD5HASH.getGrpcName(), BlobInfo.Builder::clearMd5)
+            .put(BlobField.MEDIA_LINK.getGrpcName(), BlobInfo.Builder::clearMediaLink)
+            .put(BlobField.METADATA.getGrpcName(), BlobInfo.Builder::clearMetadata)
+            .put(BlobField.METAGENERATION.getGrpcName(), BlobInfo.Builder::clearMetageneration)
+            .put(BlobField.OWNER.getGrpcName(), BlobInfo.Builder::clearOwner)
+            .put(
+                BlobField.RETENTION_EXPIRATION_TIME.getGrpcName(),
+                BlobInfo.Builder::clearRetentionExpirationTime)
+            .put(BlobField.SELF_LINK.getGrpcName(), BlobInfo.Builder::clearSelfLink)
+            .put(BlobField.SIZE.getGrpcName(), BlobInfo.Builder::clearSize)
+            .put(BlobField.STORAGE_CLASS.getGrpcName(), BlobInfo.Builder::clearStorageClass)
+            .put(BlobField.TEMPORARY_HOLD.getGrpcName(), BlobInfo.Builder::clearTemporaryHold)
+            .put(BlobField.TIME_CREATED.getGrpcName(), BlobInfo.Builder::clearCreateTime)
+            .put(BlobField.TIME_DELETED.getGrpcName(), BlobInfo.Builder::clearDeleteTime)
+            .put(
+                BlobField.TIME_STORAGE_CLASS_UPDATED.getGrpcName(),
+                BlobInfo.Builder::clearTimeStorageClassUpdated)
+            .put(BlobField.UPDATED.getGrpcName(), BlobInfo.Builder::clearUpdateTime)
+            .build();
+
+    private static final ImmutableMap<String, Mapper<BucketInfo.Builder>> bucketInfoFieldClearers =
+        ImmutableMap.<String, Mapper<BucketInfo.Builder>>builder()
+            .put(BucketField.ACL.getGrpcName(), BucketInfo.Builder::clearAcl)
+            // .put(BucketField.AUTOCLASS.getGrpcName(), b -> b.clearAutoclass())
+            .put(BucketField.BILLING.getGrpcName(), BucketInfo.Builder::clearRequesterPays)
+            .put(BucketField.CORS.getGrpcName(), BucketInfo.Builder::clearCors)
+            .put(
+                BucketField.CUSTOM_PLACEMENT_CONFIG.getGrpcName(),
+                BucketInfo.Builder::clearCustomPlacementConfig)
+            .put(
+                BucketField.DEFAULT_EVENT_BASED_HOLD.getGrpcName(),
+                BucketInfo.Builder::clearDefaultEventBasedHold)
+            .put(BucketField.DEFAULT_OBJECT_ACL.getGrpcName(), BucketInfo.Builder::clearDefaultAcl)
+            .put(BucketField.ENCRYPTION.getGrpcName(), BucketInfo.Builder::clearDefaultKmsKeyName)
+            .put(BucketField.ETAG.getGrpcName(), BucketInfo.Builder::clearEtag)
+            .put(
+                BucketField.IAMCONFIGURATION.getGrpcName(),
+                BucketInfo.Builder::clearIamConfiguration)
+            .put(BucketField.ID.getGrpcName(), BucketInfo.Builder::clearGeneratedId)
+            .put(BucketField.LABELS.getGrpcName(), BucketInfo.Builder::clearLabels)
+            .put(BucketField.LIFECYCLE.getGrpcName(), BucketInfo.Builder::clearLifecycleRules)
+            .put(BucketField.LOCATION.getGrpcName(), BucketInfo.Builder::clearLocation)
+            .put(BucketField.LOCATION_TYPE.getGrpcName(), BucketInfo.Builder::clearLocationType)
+            .put(BucketField.LOGGING.getGrpcName(), BucketInfo.Builder::clearLogging)
+            .put(BucketField.METAGENERATION.getGrpcName(), BucketInfo.Builder::clearMetageneration)
+            .put(BucketField.NAME.getGrpcName(), BucketInfo.Builder::clearName)
+            .put(BucketField.OWNER.getGrpcName(), BucketInfo.Builder::clearOwner)
+            .put(
+                BucketField.RETENTION_POLICY.getGrpcName(),
+                b ->
+                    b.clearRetentionEffectiveTime()
+                        .clearRetentionPolicyIsLocked()
+                        .clearRetentionPeriod())
+            .put(BucketField.RPO.getGrpcName(), BucketInfo.Builder::clearRpo)
+            .put(BucketField.STORAGE_CLASS.getGrpcName(), BucketInfo.Builder::clearStorageClass)
+            .put(BucketField.TIME_CREATED.getGrpcName(), BucketInfo.Builder::clearCreateTime)
+            .put(BucketField.UPDATED.getGrpcName(), BucketInfo.Builder::clearUpdateTime)
+            .put(BucketField.VERSIONING.getGrpcName(), BucketInfo.Builder::clearVersioningEnabled)
+            .put(BucketField.WEBSITE.getGrpcName(), b -> b.clearIndexPage().clearNotFoundPage())
+            .put("project", BucketInfo.Builder::clearProject)
+            .build();
   }
 
   /**
@@ -1998,6 +2202,20 @@ final class UnifiedOpts {
       return filterTo(ReturnRawInputStream.class).findFirst().map(r -> r.val).orElse(false);
     }
 
+    Decoder<Blob, Blob> clearBlobFields() {
+      return filterTo(Fields.class)
+          .findFirst()
+          .map(Fields::clearBlobFields)
+          .orElse(Decoder.identity());
+    }
+
+    Decoder<Bucket, Bucket> clearBucketFields() {
+      return filterTo(Fields.class)
+          .findFirst()
+          .map(Fields::clearBucketFields)
+          .orElse(Decoder.identity());
+    }
+
     private Mapper<ImmutableMap.Builder<StorageRpc.Option, Object>> rpcOptionMapper() {
       return fuseMappers(RpcOptVal.class, RpcOptVal::mapper);
     }
@@ -2046,11 +2264,125 @@ final class UnifiedOpts {
     }
   }
 
+  /**
+   * Interface which represents a field of some resource which is present in the storage api, and
+   * which can be used for a {@link com.google.cloud.FieldSelector read_mask}.
+   */
+  interface NamedField extends Serializable {
+    String getApiaryName();
+
+    String getGrpcName();
+
+    default NamedField stripPrefix() {
+      if (this instanceof PrefixedNamedField) {
+        PrefixedNamedField pnf = (PrefixedNamedField) this;
+        return pnf.delegate;
+      } else {
+        return this;
+      }
+    }
+
+    static NamedField prefixed(String prefix, NamedField delegate) {
+      return new PrefixedNamedField(prefix, delegate);
+    }
+
+    static NamedField literal(String name) {
+      return new LiteralNamedField(name);
+    }
+  }
+
   private static CommonObjectRequestParams.Builder customerSuppliedKey(
       CommonObjectRequestParams.Builder b, Key key) {
     HashCode keySha256 = Hashing.sha256().hashBytes(key.getEncoded());
     return b.setEncryptionAlgorithm(key.getAlgorithm())
         .setEncryptionKeyBytes(ByteString.copyFrom(key.getEncoded()))
         .setEncryptionKeySha256Bytes(ByteString.copyFrom(keySha256.asBytes()));
+  }
+
+  private static final class PrefixedNamedField implements NamedField {
+
+    private final String prefix;
+    private final NamedField delegate;
+
+    public PrefixedNamedField(String prefix, NamedField delegate) {
+      this.prefix = prefix;
+      this.delegate = delegate;
+    }
+
+    @Override
+    public String getApiaryName() {
+      return prefix + delegate.getApiaryName();
+    }
+
+    @Override
+    public String getGrpcName() {
+      return prefix + delegate.getGrpcName();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof PrefixedNamedField)) {
+        return false;
+      }
+      PrefixedNamedField that = (PrefixedNamedField) o;
+      return Objects.equals(prefix, that.prefix) && Objects.equals(delegate, that.delegate);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(prefix, delegate);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("prefix", prefix)
+          .add("delegate", delegate)
+          .toString();
+    }
+  }
+
+  private static class LiteralNamedField implements NamedField {
+
+    private final String name;
+
+    LiteralNamedField(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String getApiaryName() {
+      return name;
+    }
+
+    @Override
+    public String getGrpcName() {
+      return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof LiteralNamedField)) {
+        return false;
+      }
+      LiteralNamedField that = (LiteralNamedField) o;
+      return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this).add("name", name).toString();
+    }
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/SerializationTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/SerializationTest.java
@@ -26,11 +26,13 @@ import com.google.cloud.PageImpl;
 import com.google.cloud.ReadChannel;
 import com.google.cloud.Restorable;
 import com.google.cloud.storage.Acl.Project.ProjectRole;
+import com.google.cloud.storage.Storage.BucketField;
 import com.google.cloud.storage.Storage.PredefinedAcl;
 import com.google.cloud.storage.UnifiedOpts.Opt;
 import com.google.cloud.storage.spi.v1.StorageRpc;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
@@ -126,7 +128,7 @@ public class SerializationTest extends BaseSerializationTest {
             .add(UnifiedOpts.doesNotExist())
             .add(UnifiedOpts.encryptionKey(keyBase64))
             .add(UnifiedOpts.endOffset("end"))
-            .add(UnifiedOpts.fields(""))
+            .add(UnifiedOpts.fields(ImmutableSet.of(BucketField.LOCATION)))
             .add(UnifiedOpts.generationMatch(0))
             .add(UnifiedOpts.generationNotMatch(0))
             .add(UnifiedOpts.kmsKeyName("key"))

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageImplMockitoTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageImplMockitoTest.java
@@ -1172,63 +1172,6 @@ public class StorageImplMockitoTest {
   }
 
   @Test
-  public void testListBucketsWithSelectedFields() {
-    String cursor = "cursor";
-    ArgumentCaptor<Map<StorageRpc.Option, Object>> capturedOptions =
-        ArgumentCaptor.forClass(Map.class);
-
-    ImmutableList<BucketInfo> bucketInfoList = ImmutableList.of(BUCKET_INFO1, BUCKET_INFO2);
-    Tuple<String, Iterable<com.google.api.services.storage.model.Bucket>> result =
-        Tuple.of(
-            cursor, Iterables.transform(bucketInfoList, Conversions.apiary().bucketInfo()::encode));
-
-    doReturn(result)
-        .doThrow(UNEXPECTED_CALL_EXCEPTION)
-        .when(storageRpcMock)
-        .list(capturedOptions.capture());
-    initializeService();
-    ImmutableList<Bucket> bucketList = ImmutableList.of(expectedBucket1, expectedBucket2);
-    Page<Bucket> page = storage.list(BUCKET_LIST_FIELDS);
-    String selector = (String) capturedOptions.getValue().get(StorageRpc.Option.FIELDS);
-    assertTrue(selector.contains("items("));
-    assertTrue(selector.contains("name"));
-    assertTrue(selector.contains("acl"));
-    assertTrue(selector.contains("location"));
-    assertTrue(selector.contains("nextPageToken"));
-    assertTrue(selector.endsWith(")"));
-    assertEquals(38, selector.length());
-    assertEquals(cursor, page.getNextPageToken());
-    assertArrayEquals(bucketList.toArray(), Iterables.toArray(page.getValues(), Bucket.class));
-  }
-
-  @Test
-  public void testListBucketsWithEmptyFields() {
-    String cursor = "cursor";
-    ArgumentCaptor<Map<StorageRpc.Option, Object>> capturedOptions =
-        ArgumentCaptor.forClass(Map.class);
-    ImmutableList<BucketInfo> bucketInfoList = ImmutableList.of(BUCKET_INFO1, BUCKET_INFO2);
-    Tuple<String, Iterable<com.google.api.services.storage.model.Bucket>> result =
-        Tuple.of(
-            cursor, Iterables.transform(bucketInfoList, Conversions.apiary().bucketInfo()::encode));
-
-    doReturn(result)
-        .doThrow(UNEXPECTED_CALL_EXCEPTION)
-        .when(storageRpcMock)
-        .list(capturedOptions.capture());
-    initializeService();
-    ImmutableList<Bucket> bucketList = ImmutableList.of(expectedBucket1, expectedBucket2);
-    Page<Bucket> page = storage.list(BUCKET_LIST_EMPTY_FIELDS);
-    String selector = (String) capturedOptions.getValue().get(StorageRpc.Option.FIELDS);
-    assertTrue(selector.contains("items("));
-    assertTrue(selector.contains("name"));
-    assertTrue(selector.contains("nextPageToken"));
-    assertTrue(selector.endsWith(")"));
-    assertEquals(25, selector.length());
-    assertEquals(cursor, page.getNextPageToken());
-    assertArrayEquals(bucketList.toArray(), Iterables.toArray(page.getValues(), Bucket.class));
-  }
-
-  @Test
   public void testListBucketsWithException() {
     doThrow(STORAGE_FAILURE).when(storageRpcMock).list(EMPTY_RPC_OPTIONS);
     initializeService();
@@ -1291,72 +1234,6 @@ public class StorageImplMockitoTest {
     ImmutableList<Blob> blobList = ImmutableList.of(expectedBlob1, expectedBlob2);
     Page<Blob> page =
         storage.list(BUCKET_NAME1, BLOB_LIST_PAGE_SIZE, BLOB_LIST_PREFIX, BLOB_LIST_VERSIONS);
-    assertEquals(cursor, page.getNextPageToken());
-    assertArrayEquals(blobList.toArray(), Iterables.toArray(page.getValues(), Blob.class));
-  }
-
-  @Test
-  public void testListBlobsWithSelectedFields() {
-    String cursor = "cursor";
-    ArgumentCaptor<Map<StorageRpc.Option, Object>> capturedOptions =
-        ArgumentCaptor.forClass(Map.class);
-    ImmutableList<BlobInfo> blobInfoList = ImmutableList.of(BLOB_INFO1, BLOB_INFO2);
-    Tuple<String, Iterable<com.google.api.services.storage.model.StorageObject>> result =
-        Tuple.of(
-            cursor, Iterables.transform(blobInfoList, Conversions.apiary().blobInfo()::encode));
-    doReturn(result)
-        .doThrow(UNEXPECTED_CALL_EXCEPTION)
-        .when(storageRpcMock)
-        .list(Mockito.eq(BUCKET_NAME1), capturedOptions.capture());
-
-    initializeService();
-    ImmutableList<Blob> blobList = ImmutableList.of(expectedBlob1, expectedBlob2);
-    Page<Blob> page =
-        storage.list(BUCKET_NAME1, BLOB_LIST_PAGE_SIZE, BLOB_LIST_PREFIX, BLOB_LIST_FIELDS);
-    assertEquals(PAGE_SIZE, capturedOptions.getValue().get(StorageRpc.Option.MAX_RESULTS));
-    assertEquals("prefix", capturedOptions.getValue().get(StorageRpc.Option.PREFIX));
-    String selector = (String) capturedOptions.getValue().get(StorageRpc.Option.FIELDS);
-    assertTrue(selector.contains("prefixes"));
-    assertTrue(selector.contains("items("));
-    assertTrue(selector.contains("bucket"));
-    assertTrue(selector.contains("name"));
-    assertTrue(selector.contains("contentType"));
-    assertTrue(selector.contains("md5Hash"));
-    assertTrue(selector.contains("nextPageToken"));
-    assertTrue(selector.endsWith(")"));
-    assertEquals(61, selector.length());
-    assertEquals(cursor, page.getNextPageToken());
-    assertArrayEquals(blobList.toArray(), Iterables.toArray(page.getValues(), Blob.class));
-  }
-
-  @Test
-  public void testListBlobsWithEmptyFields() {
-    String cursor = "cursor";
-    ArgumentCaptor<Map<StorageRpc.Option, Object>> capturedOptions =
-        ArgumentCaptor.forClass(Map.class);
-    ImmutableList<BlobInfo> blobInfoList = ImmutableList.of(BLOB_INFO1, BLOB_INFO2);
-    Tuple<String, Iterable<com.google.api.services.storage.model.StorageObject>> result =
-        Tuple.of(
-            cursor, Iterables.transform(blobInfoList, Conversions.apiary().blobInfo()::encode));
-    doReturn(result)
-        .doThrow(UNEXPECTED_CALL_EXCEPTION)
-        .when(storageRpcMock)
-        .list(Mockito.eq(BUCKET_NAME1), capturedOptions.capture());
-
-    initializeService();
-    ImmutableList<Blob> blobList = ImmutableList.of(expectedBlob1, expectedBlob2);
-    Page<Blob> page =
-        storage.list(BUCKET_NAME1, BLOB_LIST_PAGE_SIZE, BLOB_LIST_PREFIX, BLOB_LIST_EMPTY_FIELDS);
-    assertEquals(PAGE_SIZE, capturedOptions.getValue().get(StorageRpc.Option.MAX_RESULTS));
-    assertEquals("prefix", capturedOptions.getValue().get(StorageRpc.Option.PREFIX));
-    String selector = (String) capturedOptions.getValue().get(StorageRpc.Option.FIELDS);
-    assertTrue(selector.contains("prefixes"));
-    assertTrue(selector.contains("items("));
-    assertTrue(selector.contains("bucket"));
-    assertTrue(selector.contains("name"));
-    assertTrue(selector.contains("nextPageToken"));
-    assertTrue(selector.endsWith(")"));
-    assertEquals(41, selector.length());
     assertEquals(cursor, page.getNextPageToken());
     assertArrayEquals(blobList.toArray(), Iterables.toArray(page.getValues(), Blob.class));
   }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITOptionRegressionTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITOptionRegressionTest.java
@@ -19,7 +19,6 @@ package com.google.cloud.storage.it;
 import static org.junit.Assume.assumeTrue;
 
 import com.google.api.gax.retrying.RetrySettings;
-import com.google.cloud.FieldSelector.Helper;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
@@ -57,14 +56,15 @@ import com.google.cloud.storage.StorageFixture;
 import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.conformance.retry.CleanupStrategy;
 import com.google.cloud.storage.conformance.retry.TestBench;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.Hashing;
 import com.google.common.primitives.Ints;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.Collections;
+import java.util.Set;
+import java.util.function.Function;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -320,9 +320,37 @@ public final class ITOptionRegressionTest {
 
   @Test
   public void storage_BucketGetOption_fields_BucketField() {
-    String expected = Helper.selector(ImmutableList.copyOf(BucketField.values()));
+    Set<String> expected =
+        ImmutableSet.of(
+            "acl",
+            "autoclass",
+            "billing",
+            "cors",
+            "customPlacementConfig",
+            "defaultEventBasedHold",
+            "defaultObjectAcl",
+            "encryption",
+            "etag",
+            "iamConfiguration",
+            "id",
+            "labels",
+            "lifecycle",
+            "location",
+            "locationType",
+            "logging",
+            "metageneration",
+            "name",
+            "owner",
+            "retentionPolicy",
+            "rpo",
+            "selfLink",
+            "storageClass",
+            "timeCreated",
+            "updated",
+            "versioning",
+            "website");
     s.get(b.getName(), BucketGetOption.fields(BucketField.values()));
-    requestAuditing.assertQueryParam("fields", expected);
+    requestAuditing.assertQueryParam("fields", expected, splitOnCommaToSet());
   }
 
   @Test
@@ -695,9 +723,42 @@ public final class ITOptionRegressionTest {
 
   @Test
   public void storage_BlobGetOption_fields_BlobField() {
-    String expected = Helper.selector(ImmutableList.copyOf(BlobField.values()));
+    Set<String> expected =
+        ImmutableSet.of(
+            "acl",
+            "bucket",
+            "cacheControl",
+            "componentCount",
+            "contentDisposition",
+            "contentEncoding",
+            "contentLanguage",
+            "contentType",
+            "crc32c",
+            "customTime",
+            "customerEncryption",
+            "etag",
+            "eventBasedHold",
+            "generation",
+            "id",
+            "kind",
+            "kmsKeyName",
+            "md5Hash",
+            "mediaLink",
+            "metadata",
+            "metageneration",
+            "name",
+            "owner",
+            "retentionExpirationTime",
+            "selfLink",
+            "size",
+            "storageClass",
+            "temporaryHold",
+            "timeCreated",
+            "timeDeleted",
+            "timeStorageClassUpdated",
+            "updated");
     s.get(o.getBlobId(), BlobGetOption.fields(BlobField.values()));
-    requestAuditing.assertQueryParam("fields", expected);
+    requestAuditing.assertQueryParam("fields", expected, splitOnCommaToSet());
   }
 
   @Test
@@ -744,9 +805,38 @@ public final class ITOptionRegressionTest {
 
   @Test
   public void storage_BucketListOption_fields_BucketField() {
-    String expected = Helper.listSelector("items", ImmutableList.copyOf(BucketField.values()));
+    Set<String> expected =
+        ImmutableSet.of(
+            "nextPageToken",
+            "items/acl",
+            "items/autoclass",
+            "items/billing",
+            "items/cors",
+            "items/customPlacementConfig",
+            "items/defaultEventBasedHold",
+            "items/defaultObjectAcl",
+            "items/encryption",
+            "items/etag",
+            "items/iamConfiguration",
+            "items/id",
+            "items/labels",
+            "items/lifecycle",
+            "items/location",
+            "items/locationType",
+            "items/logging",
+            "items/metageneration",
+            "items/name",
+            "items/owner",
+            "items/retentionPolicy",
+            "items/rpo",
+            "items/selfLink",
+            "items/storageClass",
+            "items/timeCreated",
+            "items/updated",
+            "items/versioning",
+            "items/website");
     s.list(BucketListOption.fields(BucketField.values()));
-    requestAuditing.assertQueryParam("fields", expected);
+    requestAuditing.assertQueryParam("fields", expected, splitOnCommaToSet());
   }
 
   @Test
@@ -805,11 +895,44 @@ public final class ITOptionRegressionTest {
 
   @Test
   public void storage_BlobListOption_fields_BlobField() {
-    String expected =
-        Helper.listSelector(
-            new String[] {"prefixes"}, "items", Collections.emptyList(), BlobField.values());
+    Set<String> expected =
+        ImmutableSet.of(
+            "nextPageToken",
+            "prefixes",
+            "items/acl",
+            "items/bucket",
+            "items/cacheControl",
+            "items/componentCount",
+            "items/contentDisposition",
+            "items/contentEncoding",
+            "items/contentLanguage",
+            "items/contentType",
+            "items/crc32c",
+            "items/customTime",
+            "items/customerEncryption",
+            "items/etag",
+            "items/eventBasedHold",
+            "items/generation",
+            "items/id",
+            "items/kind",
+            "items/kmsKeyName",
+            "items/md5Hash",
+            "items/mediaLink",
+            "items/metadata",
+            "items/metageneration",
+            "items/name",
+            "items/owner",
+            "items/retentionExpirationTime",
+            "items/selfLink",
+            "items/size",
+            "items/storageClass",
+            "items/temporaryHold",
+            "items/timeCreated",
+            "items/timeDeleted",
+            "items/timeStorageClassUpdated",
+            "items/updated");
     s.list(b.getName(), BlobListOption.fields(BlobField.values()));
-    requestAuditing.assertQueryParam("fields", expected);
+    requestAuditing.assertQueryParam("fields", expected, splitOnCommaToSet());
   }
 
   @Test
@@ -1064,6 +1187,10 @@ public final class ITOptionRegressionTest {
 
   private static String objectName() {
     return String.format("object-%03d", objectCounter++);
+  }
+
+  private static Function<String, Set<String>> splitOnCommaToSet() {
+    return s -> ImmutableSet.copyOf(s.split(","));
   }
 
   private static final class Content {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITReadMaskTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITReadMaskTest.java
@@ -1,0 +1,446 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.it;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketFixture;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Rpo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobField;
+import com.google.cloud.storage.Storage.BlobGetOption;
+import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.cloud.storage.Storage.BlobTargetOption;
+import com.google.cloud.storage.Storage.BucketField;
+import com.google.cloud.storage.Storage.BucketGetOption;
+import com.google.cloud.storage.Storage.BucketListOption;
+import com.google.cloud.storage.Storage.ComposeRequest;
+import com.google.cloud.storage.StorageFixture;
+import com.google.cloud.storage.conformance.retry.ParallelParameterized;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Enclosed.class)
+public final class ITReadMaskTest {
+
+  @ClassRule(order = 1)
+  public static final StorageFixture sfH = StorageFixture.defaultHttp();
+
+  @ClassRule(order = 1)
+  public static final StorageFixture sfG = StorageFixture.defaultGrpc();
+
+  @ClassRule(order = 2)
+  public static final BucketFixture bucketFixture =
+      BucketFixture.newBuilder()
+          .setHandle(sfH::getInstance)
+          .setBucketNameFmtString("java-storage-grpc-%s")
+          .build();
+
+  private static Storage sh;
+  private static Storage sg;
+  private static BlobId blobId;
+
+  @BeforeClass
+  public static void beforeClass() {
+    sh = sfH.getInstance();
+    sg = sfG.getInstance();
+
+    String bucket = bucketFixture.getBucketInfo().getName();
+
+    BlobId blobId1 = BlobId.of(bucket, objName("001"));
+    BlobId blobId2 = BlobId.of(bucket, objName("002"));
+    BlobId blobId3 = BlobId.of(bucket, objName("003"));
+    BlobId blobId4 = BlobId.of(bucket, objName("004"));
+
+    BlobInfo info1 = BlobInfo.newBuilder(blobId1).setMetadata(ImmutableMap.of("pow", "1")).build();
+    BlobInfo info2 = BlobInfo.newBuilder(blobId2).setMetadata(ImmutableMap.of("pow", "2")).build();
+    BlobInfo info3 = BlobInfo.newBuilder(blobId3).setMetadata(ImmutableMap.of("pow", "3")).build();
+    BlobInfo info4 = BlobInfo.newBuilder(blobId4).setMetadata(ImmutableMap.of("pow", "4")).build();
+    sh.create(info1, "A".getBytes(StandardCharsets.UTF_8), BlobTargetOption.doesNotExist());
+
+    ComposeRequest c2 =
+        ComposeRequest.newBuilder()
+            .addSource(blobId1.getName(), blobId1.getName())
+            .setTarget(info2)
+            .setTargetOptions(BlobTargetOption.doesNotExist())
+            .build();
+    ComposeRequest c3 =
+        ComposeRequest.newBuilder()
+            .addSource(blobId2.getName(), blobId2.getName())
+            .setTarget(info3)
+            .setTargetOptions(BlobTargetOption.doesNotExist())
+            .build();
+    ComposeRequest c4 =
+        ComposeRequest.newBuilder()
+            .addSource(blobId3.getName(), blobId3.getName())
+            .setTarget(info4)
+            .setTargetOptions(BlobTargetOption.doesNotExist())
+            .build();
+    sh.compose(c2);
+    sh.compose(c3);
+    sh.compose(c4);
+
+    blobId = blobId1;
+  }
+
+  /*
+  public static final class UpdateMask {
+
+    @Test
+    public void nestedUpdate() {
+      ImmutableMap<String, String> m1 = ImmutableMap.of("x", "X");
+      ImmutableMap<String, String> m2 = ImmutableMap.<String, String>builder()
+          .putAll(m1)
+          .put("y", "Y")
+          .build();
+      ImmutableMap<String, String> m3 = ImmutableMap.<String, String>builder()
+          .putAll(m1)
+          .put("y", "Z")
+          .build();
+      BlobInfo info1 = BlobInfo.newBuilder(bucketFixture.getBucketInfo(), "UpdateMask/001")
+          .setMetadata(m1).build();
+      Blob blob = sh.create(info1);
+      Blob update1 = sh.update(blob.toBuilder().setMetadata(m2).build(),
+          BlobTargetOption.metagenerationMatch());
+      Blob update2 = sg.update(update1.toBuilder().setMetadata(m3).build(),
+          BlobTargetOption.metagenerationMatch());
+
+      assertThat(update2.asBlobInfo()).isEqualTo(update1.asBlobInfo());
+    }
+  }
+  */
+
+  @RunWith(ParallelParameterized.class)
+  public static final class BucketReadMask {
+
+    private final BucketField field;
+    private final LazyAssertion<BucketInfo> assertion;
+
+    public BucketReadMask(Args<BucketField, BucketInfo> arg) {
+      this.field = arg.f;
+      this.assertion = arg.assertion;
+    }
+
+    @Test
+    public void get() {
+      BucketInfo bucketJson = getBucket(sh);
+      BucketInfo bucketGrpc = getBucket(sg);
+
+      assertion.validate(bucketJson, bucketGrpc);
+    }
+
+    @Test
+    public void list() {
+      List<BucketInfo> bucketsJson = listBuckets(sh);
+      List<BucketInfo> bucketsGrpc = listBuckets(sg);
+
+      assertion.pairwiseList().validate(bucketsJson, bucketsGrpc);
+    }
+
+    @Parameters(name = "{0}")
+    public static Iterable<Args<BucketField, BucketInfo>> parameters() {
+      ImmutableList<Args<BucketField, BucketInfo>> args =
+          ImmutableList.of(
+              new Args<>(BucketField.ACL, LazyAssertion.equal()),
+              new Args<>(BucketField.AUTOCLASS, LazyAssertion.equal()),
+              new Args<>(BucketField.BILLING, LazyAssertion.equal()),
+              new Args<>(BucketField.CORS, LazyAssertion.equal()),
+              new Args<>(BucketField.CUSTOM_PLACEMENT_CONFIG, LazyAssertion.equal()),
+              new Args<>(
+                  BucketField.DEFAULT_EVENT_BASED_HOLD,
+                  (jsonT, grpcT) -> {
+                    assertThat(jsonT.getDefaultEventBasedHold()).isNull();
+                    assertThat(grpcT.getDefaultEventBasedHold()).isFalse();
+                  }),
+              new Args<>(
+                  BucketField.DEFAULT_OBJECT_ACL,
+                  (jsonT, grpcT) -> {
+                    assertThat(jsonT.getDefaultAcl()).isNotEmpty();
+                    assertThat(grpcT.getDefaultAcl()).isNull();
+                  }),
+              new Args<>(BucketField.ENCRYPTION, LazyAssertion.equal()),
+              new Args<>(BucketField.ETAG, LazyAssertion.equal()),
+              new Args<>(BucketField.IAMCONFIGURATION, LazyAssertion.equal()),
+              new Args<>(BucketField.ID, LazyAssertion.equal()),
+              new Args<>(BucketField.LABELS, LazyAssertion.equal()),
+              new Args<>(BucketField.LIFECYCLE, LazyAssertion.equal()),
+              new Args<>(BucketField.LOCATION, LazyAssertion.equal()),
+              new Args<>(BucketField.LOCATION_TYPE, LazyAssertion.equal()),
+              new Args<>(BucketField.LOGGING, LazyAssertion.equal()),
+              new Args<>(BucketField.METAGENERATION, LazyAssertion.equal()),
+              new Args<>(BucketField.NAME, LazyAssertion.equal()),
+              new Args<>(BucketField.OWNER, LazyAssertion.equal()),
+              new Args<>(BucketField.RETENTION_POLICY, LazyAssertion.equal()),
+              new Args<>(
+                  BucketField.RPO,
+                  (jsonT, grpcT) -> {
+                    assertThat(jsonT.getRpo()).isEqualTo(Rpo.DEFAULT);
+                    assertThat(grpcT.getRpo()).isNull();
+                  }),
+              new Args<>(
+                  BucketField.SELF_LINK,
+                  (jsonT, grpcT) -> {
+                    assertThat(jsonT.getSelfLink()).isNotEmpty();
+                    assertThat(grpcT.getSelfLink()).isNull();
+                  }),
+              new Args<>(BucketField.STORAGE_CLASS, LazyAssertion.equal()),
+              new Args<>(BucketField.TIME_CREATED, LazyAssertion.equal()),
+              new Args<>(BucketField.UPDATED, LazyAssertion.equal()),
+              new Args<>(BucketField.VERSIONING, LazyAssertion.equal()),
+              new Args<>(BucketField.WEBSITE, LazyAssertion.equal()));
+
+      List<String> argsDefined =
+          args.stream().map(Args::getF).map(Enum::name).sorted().collect(Collectors.toList());
+
+      List<String> definedFields =
+          Arrays.stream(BucketField.values()).map(Enum::name).sorted().collect(Collectors.toList());
+
+      assertThat(argsDefined).containsExactlyElementsIn(definedFields);
+      return args;
+    }
+
+    private BucketInfo getBucket(Storage s) {
+      return s.get(blobId.getBucket(), BucketGetOption.fields(field)).asBucketInfo();
+    }
+
+    private List<BucketInfo> listBuckets(Storage s) {
+      Page<Bucket> p =
+          s.list(BucketListOption.prefix(blobId.getBucket()), BucketListOption.fields(field));
+      return StreamSupport.stream(p.iterateAll().spliterator(), false)
+          .map(Bucket::asBucketInfo)
+          .collect(Collectors.toList());
+    }
+  }
+
+  @RunWith(ParallelParameterized.class)
+  public static final class BlobReadMask {
+
+    private final BlobField field;
+    private final LazyAssertion<BlobInfo> assertion;
+
+    public BlobReadMask(Args<BlobField, BlobInfo> args) {
+      this.field = args.f;
+      this.assertion = args.assertion;
+    }
+
+    @Test
+    public void get() {
+      BlobInfo blobJson = getBlob(sh);
+      BlobInfo blobGrpc = getBlob(sg);
+
+      assertion.validate(blobJson, blobGrpc);
+    }
+
+    @Test
+    public void list() {
+      List<BlobInfo> blobsJson = listBlobs(sh);
+      List<BlobInfo> blobsGrpc = listBlobs(sg);
+
+      assertion.pairwiseList().validate(blobsJson, blobsGrpc);
+    }
+
+    @Parameters(name = "{0}")
+    public static Iterable<Args<BlobField, BlobInfo>> parameters() {
+      ImmutableList<Args<BlobField, BlobInfo>> args =
+          ImmutableList.of(
+              new Args<>(BlobField.ACL, LazyAssertion.equal()),
+              new Args<>(BlobField.BUCKET, LazyAssertion.equal()),
+              new Args<>(
+                  BlobField.CACHE_CONTROL,
+                  LazyAssertion.apiaryNullGrpcDefault("", BlobInfo::getCacheControl)),
+              // for non-composed objects, json and grpc differ in their resulting values. For json,
+              // a null will be returned whereas for grpc we will get the type default value which
+              // in this case is 0. The only possible way we could guard against this would be if
+              // the proto changed component_count to proto3_optional forcing it to generate a
+              // hasComponentCount.
+              new Args<>(
+                  BlobField.COMPONENT_COUNT,
+                  (jsonT, grpcT) -> {
+                    if (grpcT.getComponentCount() == 0) {
+                      assertThat(jsonT.getComponentCount()).isNull();
+                    } else {
+                      assertThat(grpcT.getComponentCount()).isEqualTo(jsonT.getComponentCount());
+                    }
+                  }),
+              new Args<>(
+                  BlobField.CONTENT_DISPOSITION,
+                  LazyAssertion.apiaryNullGrpcDefault("", BlobInfo::getContentDisposition)),
+              new Args<>(
+                  BlobField.CONTENT_ENCODING,
+                  LazyAssertion.apiaryNullGrpcDefault("", BlobInfo::getContentEncoding)),
+              new Args<>(
+                  BlobField.CONTENT_LANGUAGE,
+                  LazyAssertion.apiaryNullGrpcDefault("", BlobInfo::getContentLanguage)),
+              // we'd expect this to follow the patter of the other Content-* headers, however via
+              // the json api GCS will default null contentType to application/octet-stream. Note,
+              // however it doesn't carry this forward to composed objects so a composed object can
+              // have a null/empty content-type.
+              new Args<>(
+                  BlobField.CONTENT_TYPE,
+                  (jsonT, grpcT) -> {
+                    assertThat(jsonT.getContentType()).isAnyOf("application/octet-stream", null);
+                    assertThat(grpcT.getContentType()).isAnyOf("application/octet-stream", "");
+                  }),
+              new Args<>(BlobField.CRC32C, LazyAssertion.equal()),
+              new Args<>(BlobField.CUSTOMER_ENCRYPTION, LazyAssertion.equal()),
+              new Args<>(BlobField.CUSTOM_TIME, LazyAssertion.equal()),
+              new Args<>(BlobField.ETAG, LazyAssertion.equal()),
+              new Args<>(
+                  BlobField.EVENT_BASED_HOLD,
+                  LazyAssertion.apiaryNullGrpcDefault(false, BlobInfo::getEventBasedHold)),
+              new Args<>(BlobField.GENERATION, LazyAssertion.equal()),
+              new Args<>(
+                  BlobField.ID,
+                  (jsonT, grpcT) -> {
+                    assertThat(jsonT.getGeneratedId()).isNotEmpty();
+                    assertThat(grpcT.getGeneratedId()).isNull();
+                  }),
+              new Args<>(
+                  BlobField.KIND,
+                  (jsonT, grpcT) -> {
+                    // pass - we don't expose kind in the public surface
+                  }),
+              new Args<>(BlobField.KMS_KEY_NAME, LazyAssertion.equal()),
+              new Args<>(BlobField.MD5HASH, LazyAssertion.equal()),
+              new Args<>(
+                  BlobField.MEDIA_LINK,
+                  (jsonT, grpcT) -> {
+                    assertThat(jsonT.getMediaLink()).isNotEmpty();
+                    assertThat(grpcT.getMediaLink()).isNull();
+                  }),
+              new Args<>(BlobField.METADATA, LazyAssertion.equal()),
+              new Args<>(BlobField.METAGENERATION, LazyAssertion.equal()),
+              new Args<>(BlobField.NAME, LazyAssertion.equal()),
+              new Args<>(BlobField.OWNER, LazyAssertion.equal()),
+              new Args<>(BlobField.RETENTION_EXPIRATION_TIME, LazyAssertion.equal()),
+              new Args<>(
+                  BlobField.SELF_LINK,
+                  (jsonT, grpcT) -> {
+                    assertThat(jsonT.getSelfLink()).isNotEmpty();
+                    assertThat(grpcT.getSelfLink()).isNull();
+                  }),
+              new Args<>(BlobField.SIZE, LazyAssertion.equal()),
+              new Args<>(BlobField.STORAGE_CLASS, LazyAssertion.equal()),
+              new Args<>(
+                  BlobField.TEMPORARY_HOLD,
+                  LazyAssertion.apiaryNullGrpcDefault(false, BlobInfo::getTemporaryHold)),
+              new Args<>(BlobField.TIME_CREATED, LazyAssertion.equal()),
+              new Args<>(BlobField.TIME_DELETED, LazyAssertion.equal()),
+              new Args<>(BlobField.TIME_STORAGE_CLASS_UPDATED, LazyAssertion.equal()),
+              new Args<>(BlobField.UPDATED, LazyAssertion.equal()));
+      List<String> argsDefined =
+          args.stream().map(Args::getF).map(Enum::name).sorted().collect(Collectors.toList());
+
+      List<String> definedFields =
+          Arrays.stream(BlobField.values()).map(Enum::name).sorted().collect(Collectors.toList());
+
+      assertThat(argsDefined).containsExactlyElementsIn(definedFields);
+      return args;
+    }
+
+    private BlobInfo getBlob(Storage s) {
+      return s.get(blobId, BlobGetOption.fields(field)).asBlobInfo();
+    }
+
+    private List<BlobInfo> listBlobs(Storage s) {
+      Page<Blob> p =
+          s.list(
+              blobId.getBucket(),
+              BlobListOption.prefix(ITReadMaskTest.class.getSimpleName()),
+              BlobListOption.fields(field));
+      return StreamSupport.stream(p.iterateAll().spliterator(), false)
+          .map(Blob::asBlobInfo)
+          .collect(Collectors.toList());
+    }
+  }
+
+  private static String objName(String name) {
+    return String.format("%s/%s", ITReadMaskTest.class.getSimpleName(), name);
+  }
+
+  private static final class Args<F, T> {
+    private final F f;
+    private final LazyAssertion<T> assertion;
+
+    Args(F f, LazyAssertion<T> assertion) {
+      this.f = f;
+      this.assertion = assertion;
+    }
+
+    F getF() {
+      return f;
+    }
+
+    @Override
+    public String toString() {
+      return f.toString();
+    }
+  }
+
+  @FunctionalInterface
+  private interface LazyAssertion<T> {
+    void validate(T jsonT, T grpcT) throws AssertionError;
+
+    default LazyAssertion<List<T>> pairwiseList() {
+      LazyAssertion<T> self = this;
+      return (jsonTs, grpcTs) -> {
+        final int length = Math.min(jsonTs.size(), grpcTs.size());
+        int idx = 0;
+        for (; idx < length; idx++) {
+          T jT = jsonTs.get(idx);
+          T gT = grpcTs.get(idx);
+          self.validate(jT, gT);
+        }
+
+        assertThat(idx).isEqualTo(jsonTs.size());
+        assertThat(idx).isEqualTo(grpcTs.size());
+
+        assertThat(jsonTs.size()).isEqualTo(length);
+        assertThat(grpcTs.size()).isEqualTo(length);
+      };
+    }
+
+    static <X> LazyAssertion<X> equal() {
+      return (a, g) -> assertThat(g).isEqualTo(a);
+    }
+
+    static <X, F> LazyAssertion<X> apiaryNullGrpcDefault(F def, Function<X, F> extractor) {
+      return (jsonT, grpcT) -> {
+        assertThat(extractor.apply(jsonT)).isNull();
+        assertThat(extractor.apply(grpcT)).isEqualTo(def);
+      };
+    }
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITReadMaskTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITReadMaskTest.java
@@ -115,33 +115,6 @@ public final class ITReadMaskTest {
     blobId = blobId1;
   }
 
-  /*
-  public static final class UpdateMask {
-
-    @Test
-    public void nestedUpdate() {
-      ImmutableMap<String, String> m1 = ImmutableMap.of("x", "X");
-      ImmutableMap<String, String> m2 = ImmutableMap.<String, String>builder()
-          .putAll(m1)
-          .put("y", "Y")
-          .build();
-      ImmutableMap<String, String> m3 = ImmutableMap.<String, String>builder()
-          .putAll(m1)
-          .put("y", "Z")
-          .build();
-      BlobInfo info1 = BlobInfo.newBuilder(bucketFixture.getBucketInfo(), "UpdateMask/001")
-          .setMetadata(m1).build();
-      Blob blob = sh.create(info1);
-      Blob update1 = sh.update(blob.toBuilder().setMetadata(m2).build(),
-          BlobTargetOption.metagenerationMatch());
-      Blob update2 = sg.update(update1.toBuilder().setMetadata(m3).build(),
-          BlobTargetOption.metagenerationMatch());
-
-      assertThat(update2.asBlobInfo()).isEqualTo(update1.asBlobInfo());
-    }
-  }
-  */
-
   @RunWith(ParallelParameterized.class)
   public static final class BucketReadMask {
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/RequestAuditing.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/RequestAuditing.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 final class RequestAuditing extends HttpTransportOptions {
@@ -64,13 +65,18 @@ final class RequestAuditing extends HttpTransportOptions {
   }
 
   void assertQueryParam(String paramName, String expectedValue) {
+    assertQueryParam(paramName, expectedValue, Function.identity());
+  }
+
+  <T> void assertQueryParam(String paramName, T expectedValue, Function<String, T> transform) {
     ImmutableList<HttpRequest> requests = getRequests();
 
-    List<String> actual =
+    List<T> actual =
         requests.stream()
             .map(HttpRequest::getUrl)
             .distinct() // todo: figure out why requests seem to be recorded twice for blob create
             .map(u -> (String) u.getFirst(paramName))
+            .map(transform)
             .collect(Collectors.toList());
 
     assertThat(actual).isEqualTo(ImmutableList.of(expectedValue));


### PR DESCRIPTION
### Read Mask
Both JSON and gRPC provide the means of being able to specify a mask to select specific fields be returned in a response. However, there are slightly differing approaches taken between the different transports as well as outward facing impacts for existing code of our client.

Primary difference between JSON and gRPC is null vs default values. Several fields in gRPC can be excluded from the response from GCS but protobuf will still yield a value for our decoder. To address this compatibility issue, in the case of gRPC if a read_mask is defined we will clear out any non-selected field after decoding.

### Impact to existing JSON support
The new NamedField construct forces a decoupling from FieldSelector and it's associated Helper as JSON and gRPC have different formats for specifying their selectors/masks.

We are no longer using FieldSelector.Helper methods, instead we are using our own code to stitch together the values for selection. For JSON, we're not using the "slash form" presented in https://cloud.google.com/storage/docs/json_api#partial-response (i.e. `items/name,items/bucket` vs `items(name,bucket)`). Functionally these are equivalent and do not chang any of our tests which verify behavior.

### New internal only API
Both BlobInfo.Builder and BucketInfo.Builder have had `clear*` methods added to allow explicitly setting the field to `null` side stepping any possible guarding done in the respective `set*` method.

These clear methods will likely never be public, and also are no longer necessary if our decoders are field mask aware when they try to process a response.

### GrpcConversions
Fixed a couple decoder issues which present when comparing explicitly to json

### Field @TransportCompatibility
Added @TransportCompatibility too all BlobField and BucketField values

### ITReadMaskTest.java
Add a new test class which will validate expected behavior for all fields across json and grpc

### StorageImplMockitoTest.java
Remove 4 tests which weren't valuable now that we have more robust field selector and options tests
