### PR TITLE
fix: update GrpcBlobWriteChannel to share compatible behavior with BlobWriteChannel

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Buffers.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Buffers.java
@@ -113,9 +113,14 @@ final class Buffers {
    * <p>i.e. Given 344k size, 256k alignmentMultiple expect 512k
    */
   static ByteBuffer allocateAligned(int size, int alignmentMultiple) {
-    int actualSize = size;
+    int actualSize = alignSize(size, alignmentMultiple);
+    return allocate(actualSize);
+  }
+
+  static int alignSize(int size, int alignmentMultiple) {
+    int alignedSize = size;
     if (size < alignmentMultiple) {
-      actualSize = alignmentMultiple;
+      alignedSize = alignmentMultiple;
     } else if (size % alignmentMultiple != 0) {
       // TODO: this mod will cause two divisions to happen
       //   * try and measure how expensive two divisions is compared to one
@@ -124,8 +129,8 @@ final class Buffers {
 
       // add almost another full alignmentMultiple to the size
       // then integer divide it before multiplying it by the alignmentMultiple
-      actualSize = (size + alignmentMultiple - 1) / alignmentMultiple * alignmentMultiple;
+      alignedSize = (size + alignmentMultiple - 1) / alignmentMultiple * alignmentMultiple;
     } // else size is already aligned
-    return allocate(actualSize);
+    return alignedSize;
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicWritableByteChannelSessionBuilder.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicWritableByteChannelSessionBuilder.java
@@ -164,7 +164,7 @@ final class GapicWritableByteChannelSessionBuilder {
       return buffered(BufferHandle.handleOf(byteBuffer));
     }
 
-    private BufferedDirectUploadBuilder buffered(BufferHandle bufferHandle) {
+    BufferedDirectUploadBuilder buffered(BufferHandle bufferHandle) {
       return new BufferedDirectUploadBuilder(bufferHandle);
     }
 
@@ -260,7 +260,7 @@ final class GapicWritableByteChannelSessionBuilder {
       return buffered(BufferHandle.handleOf(byteBuffer));
     }
 
-    private BufferedResumableUploadBuilder buffered(BufferHandle bufferHandle) {
+    BufferedResumableUploadBuilder buffered(BufferHandle bufferHandle) {
       return new BufferedResumableUploadBuilder(bufferHandle);
     }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectTest.java
@@ -1553,9 +1553,6 @@ public class ITObjectTest {
 
   @Test
   public void testAutoContentTypeWriter() throws IOException {
-    // GRPC Write Channel bug
-    // b/248605626
-    assumeTrue(clientName.startsWith("JSON"));
     testAutoContentType("writer");
   }
 


### PR DESCRIPTION
Update GrpcBlobWriteChannel to always create and finalize an upload session even if `write` is never called. This change follows the behavior of BlobWriteChannel today and is done for compatibility sake.

Fixes b/248605626

