### PR TITLE
chore: fix native-image.properties to allow running jqwik tests

### DIFF
--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -17,7 +17,7 @@
   <properties>
     <site.installationModule>google-cloud-storage</site.installationModule>
     <kms.version>0.97.7</kms.version>
-    <junit-platform.version>5.8.2</junit-platform.version>
+    <junit-platform.version>5.9.1</junit-platform.version>
   </properties>
   <dependencies>
     <dependency>

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ShimClientTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ShimClientTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Somehow by having this class defined, it makes it so the native-image builds are able to find
+ * tests. If it isn't able to find tests, it will error and fail the build.
+ */
+public final class ShimClientTest {
+
+  @Test
+  public void fakeOutNativeMavenPlugin_test() {
+    assertThat(true).isTrue();
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITNotificationTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITNotificationTest.java
@@ -25,7 +25,6 @@ import com.google.cloud.storage.Notification;
 import com.google.cloud.storage.NotificationInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageFixture;
-import com.google.cloud.storage.testing.RemoteStorageHelper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.iam.v1.Binding;
@@ -35,8 +34,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.AfterClass;
@@ -139,7 +136,7 @@ public class ITNotificationTest {
   }
 
   @Test
-  public void testNotification() throws InterruptedException, ExecutionException {
+  public void testNotification() {
     NotificationInfo notificationInfo =
         NotificationInfo.newBuilder(TOPIC)
             .setCustomAttributes(CUSTOM_ATTRIBUTES)
@@ -190,8 +187,7 @@ public class ITNotificationTest {
           .isNull();
       assertThat(storage.listNotifications(bucketFixture.getBucketInfo().getName())).isEmpty();
     } finally {
-      RemoteStorageHelper.forceDelete(
-          storage, bucketFixture.getBucketInfo().getName(), 5, TimeUnit.SECONDS);
+      // delete is taken care of by BucketFixture now
     }
   }
 }

--- a/google-cloud-storage/src/test/resources/META-INF/native-image/com/google/cloud/storage/native-image.properties
+++ b/google-cloud-storage/src/test/resources/META-INF/native-image/com/google/cloud/storage/native-image.properties
@@ -26,7 +26,7 @@ Args = \
   com.google.gson.internal,\
   com.google.gson.internal.sql.SqlTypesSupport,\
   com.google.gson.FieldNamingPolicy$3,\
-  com.google.gson.LongSerializationPolicy$2
-
+  com.google.gson.LongSerializationPolicy$2,\
+  net.jqwik
 
 


### PR DESCRIPTION
test(deps): bump junit-platform.version to 5.9.1

Also removed a dangling bucket deletion in ITNotificationTest which was resulting in an exception at cleanup time.

