### PR TITLE
feat: add GrpcStorageOptions.Builder#setAttemptDirectPath

### DIFF
--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -151,6 +151,11 @@
       <artifactId>grpc-stub</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-googleapis</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-qual</artifactId>
     </dependency>
@@ -260,6 +265,11 @@
             <usedDependencies>io.grpc:grpc-xds</usedDependencies>
             <ignoredDependencies>
               <dependency>io.grpc:grpc-netty-shaded</dependency>
+              <!--
+              defining a runtime dependency on this so it is on the default classpath for customers wanting
+              to use direct path
+              -->
+              <dependency>io.grpc:grpc-googleapis</dependency>
               <!--
               We depend on `net.jqwik:jqwik` which itself has no classes, but depends on each of the other jars.
               In order to not churn on which of the sub apis we happen to be using at this time, we're flagging

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
@@ -39,6 +39,8 @@ import com.google.cloud.spi.ServiceRpcFactory;
 import com.google.cloud.storage.TransportCompatibility.Transport;
 import com.google.cloud.storage.spi.StorageRpcFactory;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.storage.v2.ReadObjectRequest;
 import com.google.storage.v2.ReadObjectResponse;
@@ -64,6 +66,7 @@ public final class GrpcStorageOptions extends StorageOptions
 
   private final GrpcRetryAlgorithmManager retryAlgorithmManager;
   private final Duration terminationAwaitDuration;
+  private final boolean attemptDirectPath;
 
   @BetaApi
   public GrpcStorageOptions(Builder builder, GrpcStorageDefaults serviceDefaults) {
@@ -75,6 +78,7 @@ public final class GrpcStorageOptions extends StorageOptions
     this.terminationAwaitDuration =
         MoreObjects.firstNonNull(
             builder.terminationAwaitDuration, serviceDefaults.getTerminationAwaitDuration());
+    this.attemptDirectPath = builder.attemptDirectPath;
   }
 
   @Override
@@ -94,10 +98,20 @@ public final class GrpcStorageOptions extends StorageOptions
 
   @InternalApi
   StorageSettings getStorageSettings() throws IOException {
-    URI uri = URI.create(getHost());
+    String endpoint = getHost();
+    URI uri = URI.create(endpoint);
     String scheme = uri.getScheme();
-    int port = uri.getPort() > 0 ? uri.getPort() : scheme.equals("http") ? 80 : 443;
-    String endpoint = String.format("%s:%d", uri.getHost(), port);
+    int port = uri.getPort();
+    // Gax routes the endpoint into a method which can't handle schemes, unless for direct path
+    // try and strip here if we can
+    switch (scheme) {
+      case "http":
+        endpoint = String.format("%s:%s", uri.getHost(), port > 0 ? port : 80);
+        break;
+      case "https":
+        endpoint = String.format("%s:%s", uri.getHost(), port > 0 ? port : 443);
+        break;
+    }
 
     CredentialsProvider credentialsProvider;
     if (credentials instanceof NoCredentials) {
@@ -112,13 +126,28 @@ public final class GrpcStorageOptions extends StorageOptions
             .setCredentialsProvider(credentialsProvider)
             .setClock(getClock());
 
-    if (scheme.equals("http")) {
-      builder.setTransportChannelProvider(
-          InstantiatingGrpcChannelProvider.newBuilder()
-              .setEndpoint(endpoint)
-              .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
-              .build());
+    InstantiatingGrpcChannelProvider.Builder channelProviderBuilder =
+        InstantiatingGrpcChannelProvider.newBuilder().setEndpoint(endpoint);
+
+    if (attemptDirectPath) {
+      channelProviderBuilder
+          .setAttemptDirectPath(true)
+          .setDirectPathServiceConfig(
+              ImmutableMap.of(
+                  "loadBalancingConfig",
+                  ImmutableList.of(
+                      ImmutableMap.of(
+                          "grpclb",
+                          ImmutableMap.of(
+                              "childPolicy",
+                              ImmutableList.of(
+                                  ImmutableMap.of("round_robin", ImmutableMap.of())))))));
     }
+
+    if (scheme.equals("http")) {
+      channelProviderBuilder.setChannelConfigurator(ManagedChannelBuilder::usePlaintext);
+    }
+    builder.setTransportChannelProvider(channelProviderBuilder.build());
     RetrySettings baseRetrySettings = getRetrySettings();
     RetrySettings readRetrySettings =
         baseRetrySettings
@@ -215,6 +244,7 @@ public final class GrpcStorageOptions extends StorageOptions
 
     private StorageRetryStrategy storageRetryStrategy;
     private Duration terminationAwaitDuration;
+    private boolean attemptDirectPath = GrpcStorageDefaults.INSTANCE.isAttemptDirectPath();
 
     Builder() {}
 
@@ -233,6 +263,22 @@ public final class GrpcStorageOptions extends StorageOptions
     public Builder setTerminationAwaitDuration(Duration terminationAwaitDuration) {
       this.terminationAwaitDuration =
           requireNonNull(terminationAwaitDuration, "terminationAwaitDuration must be non null");
+      return this;
+    }
+
+    /**
+     * Option which signifies the client should attempt to connect to gcs via Direct Path.
+     *
+     * <p>In order to use direct path, both this option must be true and the environment variable
+     * (not system property) {@code GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS} must be true.
+     *
+     * <p><i>NOTE</i>There is no need to specify a new endpoint via {@link #setHost(String)} as the
+     * underlying code will translate the normal {@code https://storage.googleapis.com:443} into the
+     * proper Direct Path URI for you.
+     */
+    @BetaApi
+    public GrpcStorageOptions.Builder setAttemptDirectPath(boolean attemptDirectPath) {
+      this.attemptDirectPath = attemptDirectPath;
       return this;
     }
 
@@ -379,6 +425,11 @@ public final class GrpcStorageOptions extends StorageOptions
     @BetaApi
     public Duration getTerminationAwaitDuration() {
       return Duration.ofMinutes(1);
+    }
+
+    @BetaApi
+    public boolean isAttemptDirectPath() {
+      return false;
     }
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
@@ -39,8 +39,6 @@ import com.google.cloud.spi.ServiceRpcFactory;
 import com.google.cloud.storage.TransportCompatibility.Transport;
 import com.google.cloud.storage.spi.StorageRpcFactory;
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.storage.v2.ReadObjectRequest;
 import com.google.storage.v2.ReadObjectResponse;
@@ -127,22 +125,9 @@ public final class GrpcStorageOptions extends StorageOptions
             .setClock(getClock());
 
     InstantiatingGrpcChannelProvider.Builder channelProviderBuilder =
-        InstantiatingGrpcChannelProvider.newBuilder().setEndpoint(endpoint);
-
-    if (attemptDirectPath) {
-      channelProviderBuilder
-          .setAttemptDirectPath(true)
-          .setDirectPathServiceConfig(
-              ImmutableMap.of(
-                  "loadBalancingConfig",
-                  ImmutableList.of(
-                      ImmutableMap.of(
-                          "grpclb",
-                          ImmutableMap.of(
-                              "childPolicy",
-                              ImmutableList.of(
-                                  ImmutableMap.of("round_robin", ImmutableMap.of())))))));
-    }
+        InstantiatingGrpcChannelProvider.newBuilder()
+            .setEndpoint(endpoint)
+            .setAttemptDirectPath(attemptDirectPath);
 
     if (scheme.equals("http")) {
       channelProviderBuilder.setChannelConfigurator(ManagedChannelBuilder::usePlaintext);


### PR DESCRIPTION
Add new builder method to all setting attempt of direct path connection.

If enabled, the underlying gapic client will be configured to attempt connecting via direct path and using client side load balancing.

deps: add a direct dependency to io.grpc:grpc-googleapis

Rumour has it this dependency will be removed from gax, and we need to pull it up to our level to ensure it's there for storage direct path.
