### PR TITLE
test: enable grpc config for ITBlobReadChannelTest

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobReadChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobReadChannel.java
@@ -146,7 +146,7 @@ class BlobReadChannel implements ReadChannel {
         lastEtag = etag;
         buffer = bytes;
       } catch (RetryHelper.RetryHelperException e) {
-        throw new IOException(e);
+        throw new IOException(e.getCause());
       }
       if (toRead > buffer.length) {
         endOfStream = true;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcBlobReadChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcBlobReadChannel.java
@@ -49,7 +49,8 @@ final class GrpcBlobReadChannel implements ReadChannel {
         new LazyReadChannel(
             Suppliers.memoize(
                 () -> {
-                  ReadObjectRequest req = seekReadObjectRequest(request, position, limit);
+                  ReadObjectRequest req =
+                      seekReadObjectRequest(request, position, limit - position);
                   return ResumableMedia.gapic()
                       .read()
                       .byteChannel(read)
@@ -111,6 +112,10 @@ final class GrpcBlobReadChannel implements ReadChannel {
 
   @Override
   public int read(ByteBuffer dst) throws IOException {
+    if (limit - position <= 0) {
+      close();
+      return -1;
+    }
     return lazyReadChannel.getChannel().read(dst);
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcBlobReadChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcBlobReadChannel.java
@@ -118,7 +118,13 @@ final class GrpcBlobReadChannel implements ReadChannel {
       close();
       return -1;
     }
-    return lazyReadChannel.getChannel().read(dst);
+    try {
+      return lazyReadChannel.getChannel().read(dst);
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IOException(StorageException.coalesce(e));
+    }
   }
 
   ApiFuture<Object> getResults() {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageV2ProtoUtils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageV2ProtoUtils.java
@@ -28,7 +28,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class StorageV2ProtoUtils {
 
-  private static final String VALIDATION_TEMPLATE = "0 <= offset <= limit (0 <= %s <= %s)";
+  private static final String VALIDATION_TEMPLATE =
+      "offset >= 0 && limit >= 0 (%s >= 0 && %s >= 0)";
 
   private static final Printer PROTO_PRINTER =
       JsonFormat.printer().omittingInsignificantWhitespace().preservingProtoFieldNames();
@@ -70,10 +71,6 @@ final class StorageV2ProtoUtils {
 
     if (!limitNull) {
       checkArgument(0 <= limit, VALIDATION_TEMPLATE, offset, limit);
-    }
-
-    if (!offsetNull && !limitNull) {
-      checkArgument(offset <= limit, VALIDATION_TEMPLATE, offset, limit);
     }
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
@@ -2199,7 +2199,7 @@ final class UnifiedOpts {
      */
     @Deprecated
     boolean autoGzipDecompression() {
-      return filterTo(ReturnRawInputStream.class).findFirst().map(r -> r.val).orElse(false);
+      return filterTo(ReturnRawInputStream.class).findFirst().map(r -> r.val).orElse(true);
     }
 
     Decoder<Blob, Blob> clearBlobFields() {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageV2ProtoUtilsTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageV2ProtoUtilsTest.java
@@ -47,9 +47,7 @@ public final class StorageV2ProtoUtilsTest {
 
   @Example
   void validation_offset_lteq_limit() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> seekReadObjectRequest(ReadObjectRequest.getDefaultInstance(), 3L, 2L));
+    seekReadObjectRequest(ReadObjectRequest.getDefaultInstance(), 3L, 2L);
     seekReadObjectRequest(ReadObjectRequest.getDefaultInstance(), 0L, 0L);
     seekReadObjectRequest(ReadObjectRequest.getDefaultInstance(), 1L, 1L);
   }
@@ -83,13 +81,10 @@ public final class StorageV2ProtoUtilsTest {
     } else if (offset == null && limit != null) {
       ReadObjectRequest seek = seekReadObjectRequest(srr.req, offset, limit);
       assertThat(seek.getReadLimit()).isEqualTo(limit);
-    } else if (offset <= limit) {
+    } else {
       ReadObjectRequest seek = seekReadObjectRequest(srr.req, offset, limit);
       assertThat(seek.getReadOffset()).isEqualTo(offset);
       assertThat(seek.getReadLimit()).isEqualTo(limit);
-    } else {
-      assertThrows(
-          IllegalArgumentException.class, () -> seekReadObjectRequest(srr.req, offset, limit));
     }
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
@@ -151,6 +151,7 @@ public class ITRetryConformanceTest {
             .setHost(TEST_BENCH.getBaseUri().replaceAll("https?://", ""))
             .setTestAllowFilter(
                 RetryTestCaseResolver.includeAll()
+                    // .and(RetryTestCaseResolver.specificMappings(44, 45))
                     .and(
                         (m, trc) ->
                             trc.getScenarioId()

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
@@ -28,7 +28,6 @@ import com.google.cloud.Binding;
 import com.google.cloud.Identity;
 import com.google.cloud.Policy;
 import com.google.cloud.ReadChannel;
-import com.google.cloud.RetryHelper.RetryHelperException;
 import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.Acl.User;
 import com.google.cloud.storage.Blob;
@@ -1172,11 +1171,8 @@ final class RpcMethodMappings {
                                     Channels.newChannel(ByteStreams.nullOutputStream());
                                 ByteStreams.copy(reader, write);
                               } catch (IOException e) {
-                                if (e.getCause() instanceof RetryHelperException) {
-                                  RetryHelperException cause = (RetryHelperException) e.getCause();
-                                  if (cause.getCause() instanceof BaseServiceException) {
-                                    throw cause.getCause();
-                                  }
+                                if (e.getCause() instanceof BaseServiceException) {
+                                  throw e.getCause();
                                 }
                               }
                             }))
@@ -1197,11 +1193,8 @@ final class RpcMethodMappings {
                                     Channels.newChannel(ByteStreams.nullOutputStream());
                                 ByteStreams.copy(reader, write);
                               } catch (IOException e) {
-                                if (e.getCause() instanceof RetryHelperException) {
-                                  RetryHelperException cause = (RetryHelperException) e.getCause();
-                                  if (cause.getCause() instanceof BaseServiceException) {
-                                    throw cause.getCause();
-                                  }
+                                if (e.getCause() instanceof BaseServiceException) {
+                                  throw e.getCause();
                                 }
                               }
                             }))

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobReadChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobReadChannelTest.java
@@ -184,31 +184,48 @@ public final class ITBlobReadChannelTest {
   }
 
   @Test
-  public void testReadChannelFail() {
-    String blobName = "test-read-channel-blob-fail";
+  public void
+      testReadChannel_preconditionFailureResultsInIOException_metagenerationMatch_specified() {
+    String blobName = testName.getMethodName();
     BlobInfo blob = BlobInfo.newBuilder(bucketFixture.getBucketInfo(), blobName).build();
     Blob remoteBlob = storage.create(blob);
     assertNotNull(remoteBlob);
     try (ReadChannel reader =
         storage.reader(blob.getBlobId(), Storage.BlobSourceOption.metagenerationMatch(-1L))) {
       reader.read(ByteBuffer.allocate(42));
-      fail("StorageException was expected");
+      fail("IOException was expected");
     } catch (IOException ex) {
       // expected
     }
+  }
+
+  @Test
+  public void testReadChannel_preconditionFailureResultsInIOException_generationMatch_specified() {
+    String blobName = testName.getMethodName();
+    BlobInfo blob = BlobInfo.newBuilder(bucketFixture.getBucketInfo(), blobName).build();
+    Blob remoteBlob = storage.create(blob);
+    assertNotNull(remoteBlob);
     try (ReadChannel reader =
         storage.reader(blob.getBlobId(), Storage.BlobSourceOption.generationMatch(-1L))) {
       reader.read(ByteBuffer.allocate(42));
-      fail("StorageException was expected");
+      fail("IOException was expected");
     } catch (IOException ex) {
       // expected
     }
+  }
+
+  @Test
+  public void testReadChannel_preconditionFailureResultsInIOException_generationMatch_extractor() {
+    String blobName = testName.getMethodName();
+    BlobInfo blob = BlobInfo.newBuilder(bucketFixture.getBucketInfo(), blobName).build();
+    Blob remoteBlob = storage.create(blob);
+    assertNotNull(remoteBlob);
     BlobId blobIdWrongGeneration =
         BlobId.of(bucketFixture.getBucketInfo().getName(), blobName, -1L);
     try (ReadChannel reader =
         storage.reader(blobIdWrongGeneration, Storage.BlobSourceOption.generationMatch())) {
       reader.read(ByteBuffer.allocate(42));
-      fail("StorageException was expected");
+      fail("IOException was expected");
     } catch (IOException ex) {
       // expected
     }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobReadChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobReadChannelTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.cloud.ReadChannel;
 import com.google.cloud.WriteChannel;
@@ -213,6 +214,9 @@ public final class ITBlobReadChannelTest {
 
   @Test
   public void testReadChannelFailUpdatedGeneration() throws IOException {
+    // this test scenario is valid for both grpc and json, however the current semantics of actual
+    // request interleaving are very different, so this specific test is only applicable to json.
+    assumeTrue(this.clientName.startsWith("JSON"));
     String blobName = "test-read-blob-fail-updated-generation";
     BlobInfo blob = BlobInfo.newBuilder(bucketFixture.getBucketInfo(), blobName).build();
     Random random = new Random();

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobReadChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobReadChannelTest.java
@@ -59,8 +59,6 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public final class ITBlobReadChannelTest {
 
-  // Stubbed From GRPC Uncomment Fixtures and parameters to enable GRPC tests
-
   private static final int _16MiB = 16 * 1024 * 1024;
   private static final int _256KiB = 256 * 1024;
   private static final String BLOB_STRING_CONTENT = "Hello Google Cloud Storage!";
@@ -76,10 +74,9 @@ public final class ITBlobReadChannelTest {
 
   @ClassRule(order = 1)
   public static final StorageFixture storageFixtureHttp = StorageFixture.defaultHttp();
-  /*
+
   @ClassRule(order = 1)
   public static final StorageFixture storageFixtureGrpc = StorageFixture.defaultGrpc();
-   */
 
   @ClassRule(order = 2)
   public static final BucketFixture bucketFixtureHttp =
@@ -87,14 +84,13 @@ public final class ITBlobReadChannelTest {
           .setBucketNameFmtString("java-storage-http-%s")
           .setHandle(storageFixtureHttp::getInstance)
           .build();
-  /*
+
   @ClassRule(order = 2)
   public static final BucketFixture bucketFixtureGrpc =
       BucketFixture.newBuilder()
           .setBucketNameFmtString("java-storage-grpc-%s")
           .setHandle(storageFixtureHttp::getInstance)
           .build();
-   */
 
   private final Storage storage;
   private final BucketFixture bucketFixture;
@@ -109,13 +105,9 @@ public final class ITBlobReadChannelTest {
 
   @Parameters(name = "{0}")
   public static Iterable<Object[]> data() {
-    return ImmutableList.of(new Object[] {"JSON/Prod", storageFixtureHttp, bucketFixtureHttp});
-    /*
     return ImmutableList.of(
         new Object[] {"JSON/Prod", storageFixtureHttp, bucketFixtureHttp},
         new Object[] {"GRPC/Prod", storageFixtureGrpc, bucketFixtureGrpc});
-    */
-
   }
 
   @Test


### PR DESCRIPTION
* fix: update GrpcBlobReadChannel to set limit as a number of bytes rather than end_offset
* fix: update StorageV2ProtoUtils#validation to treat limit as number of bytes to read rather than end_offset
* test: mark com.google.cloud.storage.it.ITBlobReadChannelTest.testReadChannelFailUpdatedGeneration as json only
* fix: update GrpcBlobReadChannel to match automatic decompression behavior of json
* fix: update GrpcBlobReadChannel to match exception behavior for failed preconditions
