### PR TITLE
fix: update codec handling for Bucket Retention Period

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryConversions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryConversions.java
@@ -17,7 +17,7 @@
 package com.google.cloud.storage;
 
 import static com.google.cloud.storage.Utils.dateTimeCodec;
-import static com.google.cloud.storage.Utils.durationMillisCodec;
+import static com.google.cloud.storage.Utils.durationSecondsCodec;
 import static com.google.cloud.storage.Utils.ifNonNull;
 import static com.google.cloud.storage.Utils.lift;
 import static com.google.cloud.storage.Utils.nullableDateTimeCodec;
@@ -376,7 +376,7 @@ final class ApiaryConversions {
       to.setRetentionPolicy(Data.nullOf(Bucket.RetentionPolicy.class));
     } else {
       Bucket.RetentionPolicy retentionPolicy = new Bucket.RetentionPolicy();
-      retentionPolicy.setRetentionPeriod(durationMillisCodec.encode(retentionPeriod));
+      retentionPolicy.setRetentionPeriod(durationSecondsCodec.encode(retentionPeriod));
       ifNonNull(
           from.getRetentionEffectiveTimeOffsetDateTime(),
           dateTimeCodec::encode,

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BackwardCompatibilityUtils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BackwardCompatibilityUtils.java
@@ -67,8 +67,8 @@ final class BackwardCompatibilityUtils {
                   .atOffset(ZoneOffset.UTC),
           odt -> requireNonNull(odt, "odt must be non null").toInstant().toEpochMilli());
 
-  static final Codec<@Nullable Duration, @Nullable Long> nullableDurationMillisCodec =
-      Utils.durationMillisCodec.nullable();
+  static final Codec<@Nullable Duration, @Nullable Long> nullableDurationSecondsCodec =
+      Utils.durationSecondsCodec.nullable();
 
   @SuppressWarnings("deprecation")
   static final Codec<DeleteRule, LifecycleRule> deleteRuleCodec =

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BucketInfo.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BucketInfo.java
@@ -18,7 +18,7 @@ package com.google.cloud.storage;
 
 import static com.google.cloud.storage.BackwardCompatibilityUtils.millisOffsetDateTimeCodec;
 import static com.google.cloud.storage.BackwardCompatibilityUtils.millisUtcCodec;
-import static com.google.cloud.storage.BackwardCompatibilityUtils.nullableDurationMillisCodec;
+import static com.google.cloud.storage.BackwardCompatibilityUtils.nullableDurationSecondsCodec;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Lists.newArrayList;
@@ -1425,7 +1425,7 @@ public class BucketInfo implements Serializable {
      */
     @BetaApi
     public Builder setRetentionPeriodDuration(Duration retentionPeriod) {
-      return setRetentionPeriod(nullableDurationMillisCodec.encode(retentionPeriod));
+      return setRetentionPeriod(nullableDurationSecondsCodec.encode(retentionPeriod));
     }
 
     /**
@@ -1883,7 +1883,7 @@ public class BucketInfo implements Serializable {
     /** @deprecated Use {@link #setRetentionPeriodDuration(Duration)} */
     @Override
     public Builder setRetentionPeriod(Long retentionPeriod) {
-      return setRetentionPeriodDuration(nullableDurationMillisCodec.decode(retentionPeriod));
+      return setRetentionPeriodDuration(nullableDurationSecondsCodec.decode(retentionPeriod));
     }
 
     @Override
@@ -2466,7 +2466,7 @@ public class BucketInfo implements Serializable {
   @BetaApi
   @Deprecated
   public Long getRetentionPeriod() {
-    return nullableDurationMillisCodec.encode(retentionPeriod);
+    return nullableDurationSecondsCodec.encode(retentionPeriod);
   }
 
   /** Returns the retention policy retention period. */

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
@@ -17,7 +17,7 @@
 package com.google.cloud.storage;
 
 import static com.google.cloud.storage.Utils.bucketNameCodec;
-import static com.google.cloud.storage.Utils.durationMillisCodec;
+import static com.google.cloud.storage.Utils.durationSecondsCodec;
 import static com.google.cloud.storage.Utils.ifNonNull;
 import static com.google.cloud.storage.Utils.lift;
 import static com.google.cloud.storage.Utils.projectNameCodec;
@@ -203,7 +203,7 @@ final class GrpcConversions {
       ifNonNull(retentionPolicy.getIsLocked(), to::setRetentionPolicyIsLocked);
       ifNonNull(
           retentionPolicy.getRetentionPeriod(),
-          Utils.durationMillisCodec::decode,
+          Utils.durationSecondsCodec::decode,
           to::setRetentionPeriodDuration);
       ifNonNull(
           retentionPolicy.getEffectiveTime(),
@@ -299,7 +299,7 @@ final class GrpcConversions {
       Bucket.RetentionPolicy.Builder retentionPolicyBuilder = to.getRetentionPolicyBuilder();
       ifNonNull(
           from.getRetentionPeriodDuration(),
-          durationMillisCodec::encode,
+          durationSecondsCodec::encode,
           retentionPolicyBuilder::setRetentionPeriod);
       ifNonNull(from.retentionPolicyIsLocked(), retentionPolicyBuilder::setIsLocked);
       if (from.retentionPolicyIsLocked() == Boolean.TRUE) {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Utils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Utils.java
@@ -50,8 +50,8 @@ final class Utils {
 
   static final DateTimeFormatter RFC_3339_DATE_TIME_FORMATTER =
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-  static final Codec<Duration, Long> durationMillisCodec =
-      Codec.of(Duration::toMillis, Duration::ofMillis);
+  static final Codec<Duration, Long> durationSecondsCodec =
+      Codec.of(Duration::getSeconds, Duration::ofSeconds);
 
   @VisibleForTesting
   static final Codec<OffsetDateTime, DateTime> dateTimeCodec =

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBucketTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBucketTest.java
@@ -43,6 +43,7 @@ import com.google.cloud.storage.conformance.retry.ParallelParameterized;
 import com.google.cloud.storage.testing.RemoteStorageHelper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -101,6 +102,7 @@ public class ITBucketTest {
   private static final byte[] BLOB_BYTE_CONTENT = {0xD, 0xE, 0xA, 0xD};
   private static final Map<String, String> BUCKET_LABELS = ImmutableMap.of("label1", "value1");
   private static final Long RETENTION_PERIOD = 5L;
+  private static final Duration RETENTION_DURATION = Duration.ofSeconds(5);
 
   public ITBucketTest(
       String clientName,
@@ -364,6 +366,8 @@ public class ITBucketTest {
       bucketInfo = BucketInfo.newBuilder(bucketName).setRetentionPeriod(RETENTION_PERIOD).build();
     }
     Bucket remoteBucket = storageFixtureHttp.getInstance().create(bucketInfo);
+    assertThat(remoteBucket.getRetentionPeriod()).isEqualTo(RETENTION_PERIOD);
+    assertThat(remoteBucket.getRetentionPeriodDuration()).isEqualTo(RETENTION_DURATION);
     try {
       assertNull(remoteBucket.retentionPolicyIsLocked());
       assertNotNull(remoteBucket.getRetentionEffectiveTime());


### PR DESCRIPTION
A Retention Periods duration is expressed in seconds, not milliseconds. Update test to ensure the retention period duration that is processed is interpreted in the correct units.

