### PR TITLE
fix: update Object Write handling to be able to specify an explicit crc32c value

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BackwardCompatibilityUtils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BackwardCompatibilityUtils.java
@@ -93,6 +93,7 @@ final class BackwardCompatibilityUtils {
       case OK:
         return 200;
         // 400 Bad Request
+      case DATA_LOSS:
       case INVALID_ARGUMENT:
       case OUT_OF_RANGE:
         return 400;
@@ -133,7 +134,6 @@ final class BackwardCompatibilityUtils {
       case ABORTED: // ?
       case CANCELLED: // ?
       case UNKNOWN: // ?
-      case DATA_LOSS: // ?
       default:
         return 0;
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcBlobWriteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcBlobWriteChannel.java
@@ -53,7 +53,8 @@ final class GrpcBlobWriteChannel implements WriteChannel {
       ClientStreamingCallable<WriteObjectRequest, WriteObjectResponse> write,
       RetryingDependencies deps,
       ResultRetryAlgorithm<?> alg,
-      Supplier<ApiFuture<ResumableWrite>> start) {
+      Supplier<ApiFuture<ResumableWrite>> start,
+      Hasher hasher) {
     lazyWriteChannel =
         new LazyWriteChannel(
             Suppliers.memoize(
@@ -61,7 +62,7 @@ final class GrpcBlobWriteChannel implements WriteChannel {
                     ResumableMedia.gapic()
                         .write()
                         .byteChannel(write)
-                        .setHasher(Hasher.noop())
+                        .setHasher(hasher)
                         .setByteStringStrategy(ByteStringStrategy.copy())
                         .resumable()
                         .withRetryConfig(deps, alg)

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
@@ -721,7 +721,11 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     /**
      * Returns an option for blob's data MD5 hash match. If this option is used the request will
      * fail if blobs' data MD5 hash does not match.
+     *
+     * @deprecated Please compute and use a crc32c checksum instead. {@link #crc32cMatch()}
      */
+    @Deprecated
+    @TransportCompatibility(Transport.HTTP)
     public static BlobWriteOption md5Match() {
       return new BlobWriteOption(UnifiedOpts.md5MatchExtractor());
     }
@@ -730,6 +734,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's data CRC32C checksum match. If this option is used the request
      * will fail if blobs' data CRC32C checksum does not match.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption crc32cMatch() {
       return new BlobWriteOption(UnifiedOpts.crc32cMatchExtractor());
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
@@ -331,8 +331,12 @@ final class UnifiedOpts {
   compatibility overloads
   -- */
 
-  static Crc32cMatch crc32cMatch(String i) {
+  static Crc32cMatch crc32cMatch(int i) {
     return new Crc32cMatch(i);
+  }
+
+  static Crc32cMatch crc32cMatch(String i) {
+    return new Crc32cMatch(Utils.crc32cCodec.decode(i));
   }
 
   static Delimiter currentDirectory() {
@@ -495,18 +499,17 @@ final class UnifiedOpts {
     return Md5MatchExtractor.INSTANCE;
   }
 
-  @Deprecated
   static final class Crc32cMatch implements ObjectTargetOpt {
     private static final long serialVersionUID = -8680237667319155418L;
-    private final String val;
+    private final int val;
 
-    private Crc32cMatch(String val) {
+    private Crc32cMatch(int val) {
       this.val = val;
     }
 
     @Override
     public Mapper<BlobInfo.Builder> blobInfo() {
-      return b -> b.setCrc32c(val);
+      return b -> b.setCrc32c(Utils.crc32cCodec.encode(val));
     }
 
     @Override
@@ -519,6 +522,14 @@ final class UnifiedOpts {
       }
       Crc32cMatch that = (Crc32cMatch) o;
       return Objects.equals(val, that.val);
+    }
+
+    @Override
+    public Mapper<WriteObjectRequest.Builder> writeObject() {
+      return b -> {
+        b.getObjectChecksumsBuilder().setCrc32C(val);
+        return b;
+      };
     }
 
     @Override

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Utils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Utils.java
@@ -23,6 +23,8 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.storage.Conversions.Codec;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.BaseEncoding;
+import com.google.common.primitives.Ints;
 import com.google.storage.v2.BucketName;
 import com.google.storage.v2.ProjectName;
 import java.time.Duration;
@@ -147,6 +149,9 @@ final class Utils {
             }
           });
 
+  static final Codec<Integer, String> crc32cCodec =
+      Codec.of(Utils::crc32cEncode, Utils::crc32cDecode);
+
   private Utils() {}
 
   /**
@@ -227,5 +232,14 @@ final class Utils {
       }
     }
     throw new IllegalStateException("Unable to resolve non-null value");
+  }
+
+  private static int crc32cDecode(String from) {
+    byte[] decodeCrc32c = BaseEncoding.base64().decode(from);
+    return Ints.fromByteArray(decodeCrc32c);
+  }
+
+  private static String crc32cEncode(int from) {
+    return BaseEncoding.base64().encode(Ints.toByteArray(from));
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BackwardCompatibilityUtilsTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BackwardCompatibilityUtilsTest.java
@@ -113,7 +113,7 @@ public final class BackwardCompatibilityUtilsTest {
     expected.put(Code.CANCELLED, 0);
     expected.put(Code.UNKNOWN, 0);
     expected.put(Code.DEADLINE_EXCEEDED, 504);
-    expected.put(Code.DATA_LOSS, 0);
+    expected.put(Code.DATA_LOSS, 400);
 
     EnumMap<Code, Integer> actual = new EnumMap<>(Code.class);
     for (Code c : Code.values()) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BucketTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BucketTest.java
@@ -45,6 +45,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -484,6 +485,7 @@ public class BucketTest {
     BlobInfo info = BlobInfo.newBuilder(BlobId.of("b", "n")).setContentType(CONTENT_TYPE).build();
     Blob expectedBlob = info.asBlob(serviceMockReturnsOptions);
     byte[] content = {0xD, 0xE, 0xA, 0xD};
+    String crc32c = Utils.crc32cCodec.encode(Hashing.crc32c().hashBytes(content).asInt());
     Storage.PredefinedAcl acl = Storage.PredefinedAcl.ALL_AUTHENTICATED_USERS;
     InputStream streamContent = new ByteArrayInputStream(content);
     expect(storage.getOptions()).andReturn(mockOptions);
@@ -494,7 +496,7 @@ public class BucketTest {
                 new BlobWriteOption(UnifiedOpts.generationMatch(42L)),
                 new BlobWriteOption(UnifiedOpts.metagenerationMatch(24L)),
                 Storage.BlobWriteOption.predefinedAcl(acl),
-                new BlobWriteOption(UnifiedOpts.crc32cMatch("crc")),
+                new BlobWriteOption(UnifiedOpts.crc32cMatch(crc32c)),
                 new BlobWriteOption(UnifiedOpts.md5Match("md5")),
                 Storage.BlobWriteOption.encryptionKey(BASE64_KEY),
                 Storage.BlobWriteOption.userProject(USER_PROJECT)))
@@ -509,7 +511,7 @@ public class BucketTest {
             Bucket.BlobWriteOption.generationMatch(42L),
             Bucket.BlobWriteOption.metagenerationMatch(24L),
             Bucket.BlobWriteOption.predefinedAcl(acl),
-            Bucket.BlobWriteOption.crc32cMatch("crc"),
+            Bucket.BlobWriteOption.crc32cMatch(crc32c),
             Bucket.BlobWriteOption.md5Match("md5"),
             Bucket.BlobWriteOption.encryptionKey(BASE64_KEY),
             Bucket.BlobWriteOption.userProject(USER_PROJECT));


### PR DESCRIPTION
Storage#createFrom and Storage#writer allow specifying an explicit crc32c value which should be passed to GCS for validation. Update our uploads to allow these explicitly defined values to be passed in the `finish_write` message to GCS.

Update UnifiedOpts.Crc32cValue to represent its value as an int rather than the b64 string from apiary. Internally when the value is necessary for apiary it will be converted to the b64 string representation.

Map gRPC Status `DATA_LOSS` to HTTP 400 Bad Request to mirror the behavior of JSON when a checksum validation fails.

Add a new Hasher.constant instant which will function to specify a constant value for the cumulative value of a write.

Various plumbing tweaks to allow passing this value all the way down and also attempting to "nullSafeConcat"

Add new integration tests to try the negative case to ensue we are getting checksum failures when we pass mismatch values and content.