### PR TITLE
chore: update javadocs, TransportCompatibility and serialVersionUID values ahead of merge to main

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Acl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Acl.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  */
 public final class Acl implements Serializable {
 
-  private static final long serialVersionUID = 7516713233557576082L;
+  private static final long serialVersionUID = -1000021464049679956L;
 
   private final Entity entity;
   private final Role role;
@@ -41,7 +41,7 @@ public final class Acl implements Serializable {
   private final String etag;
 
   public static final class Role extends StringEnumValue {
-    private static final long serialVersionUID = 123037132067643600L;
+    private static final long serialVersionUID = 2067949416720207403L;
 
     private Role(String constant) {
       super(constant);
@@ -125,7 +125,7 @@ public final class Acl implements Serializable {
   /** Base class for Access Control List entities. */
   public abstract static class Entity implements Serializable {
 
-    private static final long serialVersionUID = -2707407252771255840L;
+    private static final long serialVersionUID = 2321254094152522444L;
 
     private final Type type;
     private final String value;
@@ -179,7 +179,7 @@ public final class Acl implements Serializable {
   /** Class for ACL Domain entities. */
   public static final class Domain extends Entity {
 
-    private static final long serialVersionUID = -3033025857280447253L;
+    private static final long serialVersionUID = 6852649665598880139L;
 
     /**
      * Creates a domain entity.
@@ -199,7 +199,7 @@ public final class Acl implements Serializable {
   /** Class for ACL Group entities. */
   public static final class Group extends Entity {
 
-    private static final long serialVersionUID = -1660987136294408826L;
+    private static final long serialVersionUID = 5642929747944714384L;
 
     /**
      * Creates a group entity.
@@ -219,7 +219,7 @@ public final class Acl implements Serializable {
   /** Class for ACL User entities. */
   public static final class User extends Entity {
 
-    private static final long serialVersionUID = 3076518036392737008L;
+    private static final long serialVersionUID = -4113630416489429660L;
     static final String ALL_USERS = "allUsers";
     static final String ALL_AUTHENTICATED_USERS = "allAuthenticatedUsers";
 
@@ -249,13 +249,13 @@ public final class Acl implements Serializable {
   /** Class for ACL Project entities. */
   public static final class Project extends Entity {
 
-    private static final long serialVersionUID = 7933776866530023027L;
+    private static final long serialVersionUID = -743189540406339074L;
 
     private final ProjectRole projectRole;
     private final String projectId;
 
     public static final class ProjectRole extends StringEnumValue {
-      private static final long serialVersionUID = -8360324311187914382L;
+      private static final long serialVersionUID = 1284991422168016498L;
 
       private ProjectRole(String constant) {
         super(constant);
@@ -335,7 +335,7 @@ public final class Acl implements Serializable {
 
   public static final class RawEntity extends Entity {
 
-    private static final long serialVersionUID = 3966205614223053950L;
+    private static final long serialVersionUID = -3049252571732490102L;
 
     RawEntity(String entity) {
       super(Type.UNKNOWN, entity);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Blob.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Blob.java
@@ -88,6 +88,7 @@ public class Blob extends BlobInfo {
      * Returns an option for blob's generation match. If this option is used the request will fail
      * if generation does not match.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption generationMatch() {
       return new BlobSourceOption(UnifiedOpts.generationMatchExtractor());
     }
@@ -99,6 +100,7 @@ public class Blob extends BlobInfo {
      * @deprecated This option is invalid, and can never result in a valid response from the server.
      */
     @Deprecated
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption generationNotMatch() {
       return new BlobSourceOption(UnifiedOpts.generationNotMatchExtractor());
     }
@@ -107,6 +109,7 @@ public class Blob extends BlobInfo {
      * Returns an option for blob's metageneration match. If this option is used the request will
      * fail if metageneration does not match.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption metagenerationMatch() {
       return new BlobSourceOption(UnifiedOpts.metagenerationMatchExtractor());
     }
@@ -115,6 +118,7 @@ public class Blob extends BlobInfo {
      * Returns an option for blob's metageneration mismatch. If this option is used the request will
      * fail if metageneration matches.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption metagenerationNotMatch() {
       return new BlobSourceOption(UnifiedOpts.metagenerationNotMatchExtractor());
     }
@@ -123,6 +127,7 @@ public class Blob extends BlobInfo {
      * Returns an option to set a customer-supplied AES256 key for server-side encryption of the
      * blob.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption decryptionKey(Key key) {
       return new BlobSourceOption(UnifiedOpts.decryptionKey(key));
     }
@@ -133,6 +138,7 @@ public class Blob extends BlobInfo {
      *
      * @param key the AES256 encoded in base64
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption decryptionKey(String key) {
       return new BlobSourceOption(UnifiedOpts.decryptionKey(key));
     }
@@ -141,6 +147,7 @@ public class Blob extends BlobInfo {
      * Returns an option for blob's billing user project. This option is used only if the blob's
      * bucket has requester_pays flag enabled.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption userProject(String userProject) {
       return new BlobSourceOption(UnifiedOpts.userProject(userProject));
     }
@@ -150,6 +157,7 @@ public class Blob extends BlobInfo {
      * automatically decompressing the content. By default, this is false for Blob.downloadTo(), but
      * true for ReadChannel.read().
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption shouldReturnRawInputStream(boolean shouldReturnRawInputStream) {
       return new BlobSourceOption(UnifiedOpts.returnRawInputStream(shouldReturnRawInputStream));
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Blob.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Blob.java
@@ -67,9 +67,10 @@ import java.util.concurrent.TimeUnit;
  * byte[] content = blob.getContent(); // one or multiple RPC calls will be issued
  * }</pre>
  */
+@TransportCompatibility({Transport.HTTP, Transport.GRPC})
 public class Blob extends BlobInfo {
 
-  private static final long serialVersionUID = -6242932432991389329L;
+  private static final long serialVersionUID = 5007541696912440917L;
 
   private final StorageOptions options;
   private transient Storage storage;
@@ -77,7 +78,7 @@ public class Blob extends BlobInfo {
   /** Class for specifying blob source options when {@code Blob} methods are used. */
   public static class BlobSourceOption extends Option<ObjectSourceOpt> {
 
-    private static final long serialVersionUID = 214616862061934846L;
+    private static final long serialVersionUID = 8205000496563385634L;
 
     private BlobSourceOption(ObjectSourceOpt opt) {
       super(opt);
@@ -1162,7 +1163,11 @@ public class Blob extends BlobInfo {
     return Objects.hash(super.hashCode(), options);
   }
 
-  /** Drop the held {@link Storage} instance. */
+  /**
+   * Drop the held {@link Storage} instance.
+   *
+   * @since 2.14.0 This new api is in preview and is subject to breaking changes.
+   */
   @BetaApi
   public BlobInfo asBlobInfo() {
     return this.toBuilder().infoBuilder.build();

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobId.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobId.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
  */
 public final class BlobId implements Serializable {
 
-  private static final long serialVersionUID = -6156002883225601925L;
+  private static final long serialVersionUID = 8201580858265557469L;
   private final String bucket;
   private final String name;
   private final Long generation;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobInfo.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobInfo.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.api.client.util.Data;
 import com.google.api.core.BetaApi;
 import com.google.cloud.storage.Storage.BlobField;
+import com.google.cloud.storage.TransportCompatibility.Transport;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -58,9 +59,10 @@ import java.util.Set;
  * @see <a href="https://cloud.google.com/storage/docs/concepts-techniques#concepts">Concepts and
  *     Terminology</a>
  */
+@TransportCompatibility({Transport.HTTP, Transport.GRPC})
 public class BlobInfo implements Serializable {
 
-  private static final long serialVersionUID = -5625857076205028976L;
+  private static final long serialVersionUID = -2490471217826624578L;
   private final BlobId blobId;
   private final String generatedId;
   private final String selfLink;
@@ -115,7 +117,7 @@ public class BlobInfo implements Serializable {
    */
   public static class CustomerEncryption implements Serializable {
 
-    private static final long serialVersionUID = -2133042982786959351L;
+    private static final long serialVersionUID = -7427738060808591323L;
 
     private final String encryptionAlgorithm;
     private final String keySha256;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobReadChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobReadChannel.java
@@ -181,7 +181,7 @@ class BlobReadChannel implements ReadChannel {
 
   static class StateImpl implements RestorableState<ReadChannel>, Serializable {
 
-    private static final long serialVersionUID = 3889420316004453706L;
+    private static final long serialVersionUID = 7784852608213694645L;
 
     private final HttpStorageOptions serviceOptions;
     private final BlobId blob;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobWriteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobWriteChannel.java
@@ -329,7 +329,7 @@ class BlobWriteChannel extends BaseWriteChannel<StorageOptions, BlobInfo> {
 
   static class StateImpl extends BaseWriteChannel.BaseState<StorageOptions, BlobInfo> {
 
-    private static final long serialVersionUID = -9028324143780151286L;
+    private static final long serialVersionUID = -6700378962714601115L;
 
     private final ResultRetryAlgorithm<?> algorithmForWrite;
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Bucket.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Bucket.java
@@ -61,6 +61,7 @@ public class Bucket extends BucketInfo {
   private transient Storage storage;
 
   /** Class for specifying bucket source options when {@code Bucket} methods are used. */
+  @TransportCompatibility({Transport.HTTP, Transport.GRPC})
   public static class BucketSourceOption extends Option<BucketSourceOpt> {
 
     private static final long serialVersionUID = 6765489853972162215L;
@@ -73,6 +74,7 @@ public class Bucket extends BucketInfo {
      * Returns an option for bucket's metageneration match. If this option is used the request will
      * fail if metageneration does not match.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketSourceOption metagenerationMatch() {
       return new BucketSourceOption(UnifiedOpts.metagenerationMatchExtractor());
     }
@@ -81,6 +83,7 @@ public class Bucket extends BucketInfo {
      * Returns an option for bucket's metageneration mismatch. If this option is used the request
      * will fail if metageneration matches.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketSourceOption metagenerationNotMatch() {
       return new BucketSourceOption(UnifiedOpts.metagenerationNotMatchExtractor());
     }
@@ -89,6 +92,7 @@ public class Bucket extends BucketInfo {
      * Returns an option for blob's billing user project. This option is only used by the buckets
      * with 'requester_pays' flag.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketSourceOption userProject(String userProject) {
       return new BucketSourceOption(UnifiedOpts.userProject(userProject));
     }
@@ -137,6 +141,7 @@ public class Bucket extends BucketInfo {
     }
 
     /** Returns an option for specifying blob's predefined ACL configuration. */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption predefinedAcl(Storage.PredefinedAcl acl) {
       return new BlobTargetOption(UnifiedOpts.predefinedAcl(acl));
     }
@@ -146,6 +151,7 @@ public class Bucket extends BucketInfo {
      * This option can not be provided together with {@link #generationMatch(long)} or {@link
      * #generationNotMatch(long)}.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption doesNotExist() {
       return new BlobTargetOption(UnifiedOpts.doesNotExist());
     }
@@ -155,6 +161,7 @@ public class Bucket extends BucketInfo {
      * fail if generation does not match the provided value. This option can not be provided
      * together with {@link #generationNotMatch(long)} or {@link #doesNotExist()}.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption generationMatch(long generation) {
       return new BlobTargetOption(UnifiedOpts.generationMatch(generation));
     }
@@ -164,6 +171,7 @@ public class Bucket extends BucketInfo {
      * will fail if blob's generation matches the provided value. This option can not be provided
      * together with {@link #generationMatch(long)} or {@link #doesNotExist()}.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption generationNotMatch(long generation) {
       return new BlobTargetOption(UnifiedOpts.generationNotMatch(generation));
     }
@@ -173,6 +181,7 @@ public class Bucket extends BucketInfo {
      * fail if metageneration does not match the provided value. This option can not be provided
      * together with {@link #metagenerationNotMatch(long)}.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption metagenerationMatch(long metageneration) {
       return new BlobTargetOption(UnifiedOpts.metagenerationMatch(metageneration));
     }
@@ -182,6 +191,7 @@ public class Bucket extends BucketInfo {
      * fail if metageneration matches the provided value. This option can not be provided together
      * with {@link #metagenerationMatch(long)}.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption metagenerationNotMatch(long metageneration) {
       return new BlobTargetOption(UnifiedOpts.metagenerationNotMatch(metageneration));
     }
@@ -190,6 +200,7 @@ public class Bucket extends BucketInfo {
      * Returns an option to set a customer-supplied AES256 key for server-side encryption of the
      * blob.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption encryptionKey(Key key) {
       return new BlobTargetOption(UnifiedOpts.encryptionKey(key));
     }
@@ -200,6 +211,7 @@ public class Bucket extends BucketInfo {
      *
      * @param key the AES256 encoded in base64
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption encryptionKey(String key) {
       return new BlobTargetOption(UnifiedOpts.encryptionKey(key));
     }
@@ -209,6 +221,7 @@ public class Bucket extends BucketInfo {
      *
      * @param kmsKeyName the KMS key resource id
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption kmsKeyName(String kmsKeyName) {
       return new BlobTargetOption(UnifiedOpts.kmsKeyName(kmsKeyName));
     }
@@ -217,6 +230,7 @@ public class Bucket extends BucketInfo {
      * Returns an option for blob's billing user project. This option is only used by the buckets
      * with 'requester_pays' flag.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption userProject(String userProject) {
       return new BlobTargetOption(UnifiedOpts.userProject(userProject));
     }
@@ -248,6 +262,7 @@ public class Bucket extends BucketInfo {
     }
 
     /** Returns an option for specifying blob's predefined ACL configuration. */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption predefinedAcl(Storage.PredefinedAcl acl) {
       return new BlobWriteOption(UnifiedOpts.predefinedAcl(acl));
     }
@@ -257,6 +272,7 @@ public class Bucket extends BucketInfo {
      * This option can not be provided together with {@link #generationMatch(long)} or {@link
      * #generationNotMatch(long)}.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption doesNotExist() {
       return new BlobWriteOption(UnifiedOpts.doesNotExist());
     }
@@ -266,6 +282,7 @@ public class Bucket extends BucketInfo {
      * fail if generation does not match the provided value. This option can not be provided
      * together with {@link #generationNotMatch(long)} or {@link #doesNotExist()}.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption generationMatch(long generation) {
       return new BlobWriteOption(UnifiedOpts.generationMatch(generation));
     }
@@ -275,6 +292,7 @@ public class Bucket extends BucketInfo {
      * will fail if generation matches the provided value. This option can not be provided together
      * with {@link #generationMatch(long)} or {@link #doesNotExist()}.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption generationNotMatch(long generation) {
       return new BlobWriteOption(UnifiedOpts.generationNotMatch(generation));
     }
@@ -284,6 +302,7 @@ public class Bucket extends BucketInfo {
      * fail if metageneration does not match the provided value. This option can not be provided
      * together with {@link #metagenerationNotMatch(long)}.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption metagenerationMatch(long metageneration) {
       return new BlobWriteOption(UnifiedOpts.metagenerationMatch(metageneration));
     }
@@ -293,6 +312,7 @@ public class Bucket extends BucketInfo {
      * fail if metageneration matches the provided value. This option can not be provided together
      * with {@link #metagenerationMatch(long)}.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption metagenerationNotMatch(long metageneration) {
       return new BlobWriteOption(UnifiedOpts.metagenerationNotMatch(metageneration));
     }
@@ -301,6 +321,7 @@ public class Bucket extends BucketInfo {
      * Returns an option for blob's data MD5 hash match. If this option is used the request will
      * fail if blobs' data MD5 hash does not match the provided value.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption md5Match(String md5) {
       return new BlobWriteOption(UnifiedOpts.md5Match(md5));
     }
@@ -309,6 +330,7 @@ public class Bucket extends BucketInfo {
      * Returns an option for blob's data CRC32C checksum match. If this option is used the request
      * will fail if blobs' data CRC32C checksum does not match the provided value.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption crc32cMatch(String crc32c) {
       return new BlobWriteOption(UnifiedOpts.crc32cMatch(crc32c));
     }
@@ -317,6 +339,7 @@ public class Bucket extends BucketInfo {
      * Returns an option to set a customer-supplied AES256 key for server-side encryption of the
      * blob.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption encryptionKey(Key key) {
       return new BlobWriteOption(UnifiedOpts.encryptionKey(key));
     }
@@ -327,6 +350,7 @@ public class Bucket extends BucketInfo {
      *
      * @param key the AES256 encoded in base64
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption encryptionKey(String key) {
       return new BlobWriteOption(UnifiedOpts.encryptionKey(key));
     }
@@ -335,6 +359,7 @@ public class Bucket extends BucketInfo {
      * Returns an option for blob's billing user project. This option is only used by the buckets
      * with 'requester_pays' flag.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption userProject(String userProject) {
       return new BlobWriteOption(UnifiedOpts.userProject(userProject));
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Bucket.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Bucket.java
@@ -52,9 +52,10 @@ import java.util.Objects;
  * return a new object. To get a {@code Bucket} object with the most recent information use {@link
  * #reload}. {@code Bucket} adds a layer of service-related functionality over {@link BucketInfo}.
  */
+@TransportCompatibility({Transport.HTTP, Transport.GRPC})
 public class Bucket extends BucketInfo {
 
-  private static final long serialVersionUID = -5916736761953534767L;
+  private static final long serialVersionUID = 3599706574671671516L;
 
   private final StorageOptions options;
   private transient Storage storage;
@@ -62,7 +63,7 @@ public class Bucket extends BucketInfo {
   /** Class for specifying bucket source options when {@code Bucket} methods are used. */
   public static class BucketSourceOption extends Option<BucketSourceOpt> {
 
-    private static final long serialVersionUID = 6928872234155522371L;
+    private static final long serialVersionUID = 6765489853972162215L;
 
     private BucketSourceOption(BucketSourceOpt opt) {
       super(opt);
@@ -129,7 +130,7 @@ public class Bucket extends BucketInfo {
   /** Class for specifying blob target options when {@code Bucket} methods are used. */
   public static class BlobTargetOption extends Option<ObjectTargetOpt> {
 
-    private static final long serialVersionUID = 8345296337342509425L;
+    private static final long serialVersionUID = -7203767045761758606L;
 
     private BlobTargetOption(ObjectTargetOpt opt) {
       super(opt);
@@ -240,7 +241,7 @@ public class Bucket extends BucketInfo {
   /** Class for specifying blob write options when {@code Bucket} methods are used. */
   public static class BlobWriteOption extends OptionShim<ObjectTargetOpt> implements Serializable {
 
-    private static final long serialVersionUID = -1103041630932223724L;
+    private static final long serialVersionUID = 59762268190041584L;
 
     private BlobWriteOption(ObjectTargetOpt opt) {
       super(opt);
@@ -952,7 +953,7 @@ public class Bucket extends BucketInfo {
    * @return an immutable list of {@code Blob} objects
    * @throws StorageException upon failure
    */
-  @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+  @TransportCompatibility({Transport.HTTP})
   public List<Blob> get(String blobName1, String blobName2, String... blobNames) {
     List<BlobId> blobIds = Lists.newArrayListWithCapacity(blobNames.length + 2);
     blobIds.add(BlobId.of(getName(), blobName1));
@@ -986,7 +987,7 @@ public class Bucket extends BucketInfo {
    * @return an immutable list of {@code Blob} objects
    * @throws StorageException upon failure
    */
-  @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+  @TransportCompatibility({Transport.HTTP})
   public List<Blob> get(Iterable<String> blobNames) {
     ImmutableList.Builder<BlobId> builder = ImmutableList.builder();
     for (String blobName : blobNames) {
@@ -1351,7 +1352,11 @@ public class Bucket extends BucketInfo {
     return Objects.hash(super.hashCode(), options);
   }
 
-  /** Drop the held {@link Storage} instance. */
+  /**
+   * Drop the held {@link Storage} instance.
+   *
+   * @since 2.14.0 This new api is in preview and is subject to breaking changes.
+   */
   @BetaApi
   public BucketInfo asBucketInfo() {
     return this.toBuilder().infoBuilder.build();

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BucketInfo.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BucketInfo.java
@@ -30,6 +30,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.services.storage.model.Bucket.Lifecycle.Rule;
 import com.google.cloud.storage.Acl.Entity;
 import com.google.cloud.storage.Storage.BucketField;
+import com.google.cloud.storage.TransportCompatibility.Transport;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -57,6 +58,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * @see <a href="https://cloud.google.com/storage/docs/concepts-techniques#concepts">Concepts and
  *     Terminology</a>
  */
+@TransportCompatibility({Transport.HTTP, Transport.GRPC})
 public class BucketInfo implements Serializable {
 
   // this class reference (LifecycleRule.DeleteLifecycleAction) must be long form.
@@ -70,7 +72,7 @@ public class BucketInfo implements Serializable {
   private static final Predicate<LifecycleRule> IS_DELETE_LIFECYCLE_RULE =
       r -> r.getAction().getActionType().equals(LifecycleRule.DeleteLifecycleAction.TYPE);
 
-  private static final long serialVersionUID = -4712013629621638459L;
+  private static final long serialVersionUID = 4793572058456298945L;
   private final String generatedId;
   private final String project;
   private final String name;
@@ -172,7 +174,7 @@ public class BucketInfo implements Serializable {
    *     href="https://cloud.google.com/storage/docs/public-access-prevention">public-access-prevention</a>
    */
   public static class IamConfiguration implements Serializable {
-    private static final long serialVersionUID = -8671736104909424616L;
+    private static final long serialVersionUID = -7564209362829587435L;
 
     private final Boolean isUniformBucketLevelAccessEnabled;
     private final OffsetDateTime uniformBucketLevelAccessLockedTime;
@@ -344,7 +346,7 @@ public class BucketInfo implements Serializable {
    */
   public static class CustomPlacementConfig implements Serializable {
 
-    private static final long serialVersionUID = -3172255903331692127L;
+    private static final long serialVersionUID = 7284488308696895602L;
     private List<String> dataLocations;
 
     @Override
@@ -408,7 +410,7 @@ public class BucketInfo implements Serializable {
    */
   public static class Logging implements Serializable {
 
-    private static final long serialVersionUID = -708892101216778492L;
+    private static final long serialVersionUID = 5213268072569764596L;
     private final String logBucket;
     private final String logObjectPrefix;
 
@@ -491,7 +493,7 @@ public class BucketInfo implements Serializable {
    */
   public static class LifecycleRule implements Serializable {
 
-    private static final long serialVersionUID = -5739807320148748613L;
+    private static final long serialVersionUID = 8685745573894069326L;
     private final LifecycleAction lifecycleAction;
     private final LifecycleCondition lifecycleCondition;
 
@@ -559,7 +561,7 @@ public class BucketInfo implements Serializable {
      *     Management</a>
      */
     public static class LifecycleCondition implements Serializable {
-      private static final long serialVersionUID = -6482314338394768785L;
+      private static final long serialVersionUID = 7127585850045827932L;
       private final Integer age;
       private final OffsetDateTime createdBefore;
       private final Integer numberOfNewerVersions;
@@ -922,7 +924,7 @@ public class BucketInfo implements Serializable {
      * expressed as subclasses of this class, accessed by static factory methods.
      */
     public static class LifecycleAction implements Serializable {
-      private static final long serialVersionUID = 5801228724709173284L;
+      private static final long serialVersionUID = -816170697779323819L;
 
       private final String actionType;
 
@@ -997,7 +999,7 @@ public class BucketInfo implements Serializable {
 
     public static class DeleteLifecycleAction extends LifecycleAction {
       public static final String TYPE = "Delete";
-      private static final long serialVersionUID = -2050986302222644873L;
+      private static final long serialVersionUID = 4235058923106460876L;
 
       private DeleteLifecycleAction() {
         super(TYPE);
@@ -1006,7 +1008,7 @@ public class BucketInfo implements Serializable {
 
     public static class SetStorageClassLifecycleAction extends LifecycleAction {
       public static final String TYPE = "SetStorageClass";
-      private static final long serialVersionUID = -62615467186000899L;
+      private static final long serialVersionUID = 1235008830965208895L;
 
       private final StorageClass storageClass;
 
@@ -1030,7 +1032,7 @@ public class BucketInfo implements Serializable {
 
     public static class AbortIncompleteMPUAction extends LifecycleAction {
       public static final String TYPE = "AbortIncompleteMultipartUpload";
-      private static final long serialVersionUID = -1072182310389348060L;
+      private static final long serialVersionUID = 8158049841366366988L;
 
       private AbortIncompleteMPUAction() {
         super(TYPE);
@@ -1049,7 +1051,7 @@ public class BucketInfo implements Serializable {
   @Deprecated
   public abstract static class DeleteRule implements Serializable {
 
-    private static final long serialVersionUID = 3137971668395933033L;
+    private static final long serialVersionUID = -2831684017163653163L;
     static final String SUPPORTED_ACTION = "Delete";
     private final Type type;
 
@@ -1100,7 +1102,7 @@ public class BucketInfo implements Serializable {
   @Deprecated
   public static class AgeDeleteRule extends DeleteRule {
 
-    private static final long serialVersionUID = 5697166940712116380L;
+    private static final long serialVersionUID = 8655342969048652720L;
     private final int daysToLive;
 
     /**
@@ -1121,8 +1123,8 @@ public class BucketInfo implements Serializable {
   }
 
   static class RawDeleteRule extends DeleteRule {
-    // TODO(benwhitehead): investigate having deleted the populateCondition method
-    private static final long serialVersionUID = -7166938278642301933L;
+
+    private static final long serialVersionUID = -3490275955461147025L;
 
     private transient Rule rule;
 
@@ -1156,7 +1158,7 @@ public class BucketInfo implements Serializable {
   @Deprecated
   public static class CreatedBeforeDeleteRule extends DeleteRule {
 
-    private static final long serialVersionUID = 881692650279195867L;
+    private static final long serialVersionUID = -2941931783781989505L;
     private final OffsetDateTime time;
 
     /**
@@ -1204,7 +1206,7 @@ public class BucketInfo implements Serializable {
   @Deprecated
   public static class NumNewerVersionsDeleteRule extends DeleteRule {
 
-    private static final long serialVersionUID = -1955554976528303894L;
+    private static final long serialVersionUID = 8984956956307794724L;
     private final int numNewerVersions;
 
     /**
@@ -1233,7 +1235,7 @@ public class BucketInfo implements Serializable {
   @Deprecated
   public static class IsLiveDeleteRule extends DeleteRule {
 
-    private static final long serialVersionUID = -3502994563121313364L;
+    private static final long serialVersionUID = 6769701586197631153L;
     private final boolean isLive;
 
     /**

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Cors.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Cors.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  */
 public final class Cors implements Serializable {
 
-  private static final long serialVersionUID = -8637770919343335655L;
+  private static final long serialVersionUID = 3811576113627241235L;
 
   private final Integer maxAgeSeconds;
   private final ImmutableList<HttpMethod> methods;
@@ -43,7 +43,7 @@ public final class Cors implements Serializable {
   /** Class for a CORS origin. */
   public static final class Origin implements Serializable {
 
-    private static final long serialVersionUID = -4447958124895577993L;
+    private static final long serialVersionUID = -3240120183350397818L;
     private static final String ANY_URI = "*";
     private final String value;
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultStorageRetryStrategy.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultStorageRetryStrategy.java
@@ -28,7 +28,7 @@ import java.util.Set;
 
 final class DefaultStorageRetryStrategy implements StorageRetryStrategy {
 
-  private static final long serialVersionUID = -6145057244885961913L;
+  private static final long serialVersionUID = 7928177703325504905L;
 
   private static final Interceptor INTERCEPTOR_IDEMPOTENT =
       new InterceptorImpl(true, StorageException.RETRYABLE_ERRORS);
@@ -56,7 +56,7 @@ final class DefaultStorageRetryStrategy implements StorageRetryStrategy {
 
   private static class InterceptorImpl implements BaseInterceptor {
 
-    private static final long serialVersionUID = -5153236691367895096L;
+    private static final long serialVersionUID = 5283634944744417128L;
     private final boolean idempotent;
     private final ImmutableSet<BaseServiceException.Error> retryableErrors;
 
@@ -117,7 +117,7 @@ final class DefaultStorageRetryStrategy implements StorageRetryStrategy {
   }
 
   private static final class EmptyJsonParsingExceptionInterceptor implements BaseInterceptor {
-    private static final long serialVersionUID = -3320984020388043628L;
+    private static final long serialVersionUID = -3466977370399704805L;
 
     @Override
     public RetryResult beforeEval(Exception exception) {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcRetryAlgorithmManager.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcRetryAlgorithmManager.java
@@ -50,7 +50,7 @@ import java.io.Serializable;
 
 final class GrpcRetryAlgorithmManager implements Serializable {
 
-  private static final long serialVersionUID = -355073454247905645L;
+  private static final long serialVersionUID = 3084833873820431477L;
   private final StorageRetryStrategy retryStrategy;
 
   GrpcRetryAlgorithmManager(StorageRetryStrategy retryStrategy) {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
@@ -52,12 +52,13 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.threeten.bp.Duration;
 
+/** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
 @BetaApi
 @TransportCompatibility(Transport.GRPC)
 public final class GrpcStorageOptions extends StorageOptions
     implements Retrying.RetryingDependencies {
 
-  private static final long serialVersionUID = 4165732727259088956L;
+  private static final long serialVersionUID = -4499446543857945349L;
   private static final String GCS_SCOPE = "https://www.googleapis.com/auth/devstorage.full_control";
   private static final Set<String> SCOPES = ImmutableSet.of(GCS_SCOPE);
   private static final String DEFAULT_HOST = "https://storage.googleapis.com";
@@ -66,8 +67,7 @@ public final class GrpcStorageOptions extends StorageOptions
   private final Duration terminationAwaitDuration;
   private final boolean attemptDirectPath;
 
-  @BetaApi
-  public GrpcStorageOptions(Builder builder, GrpcStorageDefaults serviceDefaults) {
+  private GrpcStorageOptions(Builder builder, GrpcStorageDefaults serviceDefaults) {
     super(builder, serviceDefaults);
     this.retryAlgorithmManager =
         new GrpcRetryAlgorithmManager(
@@ -182,6 +182,7 @@ public final class GrpcStorageOptions extends StorageOptions
     return builder.build();
   }
 
+  /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
   @BetaApi
   @Override
   public GrpcStorageOptions.Builder toBuilder() {
@@ -198,16 +199,19 @@ public final class GrpcStorageOptions extends StorageOptions
     return obj instanceof GrpcStorageOptions && baseEquals((GrpcStorageOptions) obj);
   }
 
+  /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
   @BetaApi
   public static GrpcStorageOptions.Builder newBuilder() {
     return new GrpcStorageOptions.Builder().setHost(DEFAULT_HOST);
   }
 
+  /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
   @BetaApi
   public static GrpcStorageOptions getDefaultInstance() {
     return newBuilder().build();
   }
 
+  /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
   @BetaApi
   public static GrpcStorageOptions.GrpcStorageDefaults defaults() {
     return GrpcStorageOptions.GrpcStorageDefaults.INSTANCE;
@@ -224,8 +228,9 @@ public final class GrpcStorageOptions extends StorageOptions
     return super.shouldRefreshService(cachedService);
   }
 
+  /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
   @BetaApi
-  public static class Builder extends StorageOptions.Builder {
+  public static final class Builder extends StorageOptions.Builder {
 
     private StorageRetryStrategy storageRetryStrategy;
     private Duration terminationAwaitDuration;
@@ -243,6 +248,7 @@ public final class GrpcStorageOptions extends StorageOptions
      *
      * @param terminationAwaitDuration a non-null Duration to use
      * @return the builder
+     * @since 2.14.0 This new api is in preview and is subject to breaking changes.
      */
     @BetaApi
     public Builder setTerminationAwaitDuration(Duration terminationAwaitDuration) {
@@ -260,6 +266,8 @@ public final class GrpcStorageOptions extends StorageOptions
      * <p><i>NOTE</i>There is no need to specify a new endpoint via {@link #setHost(String)} as the
      * underlying code will translate the normal {@code https://storage.googleapis.com:443} into the
      * proper Direct Path URI for you.
+     *
+     * @since 2.14.0 This new api is in preview and is subject to breaking changes.
      */
     @BetaApi
     public GrpcStorageOptions.Builder setAttemptDirectPath(boolean attemptDirectPath) {
@@ -267,6 +275,7 @@ public final class GrpcStorageOptions extends StorageOptions
       return this;
     }
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     @Override
     public GrpcStorageOptions.Builder setTransportOptions(TransportOptions transportOptions) {
@@ -283,6 +292,7 @@ public final class GrpcStorageOptions extends StorageOptions
      * @param storageRetryStrategy a non-null storageRetryStrategy to use
      * @return the builder
      * @see StorageRetryStrategy#getDefaultStorageRetryStrategy()
+     * @since 2.14.0 This new api is in preview and is subject to breaking changes.
      */
     @BetaApi
     public GrpcStorageOptions.Builder setStorageRetryStrategy(
@@ -297,6 +307,7 @@ public final class GrpcStorageOptions extends StorageOptions
       return this;
     }
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     @Override
     public GrpcStorageOptions.Builder setServiceFactory(
@@ -305,6 +316,7 @@ public final class GrpcStorageOptions extends StorageOptions
       return this;
     }
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     @Override
     public GrpcStorageOptions.Builder setClock(ApiClock clock) {
@@ -312,6 +324,7 @@ public final class GrpcStorageOptions extends StorageOptions
       return this;
     }
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     @Override
     public GrpcStorageOptions.Builder setProjectId(String projectId) {
@@ -319,6 +332,7 @@ public final class GrpcStorageOptions extends StorageOptions
       return this;
     }
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     @Override
     public GrpcStorageOptions.Builder setHost(String host) {
@@ -326,6 +340,7 @@ public final class GrpcStorageOptions extends StorageOptions
       return this;
     }
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     @Override
     public GrpcStorageOptions.Builder setCredentials(Credentials credentials) {
@@ -333,6 +348,7 @@ public final class GrpcStorageOptions extends StorageOptions
       return this;
     }
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     @Override
     public GrpcStorageOptions.Builder setRetrySettings(RetrySettings retrySettings) {
@@ -340,14 +356,16 @@ public final class GrpcStorageOptions extends StorageOptions
       return this;
     }
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     @Override
     public GrpcStorageOptions.Builder setServiceRpcFactory(
         ServiceRpcFactory<StorageOptions> serviceRpcFactory) {
-      super.setServiceRpcFactory(serviceRpcFactory);
-      return this;
+      throw new UnsupportedOperationException(
+          "GrpcStorageOptions does not support setting a custom instance of ServiceRpcFactory");
     }
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     @Override
     public GrpcStorageOptions.Builder setHeaderProvider(HeaderProvider headerProvider) {
@@ -355,6 +373,7 @@ public final class GrpcStorageOptions extends StorageOptions
       return this;
     }
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     @Override
     public GrpcStorageOptions.Builder setClientLibToken(String clientLibToken) {
@@ -362,6 +381,7 @@ public final class GrpcStorageOptions extends StorageOptions
       return this;
     }
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     @Override
     public GrpcStorageOptions.Builder setQuotaProjectId(String quotaProjectId) {
@@ -369,6 +389,7 @@ public final class GrpcStorageOptions extends StorageOptions
       return this;
     }
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     @Override
     public GrpcStorageOptions build() {
@@ -376,6 +397,7 @@ public final class GrpcStorageOptions extends StorageOptions
     }
   }
 
+  /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
   @BetaApi
   public static final class GrpcStorageDefaults extends StorageDefaults {
     static final GrpcStorageDefaults INSTANCE = new GrpcStorageOptions.GrpcStorageDefaults();
@@ -384,34 +406,40 @@ public final class GrpcStorageOptions extends StorageOptions
 
     private GrpcStorageDefaults() {}
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     @Override
     public StorageFactory getDefaultServiceFactory() {
       return STORAGE_FACTORY;
     }
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     @Override
     public StorageRpcFactory getDefaultRpcFactory() {
       return STORAGE_RPC_FACTORY;
     }
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     @Override
     public GrpcTransportOptions getDefaultTransportOptions() {
       return GrpcTransportOptions.newBuilder().build();
     }
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     public StorageRetryStrategy getStorageRetryStrategy() {
       return StorageRetryStrategy.getDefaultStorageRetryStrategy();
     }
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     public Duration getTerminationAwaitDuration() {
       return Duration.ofMinutes(1);
     }
 
+    /** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
     @BetaApi
     public boolean isAttemptDirectPath() {
       return false;
@@ -419,7 +447,8 @@ public final class GrpcStorageOptions extends StorageOptions
   }
 
   /**
-   * Internal implementation detail, only public to allow for {@link java.io.Serializable}.
+   * Internal implementation detail, only public to allow for {@link java.io.Serializable}
+   * compatibility in {@link com.google.cloud.ServiceOptions}.
    *
    * <p>To access an instance of this class instead use {@link
    * GrpcStorageOptions.GrpcStorageDefaults#getDefaultServiceFactory()
@@ -427,13 +456,15 @@ public final class GrpcStorageOptions extends StorageOptions
    *
    * @see GrpcStorageOptions#defaults()
    * @see GrpcStorageOptions.GrpcStorageDefaults#getDefaultServiceFactory()
+   * @since 2.14.0 This new api is in preview and is subject to breaking changes.
    */
   @InternalApi
   @BetaApi
   public static class GrpcStorageFactory implements StorageFactory {
 
     /**
-     * Internal implementation detail, only public to allow for {@link java.io.Serializable}.
+     * Internal implementation detail, only public to allow for {@link java.io.Serializable}
+     * compatibility in {@link com.google.cloud.ServiceOptions}.
      *
      * <p>To access an instance of this class instead use {@link
      * GrpcStorageOptions.GrpcStorageDefaults#getDefaultServiceFactory()
@@ -444,6 +475,7 @@ public final class GrpcStorageOptions extends StorageOptions
      * @deprecated instead use {@link
      *     GrpcStorageOptions.GrpcStorageDefaults#getDefaultServiceFactory()
      *     GrpcStorageOptions.defaults().getDefaultServiceFactory()}
+     * @since 2.14.0 This new api is in preview and is subject to breaking changes.
      */
     // this class needs to be public due to ServiceOptions forName'ing it in it's readObject method
     @InternalApi
@@ -470,7 +502,8 @@ public final class GrpcStorageOptions extends StorageOptions
   }
 
   /**
-   * Internal implementation detail, only public to allow for {@link java.io.Serializable}.
+   * Internal implementation detail, only public to allow for {@link java.io.Serializable}
+   * compatibility in {@link com.google.cloud.ServiceOptions}.
    *
    * <p>To access an instance of this class instead use {@link
    * GrpcStorageOptions.GrpcStorageDefaults#getDefaultRpcFactory()
@@ -478,6 +511,7 @@ public final class GrpcStorageOptions extends StorageOptions
    *
    * @see GrpcStorageOptions#defaults()
    * @see GrpcStorageOptions.GrpcStorageDefaults#getDefaultRpcFactory()
+   * @since 2.14.0 This new api is in preview and is subject to breaking changes.
    */
   @InternalApi
   @BetaApi
@@ -485,7 +519,8 @@ public final class GrpcStorageOptions extends StorageOptions
   public static class GrpcStorageRpcFactory implements StorageRpcFactory {
 
     /**
-     * Internal implementation detail, only public to allow for {@link java.io.Serializable}.
+     * Internal implementation detail, only public to allow for {@link java.io.Serializable}
+     * compatibility in {@link com.google.cloud.ServiceOptions}.
      *
      * <p>To access an instance of this class instead use {@link
      * GrpcStorageOptions.GrpcStorageDefaults#getDefaultRpcFactory()
@@ -495,6 +530,7 @@ public final class GrpcStorageOptions extends StorageOptions
      * @see GrpcStorageOptions.GrpcStorageDefaults#getDefaultRpcFactory()
      * @deprecated instead use {@link GrpcStorageOptions.GrpcStorageDefaults#getDefaultRpcFactory()
      *     GrpcStorageOptions.defaults().getDefaultRpcFactory()}
+     * @since 2.14.0 This new api is in preview and is subject to breaking changes.
      */
     // this class needs to be public due to ServiceOptions forName'ing it in it's readObject method
     @InternalApi

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/HmacKey.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/HmacKey.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 /** HMAC key for a service account. */
 public class HmacKey implements Serializable {
 
-  private static final long serialVersionUID = -1809610424373783062L;
+  private static final long serialVersionUID = 3033393659217005187L;
   private final String secretKey;
   private final HmacKeyMetadata metadata;
 
@@ -109,7 +109,7 @@ public class HmacKey implements Serializable {
    */
   public static class HmacKeyMetadata implements Serializable {
 
-    private static final long serialVersionUID = 4571684785352640737L;
+    private static final long serialVersionUID = 9130344756739042314L;
     private final String accessId;
     private final String etag;
     private final String id;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpCopyWriter.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpCopyWriter.java
@@ -98,7 +98,7 @@ public class HttpCopyWriter extends CopyWriter {
 
   static class StateImpl implements RestorableState<CopyWriter>, Serializable {
 
-    private static final long serialVersionUID = 1693964441435822700L;
+    private static final long serialVersionUID = 1843004265650868946L;
 
     private final HttpStorageOptions serviceOptions;
     private final BlobId source;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpMethod.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpMethod.java
@@ -22,7 +22,7 @@ import com.google.cloud.StringEnumValue;
 
 /** Http method supported by Storage service. */
 public final class HttpMethod extends StringEnumValue {
-  private static final long serialVersionUID = -1394461645628254471L;
+  private static final long serialVersionUID = -5787845034130236201L;
 
   private HttpMethod(String constant) {
     super(constant);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpRetryAlgorithmManager.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpRetryAlgorithmManager.java
@@ -31,7 +31,7 @@ import java.util.Map;
 
 final class HttpRetryAlgorithmManager implements Serializable {
 
-  private static final long serialVersionUID = -8615379702537758604L;
+  private static final long serialVersionUID = -3301856948991518651L;
   private final StorageRetryStrategy retryStrategy;
 
   HttpRetryAlgorithmManager(StorageRetryStrategy retryStrategy) {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpStorageOptions.java
@@ -19,6 +19,7 @@ package com.google.cloud.storage;
 import static java.util.Objects.requireNonNull;
 
 import com.google.api.core.ApiClock;
+import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.HeaderProvider;
@@ -28,6 +29,7 @@ import com.google.cloud.ServiceRpc;
 import com.google.cloud.TransportOptions;
 import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.spi.ServiceRpcFactory;
+import com.google.cloud.storage.TransportCompatibility.Transport;
 import com.google.cloud.storage.spi.StorageRpcFactory;
 import com.google.cloud.storage.spi.v1.HttpStorageRpc;
 import com.google.cloud.storage.spi.v1.StorageRpc;
@@ -36,10 +38,13 @@ import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
 import java.util.Set;
 
+/** @since 2.14.0 This new api is in preview and is subject to breaking changes. */
+@BetaApi
+@TransportCompatibility(Transport.HTTP)
 // non-final because of mocking frameworks
 public class HttpStorageOptions extends StorageOptions {
 
-  private static final long serialVersionUID = -954534299318865816L;
+  private static final long serialVersionUID = -5302637952911052045L;
   private static final String API_SHORT_NAME = "Storage";
   private static final String GCS_SCOPE = "https://www.googleapis.com/auth/devstorage.full_control";
   private static final Set<String> SCOPES = ImmutableSet.of(GCS_SCOPE);
@@ -60,10 +65,12 @@ public class HttpStorageOptions extends StorageOptions {
     return SCOPES;
   }
 
+  @InternalApi
   HttpRetryAlgorithmManager getRetryAlgorithmManager() {
     return retryAlgorithmManager;
   }
 
+  @InternalApi
   StorageRpc getStorageRpcV1() {
     return (StorageRpc) getRpc();
   }
@@ -80,7 +87,7 @@ public class HttpStorageOptions extends StorageOptions {
 
   @Override
   public boolean equals(Object obj) {
-    return obj instanceof StorageOptions && baseEquals((StorageOptions) obj);
+    return obj instanceof HttpStorageOptions && baseEquals((HttpStorageOptions) obj);
   }
 
   public static HttpStorageOptions.Builder newBuilder() {
@@ -241,7 +248,7 @@ public class HttpStorageOptions extends StorageOptions {
    */
   @InternalApi
   public static class HttpStorageFactory implements StorageFactory, Serializable {
-    private static final long serialVersionUID = -509515936479640159L;
+    private static final long serialVersionUID = 1063208433681579145L;
 
     /**
      * Internal implementation detail, only public to allow for {@link java.io.Serializable}.
@@ -284,7 +291,7 @@ public class HttpStorageOptions extends StorageOptions {
    */
   @InternalApi
   public static class HttpStorageRpcFactory implements StorageRpcFactory, Serializable {
-    private static final long serialVersionUID = -7487671939555953705L;
+    private static final long serialVersionUID = -5896805045709989797L;
 
     /**
      * Internal implementation detail, only public to allow for {@link java.io.Serializable}.

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/NotificationInfo.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/NotificationInfo.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 /** The class representing Pub/Sub Notification metadata for the Storage. */
 public class NotificationInfo implements Serializable {
 
-  private static final long serialVersionUID = 5725883368559753810L;
+  private static final long serialVersionUID = -996243512290027661L;
   private static final PathTemplate PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("projects/{project}/topics/{topic}");
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Option.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Option.java
@@ -24,7 +24,7 @@ import java.io.Serializable;
 public abstract class Option<O extends Opt> extends UnifiedOpts.OptionShim<O>
     implements Serializable {
 
-  private static final long serialVersionUID = -3517676609070123326L;
+  private static final long serialVersionUID = -7579883369516703936L;
 
   Option(O opt) {
     super(opt);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Rpo.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Rpo.java
@@ -28,7 +28,7 @@ import com.google.cloud.StringEnumValue;
  */
 public final class Rpo extends StringEnumValue {
 
-  private static final long serialVersionUID = -3954216195295821508L;
+  private static final long serialVersionUID = -2916656819456559679L;
 
   private Rpo(String constant) {
     super(constant);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ServiceAccount.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ServiceAccount.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  */
 public final class ServiceAccount implements Serializable {
 
-  private static final long serialVersionUID = 4199610694227857331L;
+  private static final long serialVersionUID = -6492243440372543799L;
 
   private final String email;
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
@@ -838,7 +838,8 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * detected from the blob name if not explicitly set. This option is on the client side only, it
      * does not appear in a RPC call.
      *
-     * Content type detection is based on the database presented by {@link URLConnection#getFileNameMap()}
+     * <p>Content type detection is based on the database presented by {@link
+     * URLConnection#getFileNameMap()}
      */
     @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption detectContentType() {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
@@ -53,6 +53,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.file.Path;
 import java.security.Key;
 import java.util.Arrays;
@@ -73,6 +74,7 @@ import java.util.stream.Stream;
 @InternalExtensionOnly
 public interface Storage extends Service<StorageOptions>, AutoCloseable {
 
+  @TransportCompatibility({Transport.HTTP, Transport.GRPC})
   enum PredefinedAcl {
     AUTHENTICATED_READ("authenticatedRead"),
     ALL_AUTHENTICATED_USERS("allAuthenticatedUsers"),
@@ -303,11 +305,13 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     }
 
     /** Returns an option for specifying bucket's predefined ACL configuration. */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketTargetOption predefinedAcl(PredefinedAcl acl) {
       return new BucketTargetOption(UnifiedOpts.predefinedAcl(acl));
     }
 
     /** Returns an option for specifying bucket's default ACL configuration for blobs. */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketTargetOption predefinedDefaultObjectAcl(PredefinedAcl acl) {
       return new BucketTargetOption(UnifiedOpts.predefinedDefaultObjectAcl(acl));
     }
@@ -316,6 +320,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for bucket's metageneration match. If this option is used the request will
      * fail if metageneration does not match.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketTargetOption metagenerationMatch() {
       return new BucketTargetOption(UnifiedOpts.metagenerationMatchExtractor());
     }
@@ -324,6 +329,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for bucket's metageneration mismatch. If this option is used the request
      * will fail if metageneration matches.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketTargetOption metagenerationNotMatch() {
       return new BucketTargetOption(UnifiedOpts.metagenerationNotMatchExtractor());
     }
@@ -332,6 +338,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option to define the billing user project. This option is required by buckets with
      * `requester_pays` flag enabled to assign operation costs.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketTargetOption userProject(String userProject) {
       return new BucketTargetOption(UnifiedOpts.userProject(userProject));
     }
@@ -344,6 +351,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * @see <a href="https://cloud.google.com/storage/docs/json_api/v1/buckets/patch">Buckets:
      *     patch</a>
      */
+    @TransportCompatibility({Transport.HTTP})
     public static BucketTargetOption projection(String projection) {
       return new BucketTargetOption(UnifiedOpts.projection(projection));
     }
@@ -362,6 +370,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for bucket's metageneration match. If this option is used the request will
      * fail if bucket's metageneration does not match the provided value.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketSourceOption metagenerationMatch(long metageneration) {
       return new BucketSourceOption(UnifiedOpts.metagenerationMatch(metageneration));
     }
@@ -370,6 +379,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for bucket's metageneration mismatch. If this option is used the request
      * will fail if bucket's metageneration matches the provided value.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketSourceOption metagenerationNotMatch(long metageneration) {
       return new BucketSourceOption(UnifiedOpts.metagenerationNotMatch(metageneration));
     }
@@ -378,10 +388,12 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for bucket's billing user project. This option is only used by the buckets
      * with 'requester_pays' flag.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketSourceOption userProject(String userProject) {
       return new BucketSourceOption(UnifiedOpts.userProject(userProject));
     }
 
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketSourceOption requestedPolicyVersion(long version) {
       return new BucketSourceOption(UnifiedOpts.requestedPolicyVersion(version));
     }
@@ -398,16 +410,19 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for the Service Account whose keys to list. If this option is not used,
      * keys for all accounts will be listed.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static ListHmacKeysOption serviceAccount(ServiceAccount serviceAccount) {
       return new ListHmacKeysOption(UnifiedOpts.serviceAccount(serviceAccount));
     }
 
     /** Returns an option for the maximum amount of HMAC keys returned per page. */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static ListHmacKeysOption maxResults(long pageSize) {
       return new ListHmacKeysOption(UnifiedOpts.pageSize(pageSize));
     }
 
     /** Returns an option to specify the page token from which to start listing HMAC keys. */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static ListHmacKeysOption pageToken(String pageToken) {
       return new ListHmacKeysOption(UnifiedOpts.pageToken(pageToken));
     }
@@ -416,6 +431,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option to specify whether to show deleted keys in the result. This option is false
      * by default.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static ListHmacKeysOption showDeletedKeys(boolean showDeletedKeys) {
       return new ListHmacKeysOption(UnifiedOpts.showDeletedKeys(showDeletedKeys));
     }
@@ -424,6 +440,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option to specify the project to be billed for this request. Required for
      * Requester Pays buckets.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static ListHmacKeysOption userProject(String userProject) {
       return new ListHmacKeysOption(UnifiedOpts.userProject(userProject));
     }
@@ -432,6 +449,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option to specify the Project ID for this request. If not specified, defaults to
      * Application Default Credentials.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static ListHmacKeysOption projectId(String projectId) {
       return new ListHmacKeysOption(UnifiedOpts.projectId(projectId));
     }
@@ -448,6 +466,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option to specify the project to be billed for this request. Required for
      * Requester Pays buckets.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static CreateHmacKeyOption userProject(String userProject) {
       return new CreateHmacKeyOption(UnifiedOpts.userProject(userProject));
     }
@@ -456,6 +475,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option to specify the Project ID for this request. If not specified, defaults to
      * Application Default Credentials.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static CreateHmacKeyOption projectId(String projectId) {
       return new CreateHmacKeyOption(UnifiedOpts.projectId(projectId));
     }
@@ -471,6 +491,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option to specify the project to be billed for this request. Required for
      * Requester Pays buckets.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static GetHmacKeyOption userProject(String userProject) {
       return new GetHmacKeyOption(UnifiedOpts.userProject(userProject));
     }
@@ -479,6 +500,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option to specify the Project ID for this request. If not specified, defaults to
      * Application Default Credentials.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static GetHmacKeyOption projectId(String projectId) {
       return new GetHmacKeyOption(UnifiedOpts.projectId(projectId));
     }
@@ -494,6 +516,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option to specify the project to be billed for this request. Required for
      * Requester Pays buckets.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static DeleteHmacKeyOption userProject(String userProject) {
       return new DeleteHmacKeyOption(UnifiedOpts.userProject(userProject));
     }
@@ -509,6 +532,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option to specify the project to be billed for this request. Required for
      * Requester Pays buckets.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static UpdateHmacKeyOption userProject(String userProject) {
       return new UpdateHmacKeyOption(UnifiedOpts.userProject(userProject));
     }
@@ -527,6 +551,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for bucket's metageneration match. If this option is used the request will
      * fail if bucket's metageneration does not match the provided value.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketGetOption metagenerationMatch(long metageneration) {
       return new BucketGetOption(UnifiedOpts.metagenerationMatch(metageneration));
     }
@@ -535,6 +560,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for bucket's metageneration mismatch. If this option is used the request
      * will fail if bucket's metageneration matches the provided value.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketGetOption metagenerationNotMatch(long metageneration) {
       return new BucketGetOption(UnifiedOpts.metagenerationNotMatch(metageneration));
     }
@@ -543,6 +569,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for bucket's billing user project. This option is only used by the buckets
      * with 'requester_pays' flag.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketGetOption userProject(String userProject) {
       return new BucketGetOption(UnifiedOpts.userProject(userProject));
     }
@@ -553,6 +580,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * be used to specify only the fields of interest. Bucket name is always returned, even if not
      * specified.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketGetOption fields(BucketField... fields) {
       ImmutableSet<NamedField> set =
           ImmutableSet.<NamedField>builder()
@@ -573,6 +601,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     }
 
     /** Returns an option for specifying blob's predefined ACL configuration. */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption predefinedAcl(PredefinedAcl acl) {
       return new BlobTargetOption(UnifiedOpts.predefinedAcl(acl));
     }
@@ -580,6 +609,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     /**
      * Returns an option that causes an operation to succeed only if the target blob does not exist.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption doesNotExist() {
       return new BlobTargetOption(UnifiedOpts.doesNotExist());
     }
@@ -588,6 +618,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's data generation match. If this option is used the request will
      * fail if generation does not match.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption generationMatch() {
       return new BlobTargetOption(UnifiedOpts.generationMatchExtractor());
     }
@@ -596,6 +627,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's data generation mismatch. If this option is used the request
      * will fail if generation matches.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption generationNotMatch() {
       return new BlobTargetOption(UnifiedOpts.generationNotMatchExtractor());
     }
@@ -604,6 +636,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's metageneration match. If this option is used the request will
      * fail if metageneration does not match.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption metagenerationMatch() {
       return new BlobTargetOption(UnifiedOpts.metagenerationMatchExtractor());
     }
@@ -612,6 +645,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's metageneration mismatch. If this option is used the request will
      * fail if metageneration matches.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption metagenerationNotMatch() {
       return new BlobTargetOption(UnifiedOpts.metagenerationNotMatchExtractor());
     }
@@ -620,6 +654,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's data disabledGzipContent. If this option is used, the request
      * will create a blob with disableGzipContent; at present, this is only for upload.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption disableGzipContent() {
       return new BlobTargetOption(UnifiedOpts.disableGzipContent());
     }
@@ -629,6 +664,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * detected from the blob name if not explicitly set. This option is on the client side only, it
      * does not appear in a RPC call.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption detectContentType() {
       return new BlobTargetOption(UnifiedOpts.detectContentType());
     }
@@ -637,6 +673,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option to set a customer-supplied AES256 key for server-side encryption of the
      * blob.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption encryptionKey(Key key) {
       return new BlobTargetOption(UnifiedOpts.encryptionKey(key));
     }
@@ -645,6 +682,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's billing user project. This option is only used by the buckets
      * with 'requester_pays' flag.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption userProject(String userProject) {
       return new BlobTargetOption(UnifiedOpts.userProject(userProject));
     }
@@ -655,11 +693,13 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *
      * @param key the AES256 encoded in base64
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption encryptionKey(String key) {
       return new BlobTargetOption(UnifiedOpts.encryptionKey(key));
     }
 
     /** Returns an option to set a customer-managed key for server-side encryption of the blob. */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobTargetOption kmsKeyName(String kmsKeyName) {
       return new BlobTargetOption(UnifiedOpts.kmsKeyName(kmsKeyName));
     }
@@ -675,6 +715,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     }
 
     /** Returns an option for specifying blob's predefined ACL configuration. */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption predefinedAcl(PredefinedAcl acl) {
       return new BlobWriteOption(UnifiedOpts.predefinedAcl(acl));
     }
@@ -682,6 +723,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     /**
      * Returns an option that causes an operation to succeed only if the target blob does not exist.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption doesNotExist() {
       return new BlobWriteOption(UnifiedOpts.doesNotExist());
     }
@@ -690,6 +732,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's data generation match. If this option is used the request will
      * fail if generation does not match.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption generationMatch() {
       return new BlobWriteOption(UnifiedOpts.generationMatchExtractor());
     }
@@ -698,6 +741,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's data generation mismatch. If this option is used the request
      * will fail if generation matches.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption generationNotMatch() {
       return new BlobWriteOption(UnifiedOpts.generationNotMatchExtractor());
     }
@@ -706,6 +750,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's metageneration match. If this option is used the request will
      * fail if metageneration does not match.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption metagenerationMatch() {
       return new BlobWriteOption(UnifiedOpts.metagenerationMatchExtractor());
     }
@@ -714,6 +759,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's metageneration mismatch. If this option is used the request will
      * fail if metageneration matches.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption metagenerationNotMatch() {
       return new BlobWriteOption(UnifiedOpts.metagenerationNotMatchExtractor());
     }
@@ -743,6 +789,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option to set a customer-supplied AES256 key for server-side encryption of the
      * blob.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption encryptionKey(Key key) {
       return new BlobWriteOption(UnifiedOpts.encryptionKey(key));
     }
@@ -753,6 +800,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *
      * @param key the AES256 encoded in base64
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption encryptionKey(String key) {
       return new BlobWriteOption(UnifiedOpts.encryptionKey(key));
     }
@@ -762,6 +810,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *
      * @param kmsKeyName the KMS key resource id
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption kmsKeyName(String kmsKeyName) {
       return new BlobWriteOption(UnifiedOpts.kmsKeyName(kmsKeyName));
     }
@@ -770,6 +819,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's billing user project. This option is only used by the buckets
      * with 'requester_pays' flag.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption userProject(String userProject) {
       return new BlobWriteOption(UnifiedOpts.userProject(userProject));
     }
@@ -778,6 +828,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option that signals automatic gzip compression should not be performed en route to
      * the bucket.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption disableGzipContent() {
       return new BlobWriteOption(UnifiedOpts.disableGzipContent());
     }
@@ -786,7 +837,10 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for detecting content type. If this option is used, the content type is
      * detected from the blob name if not explicitly set. This option is on the client side only, it
      * does not appear in a RPC call.
+     *
+     * Content type detection is based on the database presented by {@link URLConnection#getFileNameMap()}
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption detectContentType() {
       return new BlobWriteOption(UnifiedOpts.detectContentType());
     }
@@ -808,6 +862,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * a {@link Storage} method and {@link BlobId#getGeneration()} is {@code null} or no {@link
      * BlobId} is provided an exception is thrown.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption generationMatch() {
       return new BlobSourceOption(UnifiedOpts.generationMatchExtractor());
     }
@@ -816,6 +871,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's data generation match. If this option is used the request will
      * fail if blob's generation does not match the provided value.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption generationMatch(long generation) {
       return new BlobSourceOption(UnifiedOpts.generationMatch(generation));
     }
@@ -831,6 +887,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *     use {@link #generationNotMatch(long)} instead.
      */
     @Deprecated
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption generationNotMatch() {
       return new BlobSourceOption(UnifiedOpts.generationNotMatchExtractor());
     }
@@ -839,6 +896,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's data generation mismatch. If this option is used the request
      * will fail if blob's generation matches the provided value.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption generationNotMatch(long generation) {
       return new BlobSourceOption(UnifiedOpts.generationNotMatch(generation));
     }
@@ -847,6 +905,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's metageneration match. If this option is used the request will
      * fail if blob's metageneration does not match the provided value.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption metagenerationMatch(long metageneration) {
       return new BlobSourceOption(UnifiedOpts.metagenerationMatch(metageneration));
     }
@@ -855,6 +914,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's metageneration mismatch. If this option is used the request will
      * fail if blob's metageneration matches the provided value.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption metagenerationNotMatch(long metageneration) {
       return new BlobSourceOption(UnifiedOpts.metagenerationNotMatch(metageneration));
     }
@@ -863,6 +923,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option to set a customer-supplied AES256 key for server-side encryption of the
      * blob.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption decryptionKey(Key key) {
       return new BlobSourceOption(UnifiedOpts.decryptionKey(key));
     }
@@ -873,6 +934,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *
      * @param key the AES256 encoded in base64
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption decryptionKey(String key) {
       return new BlobSourceOption(UnifiedOpts.decryptionKey(key));
     }
@@ -881,6 +943,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's billing user project. This option is only used by the buckets
      * with 'requester_pays' flag.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption userProject(String userProject) {
       return new BlobSourceOption(UnifiedOpts.userProject(userProject));
     }
@@ -890,6 +953,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * automatically decompressing the content. By default, this is false for Blob.downloadTo(), but
      * true for ReadChannel.read().
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption shouldReturnRawInputStream(boolean shouldReturnRawInputStream) {
       return new BlobSourceOption(UnifiedOpts.returnRawInputStream(shouldReturnRawInputStream));
     }
@@ -911,6 +975,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * a {@link Storage} method and {@link BlobId#getGeneration()} is {@code null} or no {@link
      * BlobId} is provided an exception is thrown.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobGetOption generationMatch() {
       return new BlobGetOption(UnifiedOpts.generationMatchExtractor());
     }
@@ -919,6 +984,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's data generation match. If this option is used the request will
      * fail if blob's generation does not match the provided value.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobGetOption generationMatch(long generation) {
       return new BlobGetOption(UnifiedOpts.generationMatch(generation));
     }
@@ -934,6 +1000,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *     use {@link #generationNotMatch(long)} instead.
      */
     @Deprecated
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobGetOption generationNotMatch() {
       return new BlobGetOption(UnifiedOpts.generationNotMatchExtractor());
     }
@@ -942,6 +1009,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's data generation mismatch. If this option is used the request
      * will fail if blob's generation matches the provided value.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobGetOption generationNotMatch(long generation) {
       return new BlobGetOption(UnifiedOpts.generationNotMatch(generation));
     }
@@ -950,6 +1018,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's metageneration match. If this option is used the request will
      * fail if blob's metageneration does not match the provided value.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobGetOption metagenerationMatch(long metageneration) {
       return new BlobGetOption(UnifiedOpts.metagenerationMatch(metageneration));
     }
@@ -958,6 +1027,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's metageneration mismatch. If this option is used the request will
      * fail if blob's metageneration matches the provided value.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobGetOption metagenerationNotMatch(long metageneration) {
       return new BlobGetOption(UnifiedOpts.metagenerationNotMatch(metageneration));
     }
@@ -968,6 +1038,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * specify only the fields of interest. Blob name and bucket are always returned, even if not
      * specified.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobGetOption fields(BlobField... fields) {
       ImmutableSet<NamedField> set =
           ImmutableSet.<NamedField>builder().addAll(BlobField.REQUIRED_FIELDS).add(fields).build();
@@ -978,6 +1049,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for blob's billing user project. This option is only used by the buckets
      * with 'requester_pays' flag.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobGetOption userProject(String userProject) {
       return new BlobGetOption(UnifiedOpts.userProject(userProject));
     }
@@ -986,6 +1058,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option to set a customer-supplied AES256 key for server-side decryption of the
      * blob.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobGetOption decryptionKey(Key key) {
       return new BlobGetOption(UnifiedOpts.decryptionKey(key));
     }
@@ -996,6 +1069,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *
      * @param key the AES256 encoded in base64
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobGetOption decryptionKey(String key) {
       return new BlobGetOption(UnifiedOpts.decryptionKey(key));
     }
@@ -1005,6 +1079,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * automatically decompressing the content. By default, this is false for Blob.downloadTo(), but
      * true for ReadChannel.read().
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobGetOption shouldReturnRawInputStream(boolean shouldReturnRawInputStream) {
       return new BlobGetOption(UnifiedOpts.returnRawInputStream(shouldReturnRawInputStream));
     }
@@ -1020,11 +1095,13 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     }
 
     /** Returns an option to specify the maximum number of buckets returned per page. */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketListOption pageSize(long pageSize) {
       return new BucketListOption(UnifiedOpts.pageSize(pageSize));
     }
 
     /** Returns an option to specify the page token from which to start listing buckets. */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketListOption pageToken(String pageToken) {
       return new BucketListOption(UnifiedOpts.pageToken(pageToken));
     }
@@ -1033,6 +1110,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option to set a prefix to filter results to buckets whose names begin with this
      * prefix.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketListOption prefix(String prefix) {
       return new BucketListOption(UnifiedOpts.prefix(prefix));
     }
@@ -1041,6 +1119,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option for bucket's billing user project. This option is only used by the buckets
      * with 'requester_pays' flag.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketListOption userProject(String userProject) {
       return new BucketListOption(UnifiedOpts.userProject(userProject));
     }
@@ -1051,6 +1130,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * be used to specify only the fields of interest. Bucket name is always returned, even if not
      * specified.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketListOption fields(BucketField... fields) {
       ImmutableSet<NamedField> set =
           Streams.concat(
@@ -1072,11 +1152,13 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     }
 
     /** Returns an option to specify the maximum number of blobs returned per page. */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobListOption pageSize(long pageSize) {
       return new BlobListOption(UnifiedOpts.pageSize(pageSize));
     }
 
     /** Returns an option to specify the page token from which to start listing blobs. */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobListOption pageToken(String pageToken) {
       return new BlobListOption(UnifiedOpts.pageToken(pageToken));
     }
@@ -1085,6 +1167,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Returns an option to set a prefix to filter results to blobs whose names begin with this
      * prefix.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobListOption prefix(String prefix) {
       return new BlobListOption(UnifiedOpts.prefix(prefix));
     }
@@ -1099,6 +1182,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Blob#getSize()} returns {@code 0} while {@link Blob#isDirectory()} returns {@code true}.
      * Duplicate directory blobs are omitted.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobListOption currentDirectory() {
       return new BlobListOption(UnifiedOpts.currentDirectory());
     }
@@ -1109,6 +1193,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * @param delimiter generally '/' is the one used most often, but you can used other delimiters
      *     as well.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobListOption delimiter(String delimiter) {
       return new BlobListOption(UnifiedOpts.delimiter(delimiter));
     }
@@ -1120,6 +1205,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *
      * @param startOffset startOffset to filter the results
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobListOption startOffset(String startOffset) {
       return new BlobListOption(UnifiedOpts.startOffset(startOffset));
     }
@@ -1131,6 +1217,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *
      * @param endOffset endOffset to filter the results
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobListOption endOffset(String endOffset) {
       return new BlobListOption(UnifiedOpts.endOffset(endOffset));
     }
@@ -1141,6 +1228,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *
      * @param userProject projectId of the billing user project.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobListOption userProject(String userProject) {
       return new BlobListOption(UnifiedOpts.userProject(userProject));
     }
@@ -1150,6 +1238,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *
      * @see <a href="https://cloud.google.com/storage/docs/object-versioning">Object Versioning</a>
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobListOption versions(boolean versions) {
       return new BlobListOption(UnifiedOpts.versionsFilter(versions));
     }
@@ -1160,6 +1249,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * specify only the fields of interest. Blob name and bucket are always returned, even if not
      * specified.
      */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobListOption fields(BlobField... fields) {
       ImmutableSet<NamedField> set =
           Streams.concat(
@@ -1177,6 +1267,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     private final PostPolicyV4Option.Option option;
     private final Object value;
 
+    @TransportCompatibility(Transport.HTTP)
     enum Option {
       PATH_STYLE,
       VIRTUAL_HOSTED_STYLE,
@@ -1204,6 +1295,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * @see <a href="https://cloud.google.com/storage/docs/authentication#service_accounts">Service
      *     Accounts</a>
      */
+    @TransportCompatibility(Transport.HTTP)
     public static PostPolicyV4Option signWith(ServiceAccountSigner signer) {
       return new PostPolicyV4Option(PostPolicyV4Option.Option.SERVICE_ACCOUNT_CRED, signer);
     }
@@ -1215,6 +1307,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *
      * @see <a href="https://cloud.google.com/storage/docs/request-endpoints">Request Endpoints</a>
      */
+    @TransportCompatibility(Transport.HTTP)
     public static PostPolicyV4Option withVirtualHostedStyle() {
       return new PostPolicyV4Option(PostPolicyV4Option.Option.VIRTUAL_HOSTED_STYLE, "");
     }
@@ -1228,6 +1321,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *
      * @see <a href="https://cloud.google.com/storage/docs/request-endpoints">Request Endpoints</a>
      */
+    @TransportCompatibility(Transport.HTTP)
     public static PostPolicyV4Option withPathStyle() {
       return new PostPolicyV4Option(PostPolicyV4Option.Option.PATH_STYLE, "");
     }
@@ -1246,6 +1340,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *     href="https://cloud.google.com/load-balancing/docs/https/adding-backend-buckets-to-load-balancers">
      *     GCLB Redirects</a>
      */
+    @TransportCompatibility(Transport.HTTP)
     public static PostPolicyV4Option withBucketBoundHostname(String bucketBoundHostname) {
       return withBucketBoundHostname(bucketBoundHostname, Storage.UriScheme.HTTP);
     }
@@ -1264,6 +1359,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *     href="https://cloud.google.com/load-balancing/docs/https/adding-backend-buckets-to-load-balancers">
      *     GCLB Redirects</a>
      */
+    @TransportCompatibility(Transport.HTTP)
     public static PostPolicyV4Option withBucketBoundHostname(
         String bucketBoundHostname, Storage.UriScheme uriScheme) {
       return new PostPolicyV4Option(
@@ -1280,6 +1376,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     private final Option option;
     private final Object value;
 
+    @TransportCompatibility(Transport.HTTP)
     enum Option {
       HTTP_METHOD,
       CONTENT_TYPE,
@@ -1294,6 +1391,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
       QUERY_PARAMS
     }
 
+    @TransportCompatibility(Transport.HTTP)
     enum SignatureVersion {
       V2,
       V4
@@ -1316,6 +1414,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * The HTTP method to be used with the signed URL. If this method is not called, defaults to
      * GET.
      */
+    @TransportCompatibility(Transport.HTTP)
     public static SignUrlOption httpMethod(HttpMethod httpMethod) {
       return new SignUrlOption(Option.HTTP_METHOD, httpMethod);
     }
@@ -1325,6 +1424,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * URL should include the blob's content-type with their request. If using this URL from a
      * browser, you must include a content type that matches what the browser will send.
      */
+    @TransportCompatibility(Transport.HTTP)
     public static SignUrlOption withContentType() {
       return new SignUrlOption(Option.CONTENT_TYPE, true);
     }
@@ -1333,6 +1433,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Use it if signature should include the blob's md5. When used, users of the signed URL should
      * include the blob's md5 with their request.
      */
+    @TransportCompatibility(Transport.HTTP)
     public static SignUrlOption withMd5() {
       return new SignUrlOption(Option.MD5, true);
     }
@@ -1344,6 +1445,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * @see <a href="https://cloud.google.com/storage/docs/xml-api/reference-headers">Request
      *     Headers</a>
      */
+    @TransportCompatibility(Transport.HTTP)
     public static SignUrlOption withExtHeaders(Map<String, String> extHeaders) {
       return new SignUrlOption(Option.EXT_HEADERS, extHeaders);
     }
@@ -1352,6 +1454,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * Use if signature version should be V2. This is the default if neither this or {@code
      * withV4Signature()} is called.
      */
+    @TransportCompatibility(Transport.HTTP)
     public static SignUrlOption withV2Signature() {
       return new SignUrlOption(Option.SIGNATURE_VERSION, SignatureVersion.V2);
     }
@@ -1361,6 +1464,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * longer than 7 days. V2 will be the default if neither this or {@code withV2Signature()} is
      * called.
      */
+    @TransportCompatibility(Transport.HTTP)
     public static SignUrlOption withV4Signature() {
       return new SignUrlOption(Option.SIGNATURE_VERSION, SignatureVersion.V4);
     }
@@ -1372,6 +1476,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * @see <a href="https://cloud.google.com/storage/docs/authentication#service_accounts">Service
      *     Accounts</a>
      */
+    @TransportCompatibility(Transport.HTTP)
     public static SignUrlOption signWith(ServiceAccountSigner signer) {
       return new SignUrlOption(Option.SERVICE_ACCOUNT_CRED, signer);
     }
@@ -1383,6 +1488,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * withVirtualHostedStyle()} method, you should omit the bucket name from the hostname, as it
      * automatically gets prepended to the hostname for virtual hosted-style URLs.
      */
+    @TransportCompatibility(Transport.HTTP)
     public static SignUrlOption withHostName(String hostName) {
       return new SignUrlOption(Option.HOST_NAME, hostName);
     }
@@ -1396,6 +1502,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *
      * @see <a href="https://cloud.google.com/storage/docs/request-endpoints">Request Endpoints</a>
      */
+    @TransportCompatibility(Transport.HTTP)
     public static SignUrlOption withVirtualHostedStyle() {
       return new SignUrlOption(Option.VIRTUAL_HOSTED_STYLE, "");
     }
@@ -1409,6 +1516,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *
      * @see <a href="https://cloud.google.com/storage/docs/request-endpoints">Request Endpoints</a>
      */
+    @TransportCompatibility(Transport.HTTP)
     public static SignUrlOption withPathStyle() {
       return new SignUrlOption(Option.PATH_STYLE, "");
     }
@@ -1427,6 +1535,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *     href="https://cloud.google.com/load-balancing/docs/https/adding-backend-buckets-to-load-balancers">
      *     GCLB Redirects</a>
      */
+    @TransportCompatibility(Transport.HTTP)
     public static SignUrlOption withBucketBoundHostname(String bucketBoundHostname) {
       return withBucketBoundHostname(bucketBoundHostname, UriScheme.HTTP);
     }
@@ -1445,6 +1554,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      *     href="https://cloud.google.com/load-balancing/docs/https/adding-backend-buckets-to-load-balancers">
      *     GCLB Redirects</a>
      */
+    @TransportCompatibility(Transport.HTTP)
     public static SignUrlOption withBucketBoundHostname(
         String bucketBoundHostname, UriScheme uriScheme) {
       return new SignUrlOption(
@@ -1464,6 +1574,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
      * @see <a href="https://cloud.google.com/storage/docs/access-control/signed-urls-v2">V2 Signing
      *     Process</a>
      */
+    @TransportCompatibility(Transport.HTTP)
     public static SignUrlOption withQueryParams(Map<String, String> queryParams) {
       return new SignUrlOption(Option.QUERY_PARAMS, queryParams);
     }
@@ -1485,6 +1596,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     private final List<BlobTargetOption> targetOptions;
 
     /** Class for Compose source blobs. */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static class SourceBlob implements Serializable {
 
       private static final long serialVersionUID = -157636474404489874L;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
@@ -296,7 +296,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
   /** Class for specifying bucket target options. */
   class BucketTargetOption extends Option<BucketTargetOpt> {
 
-    private static final long serialVersionUID = 22594853046651193L;
+    private static final long serialVersionUID = 6699243191830059404L;
 
     private BucketTargetOption(BucketTargetOpt opt) {
       super(opt);
@@ -352,7 +352,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
   /** Class for specifying bucket source options. */
   class BucketSourceOption extends Option<BucketSourceOpt> {
 
-    private static final long serialVersionUID = -162739527257621625L;
+    private static final long serialVersionUID = 3808812145390746748L;
 
     BucketSourceOption(BucketSourceOpt opt) {
       super(opt);
@@ -517,7 +517,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
   /** Class for specifying bucket get options. */
   class BucketGetOption extends Option<BucketSourceOpt> {
 
-    private static final long serialVersionUID = 6162812462707653332L;
+    private static final long serialVersionUID = -669900932880354035L;
 
     BucketGetOption(BucketSourceOpt opt) {
       super(opt);
@@ -566,7 +566,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
   /** Class for specifying blob target options. */
   class BlobTargetOption extends Option<ObjectTargetOpt> {
 
-    private static final long serialVersionUID = -389155232891981906L;
+    private static final long serialVersionUID = -5554842495450599563L;
 
     BlobTargetOption(ObjectTargetOpt opt) {
       super(opt);
@@ -668,7 +668,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
   /** Class for specifying blob write options. */
   class BlobWriteOption extends OptionShim<ObjectTargetOpt> implements Serializable {
 
-    private static final long serialVersionUID = 1834774766750256808L;
+    private static final long serialVersionUID = 5536338021856320475L;
 
     BlobWriteOption(ObjectTargetOpt opt) {
       super(opt);
@@ -795,7 +795,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
   /** Class for specifying blob source options. */
   class BlobSourceOption extends Option<ObjectSourceOpt> {
 
-    private static final long serialVersionUID = 2131185332093994401L;
+    private static final long serialVersionUID = -8626355836092280204L;
 
     BlobSourceOption(ObjectSourceOpt opt) {
       super(opt);
@@ -898,7 +898,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
   /** Class for specifying blob get options. */
   class BlobGetOption extends Option<ObjectSourceOpt> {
 
-    private static final long serialVersionUID = 4464929616050835795L;
+    private static final long serialVersionUID = -2857961421224394114L;
 
     BlobGetOption(ObjectSourceOpt opt) {
       super(opt);
@@ -1013,7 +1013,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
   /** Class for specifying bucket list options. */
   class BucketListOption extends Option<BucketListOpt> {
 
-    private static final long serialVersionUID = 5717590216719591953L;
+    private static final long serialVersionUID = 6388807550815607557L;
 
     private BucketListOption(BucketListOpt opt) {
       super(opt);
@@ -1065,7 +1065,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
   /** Class for specifying blob list options. */
   class BlobListOption extends Option<ObjectListOpt> {
 
-    private static final long serialVersionUID = 5677832374576757707L;
+    private static final long serialVersionUID = 5216908055423927281L;
 
     private BlobListOption(ObjectListOpt opt) {
       super(opt);
@@ -1173,7 +1173,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
 
   /** Class for specifying Post Policy V4 options. * */
   class PostPolicyV4Option implements Serializable {
-    private static final long serialVersionUID = 8150867146534084543L;
+    private static final long serialVersionUID = -1592545784993528897L;
     private final PostPolicyV4Option.Option option;
     private final Object value;
 
@@ -1275,7 +1275,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
   /** Class for specifying signed URL options. */
   class SignUrlOption implements Serializable {
 
-    private static final long serialVersionUID = 7850569877451099267L;
+    private static final long serialVersionUID = -3165388740755311106L;
 
     private final Option option;
     private final Object value;
@@ -1478,7 +1478,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
   @TransportCompatibility({Transport.HTTP, Transport.GRPC})
   class ComposeRequest implements Serializable {
 
-    private static final long serialVersionUID = -7385681353748590911L;
+    private static final long serialVersionUID = 6612204553167273919L;
 
     private final List<SourceBlob> sourceBlobs;
     private final BlobInfo target;
@@ -1487,7 +1487,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     /** Class for Compose source blobs. */
     public static class SourceBlob implements Serializable {
 
-      private static final long serialVersionUID = 4094962795951990439L;
+      private static final long serialVersionUID = -157636474404489874L;
 
       final String name;
       final Long generation;
@@ -1613,7 +1613,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
   @TransportCompatibility({Transport.HTTP, Transport.GRPC})
   class CopyRequest implements Serializable {
 
-    private static final long serialVersionUID = -4498650529476219937L;
+    private static final long serialVersionUID = 5670794463350011330L;
 
     private final BlobId source;
     private final List<BlobSourceOption> sourceOptions;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageClass.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageClass.java
@@ -25,7 +25,7 @@ import com.google.cloud.StringEnumValue;
  * for details.
  */
 public final class StorageClass extends StringEnumValue {
-  private static final long serialVersionUID = -6938125060419556331L;
+  private static final long serialVersionUID = -1077862391496082625L;
 
   private StorageClass(String constant) {
     super(constant);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageException.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageException.java
@@ -54,7 +54,7 @@ public final class StorageException extends BaseHttpServiceException {
           new Error(null, INTERNAL_ERROR),
           new Error(null, CONNECTION_CLOSED_PREMATURELY));
 
-  private static final long serialVersionUID = -4168430271327813063L;
+  private static final long serialVersionUID = 757915549325467990L;
 
   final ApiException apiExceptionCause;
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
@@ -311,7 +311,7 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
 
   private static class BucketPageFetcher implements NextPageFetcher<Bucket> {
 
-    private static final long serialVersionUID = 5850406828803613729L;
+    private static final long serialVersionUID = 8534413447247364038L;
     private final Map<StorageRpc.Option, ?> requestOptions;
     private final HttpStorageOptions serviceOptions;
 
@@ -330,7 +330,7 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
 
   private static class BlobPageFetcher implements NextPageFetcher<Blob> {
 
-    private static final long serialVersionUID = 81807334445874098L;
+    private static final long serialVersionUID = -4308415167471093443L;
     private final Map<StorageRpc.Option, ?> requestOptions;
     private final HttpStorageOptions serviceOptions;
     private final String bucket;
@@ -354,7 +354,7 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
 
   private static class HmacKeyMetadataPageFetcher implements NextPageFetcher<HmacKeyMetadata> {
 
-    private static final long serialVersionUID = 308012320541700881L;
+    private static final long serialVersionUID = -8637392485924772927L;
     private final HttpStorageOptions serviceOptions;
     private final HttpRetryAlgorithmManager retryAlgorithmManager;
     private final Map<StorageRpc.Option, ?> options;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageOptions.java
@@ -29,7 +29,7 @@ import com.google.cloud.storage.spi.StorageRpcFactory;
 
 public abstract class StorageOptions extends ServiceOptions<Storage, StorageOptions> {
 
-  private static final long serialVersionUID = 7784772908840175401L;
+  private static final long serialVersionUID = -7295846567928013233L;
 
   /** @deprecated Use {@link HttpStorageFactory} */
   @Deprecated
@@ -96,28 +96,48 @@ public abstract class StorageOptions extends ServiceOptions<Storage, StorageOpti
   @Override
   public abstract boolean equals(Object obj);
 
-  /** Returns a default {@code StorageOptions} instance. */
+  /**
+   * Returns a default {@code StorageOptions} instance. The default instance will use JSON over HTTP
+   * for its transport.
+   */
   @TransportCompatibility(Transport.HTTP)
   public static StorageOptions getDefaultInstance() {
     return HttpStorageOptions.newBuilder().build();
   }
 
-  /** Returns a unauthenticated {@code StorageOptions} instance. */
+  /**
+   * Returns a unauthenticated {@code StorageOptions} instance. The returned instance will use JSON
+   * over HTTP for its transport.
+   */
   @TransportCompatibility(Transport.HTTP)
   public static StorageOptions getUnauthenticatedInstance() {
     return HttpStorageOptions.newBuilder().setCredentials(NoCredentials.getInstance()).build();
   }
 
+  /** The returned instance will use JSON over HTTP for its transport. */
   @TransportCompatibility(Transport.HTTP)
   public static StorageOptions.Builder newBuilder() {
     return http();
   }
 
+  /**
+   * Builder factory method which will create a JSON over HTTP specific instance of storage options.
+   *
+   * @since 2.14.0 This new api is in preview and is subject to breaking changes.
+   */
+  @BetaApi
   @TransportCompatibility(Transport.HTTP)
   public static HttpStorageOptions.Builder http() {
     return HttpStorageOptions.newBuilder();
   }
 
+  /**
+   * Builder factory method which will create a gRPC specific instance of storage options.
+   *
+   * <p>Google Cloud Storage is in Private Preview for a gRPC centric transport.
+   *
+   * @since 2.14.0 This new api is in preview and is subject to breaking changes.
+   */
   @BetaApi
   @TransportCompatibility(Transport.GRPC)
   public static GrpcStorageOptions.Builder grpc() {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
@@ -500,7 +500,7 @@ final class UnifiedOpts {
   }
 
   static final class Crc32cMatch implements ObjectTargetOpt {
-    private static final long serialVersionUID = -8680237667319155418L;
+    private static final long serialVersionUID = 8172282701777561769L;
     private final int val;
 
     private Crc32cMatch(int val) {
@@ -545,7 +545,7 @@ final class UnifiedOpts {
 
   /** @see EncryptionKey */
   static final class DecryptionKey extends RpcOptVal<Key> implements ObjectSourceOpt {
-    private static final long serialVersionUID = -4583830666730826055L;
+    private static final long serialVersionUID = -2198422155991275316L;
 
     private DecryptionKey(Key val) {
       super(StorageRpc.Option.CUSTOMER_SUPPLIED_KEY, val);
@@ -588,7 +588,7 @@ final class UnifiedOpts {
   }
 
   static final class Delimiter extends RpcOptVal<String> implements ObjectListOpt {
-    private static final long serialVersionUID = 8639409337839854122L;
+    private static final long serialVersionUID = -3789556789947615714L;
 
     private Delimiter(String val) {
       super(StorageRpc.Option.DELIMITER, val);
@@ -602,7 +602,7 @@ final class UnifiedOpts {
 
   static final class DisableGzipContent extends RpcOptVal<@NonNull Boolean>
       implements ObjectTargetOpt {
-    private static final long serialVersionUID = -8673296387131912651L;
+    private static final long serialVersionUID = 7445066765944965549L;
 
     private DisableGzipContent(boolean val) {
       super(StorageRpc.Option.IF_DISABLE_GZIP_CONTENT, val);
@@ -611,7 +611,7 @@ final class UnifiedOpts {
 
   /** @see DecryptionKey */
   static final class EncryptionKey extends RpcOptVal<Key> implements ObjectTargetOpt {
-    private static final long serialVersionUID = 7563566358784847875L;
+    private static final long serialVersionUID = -7335988656032764620L;
 
     private EncryptionKey(Key val) {
       super(StorageRpc.Option.CUSTOMER_SUPPLIED_KEY, val);
@@ -668,7 +668,7 @@ final class UnifiedOpts {
 
   /** @see StartOffset */
   static final class EndOffset extends RpcOptVal<String> implements ObjectListOpt {
-    private static final long serialVersionUID = -4571919566602569625L;
+    private static final long serialVersionUID = 7446382028145458833L;
 
     private EndOffset(String val) {
       super(StorageRpc.Option.END_OFF_SET, val);
@@ -695,7 +695,7 @@ final class UnifiedOpts {
     private static final ImmutableSet<String> grpcExcludedFields =
         ImmutableSet.of("nextPageToken", "prefixes", "selfLink", "mediaLink", "kind", "id");
 
-    private static final long serialVersionUID = -320337719611149532L;
+    private static final long serialVersionUID = 3286889410148272195L;
 
     private Fields(ImmutableSet<NamedField> val) {
       super(StorageRpc.Option.FIELDS, val);
@@ -891,7 +891,7 @@ final class UnifiedOpts {
    */
   static final class GenerationMatch extends RpcOptVal<@NonNull Long>
       implements ObjectSourceOpt, ObjectTargetOpt, ProjectAsSource<SourceGenerationMatch> {
-    private static final long serialVersionUID = -2356341166190897807L;
+    private static final long serialVersionUID = 2645517179434741007L;
 
     private GenerationMatch(long val) {
       super(StorageRpc.Option.IF_GENERATION_MATCH, val);
@@ -947,7 +947,7 @@ final class UnifiedOpts {
    */
   static final class GenerationNotMatch extends RpcOptVal<@NonNull Long>
       implements ObjectSourceOpt, ObjectTargetOpt, ProjectAsSource<SourceGenerationNotMatch> {
-    private static final long serialVersionUID = -6055322302594035351L;
+    private static final long serialVersionUID = 156505623580743531L;
 
     private GenerationNotMatch(long val) {
       super(StorageRpc.Option.IF_GENERATION_NOT_MATCH, val);
@@ -993,7 +993,7 @@ final class UnifiedOpts {
   }
 
   static final class KmsKeyName extends RpcOptVal<String> implements ObjectTargetOpt {
-    private static final long serialVersionUID = -3337302773119117013L;
+    private static final long serialVersionUID = -3053839109272566113L;
 
     private KmsKeyName(String val) {
       super(StorageRpc.Option.KMS_KEY_NAME, val);
@@ -1020,7 +1020,7 @@ final class UnifiedOpts {
 
   @Deprecated
   static final class Md5Match implements ObjectTargetOpt {
-    private static final long serialVersionUID = -4497633005169883788L;
+    private static final long serialVersionUID = 5237207911268363887L;
     private final String val;
 
     private Md5Match(String val) {
@@ -1065,7 +1065,7 @@ final class UnifiedOpts {
           ObjectSourceOpt,
           ObjectTargetOpt,
           ProjectAsSource<SourceMetagenerationMatch> {
-    private static final long serialVersionUID = 5508074897592817147L;
+    private static final long serialVersionUID = 49086960234390739L;
 
     private MetagenerationMatch(long val) {
       super(StorageRpc.Option.IF_METAGENERATION_MATCH, val);
@@ -1145,7 +1145,7 @@ final class UnifiedOpts {
           ObjectSourceOpt,
           ObjectTargetOpt,
           ProjectAsSource<SourceMetagenerationNotMatch> {
-    private static final long serialVersionUID = 6869928996186950306L;
+    private static final long serialVersionUID = -1795350187419586248L;
 
     private MetagenerationNotMatch(long val) {
       super(StorageRpc.Option.IF_METAGENERATION_NOT_MATCH, val);
@@ -1207,7 +1207,7 @@ final class UnifiedOpts {
 
   static final class PageSize extends RpcOptVal<@NonNull Long>
       implements BucketListOpt, ObjectListOpt, HmacKeyListOpt {
-    private static final long serialVersionUID = -3510673708181397881L;
+    private static final long serialVersionUID = -8184518840397826601L;
 
     private PageSize(long val) {
       super(StorageRpc.Option.MAX_RESULTS, val);
@@ -1231,7 +1231,7 @@ final class UnifiedOpts {
 
   static final class PageToken extends RpcOptVal<String>
       implements BucketListOpt, ObjectListOpt, HmacKeyListOpt {
-    private static final long serialVersionUID = -542427084922230782L;
+    private static final long serialVersionUID = -1370658416509499177L;
 
     private PageToken(String val) {
       super(StorageRpc.Option.PAGE_TOKEN, val);
@@ -1255,7 +1255,7 @@ final class UnifiedOpts {
 
   static final class PredefinedAcl extends RpcOptVal<String>
       implements BucketTargetOpt, ObjectTargetOpt {
-    private static final long serialVersionUID = 4189588503372535057L;
+    private static final long serialVersionUID = -1743736785228368741L;
 
     private PredefinedAcl(String val) {
       super(StorageRpc.Option.PREDEFINED_ACL, val);
@@ -1297,7 +1297,7 @@ final class UnifiedOpts {
 
   static final class PredefinedDefaultObjectAcl extends RpcOptVal<String>
       implements BucketTargetOpt {
-    private static final long serialVersionUID = 6598022065653572605L;
+    private static final long serialVersionUID = -1771832790114963130L;
 
     private PredefinedDefaultObjectAcl(String val) {
       super(StorageRpc.Option.PREDEFINED_DEFAULT_OBJECT_ACL, val);
@@ -1315,7 +1315,7 @@ final class UnifiedOpts {
   }
 
   static final class Prefix extends RpcOptVal<String> implements BucketListOpt, ObjectListOpt {
-    private static final long serialVersionUID = 155278267048093608L;
+    private static final long serialVersionUID = -3973478772547687371L;
 
     private Prefix(String val) {
       super(StorageRpc.Option.PREFIX, val);
@@ -1339,7 +1339,7 @@ final class UnifiedOpts {
   @Deprecated
   static final class ProjectId extends RpcOptVal<String>
       implements HmacKeySourceOpt, HmacKeyTargetOpt, HmacKeyListOpt, BucketListOpt {
-    private static final long serialVersionUID = 1471462503030451598L;
+    private static final long serialVersionUID = 6273807286378420321L;
 
     private ProjectId(String val) {
       super(StorageRpc.Option.PROJECT_ID, val);
@@ -1367,7 +1367,7 @@ final class UnifiedOpts {
   }
 
   static final class Projection extends RpcOptVal<String> implements BucketTargetOpt {
-    private static final long serialVersionUID = -1260415089938322394L;
+    private static final long serialVersionUID = -7394684784418942133L;
 
     private Projection(String val) {
       super(StorageRpc.Option.PROJECTION, val);
@@ -1380,7 +1380,7 @@ final class UnifiedOpts {
    */
   static final class SourceGenerationMatch extends RpcOptVal<@NonNull Long>
       implements ObjectSourceOpt, ObjectTargetOpt {
-    private static final long serialVersionUID = 5530465094492461956L;
+    private static final long serialVersionUID = -4074703368515265616L;
 
     private SourceGenerationMatch(@NonNull Long val) {
       super(StorageRpc.Option.IF_SOURCE_GENERATION_MATCH, val);
@@ -1398,7 +1398,7 @@ final class UnifiedOpts {
    */
   static final class SourceGenerationNotMatch extends RpcOptVal<@NonNull Long>
       implements ObjectSourceOpt, ObjectTargetOpt {
-    private static final long serialVersionUID = 313414895558156715L;
+    private static final long serialVersionUID = -5232032184462880657L;
 
     private SourceGenerationNotMatch(@NonNull Long val) {
       super(StorageRpc.Option.IF_SOURCE_GENERATION_NOT_MATCH, val);
@@ -1416,7 +1416,7 @@ final class UnifiedOpts {
    */
   static final class SourceMetagenerationMatch extends RpcOptVal<@NonNull Long>
       implements BucketSourceOpt, BucketTargetOpt, ObjectSourceOpt, ObjectTargetOpt {
-    private static final long serialVersionUID = -3643340315457580094L;
+    private static final long serialVersionUID = 5223360761780436495L;
 
     private SourceMetagenerationMatch(@NonNull Long val) {
       super(StorageRpc.Option.IF_SOURCE_METAGENERATION_MATCH, val);
@@ -1434,7 +1434,7 @@ final class UnifiedOpts {
    */
   static final class SourceMetagenerationNotMatch extends RpcOptVal<@NonNull Long>
       implements BucketSourceOpt, BucketTargetOpt, ObjectSourceOpt, ObjectTargetOpt {
-    private static final long serialVersionUID = -6682202521743160969L;
+    private static final long serialVersionUID = 2679308305890468285L;
 
     private SourceMetagenerationNotMatch(@NonNull Long val) {
       super(StorageRpc.Option.IF_SOURCE_METAGENERATION_NOT_MATCH, val);
@@ -1448,7 +1448,7 @@ final class UnifiedOpts {
 
   static final class RequestedPolicyVersion extends RpcOptVal<@NonNull Long>
       implements BucketSourceOpt {
-    private static final long serialVersionUID = 7044856817626952830L;
+    private static final long serialVersionUID = -3606062322328656218L;
 
     private RequestedPolicyVersion(Long val) {
       super(StorageRpc.Option.REQUESTED_POLICY_VERSION, val);
@@ -1466,7 +1466,7 @@ final class UnifiedOpts {
   @Deprecated
   static final class ReturnRawInputStream extends RpcOptVal<@NonNull Boolean>
       implements ObjectSourceOpt {
-    private static final long serialVersionUID = 505293506385742781L;
+    private static final long serialVersionUID = -5741791424843430584L;
 
     private ReturnRawInputStream(boolean val) {
       super(StorageRpc.Option.RETURN_RAW_INPUT_STREAM, val);
@@ -1474,7 +1474,7 @@ final class UnifiedOpts {
   }
 
   static final class ServiceAccount extends RpcOptVal<String> implements HmacKeyListOpt {
-    private static final long serialVersionUID = 1630581690347694016L;
+    private static final long serialVersionUID = 5617709092359745482L;
 
     private ServiceAccount(String val) {
       super(StorageRpc.Option.SERVICE_ACCOUNT_EMAIL, val);
@@ -1487,7 +1487,7 @@ final class UnifiedOpts {
   }
 
   static final class SetContentType implements ObjectTargetOpt {
-    private static final long serialVersionUID = -5358445952573187492L;
+    private static final long serialVersionUID = -5715260463246857009L;
     private final String val;
 
     private SetContentType(String val) {
@@ -1539,7 +1539,7 @@ final class UnifiedOpts {
   }
 
   static final class ShowDeletedKeys extends RpcOptVal<@NonNull Boolean> implements HmacKeyListOpt {
-    private static final long serialVersionUID = 6650364639734728488L;
+    private static final long serialVersionUID = -6604176744362903487L;
 
     private ShowDeletedKeys(boolean val) {
       super(StorageRpc.Option.SHOW_DELETED_KEYS, val);
@@ -1553,7 +1553,7 @@ final class UnifiedOpts {
 
   /** @see EndOffset */
   static final class StartOffset extends RpcOptVal<String> implements ObjectListOpt {
-    private static final long serialVersionUID = 7763387382950935370L;
+    private static final long serialVersionUID = -1459727336598737833L;
 
     private StartOffset(String val) {
       super(StorageRpc.Option.START_OFF_SET, val);
@@ -1575,7 +1575,7 @@ final class UnifiedOpts {
           HmacKeySourceOpt,
           HmacKeyTargetOpt,
           HmacKeyListOpt {
-    private static final long serialVersionUID = -3580124936740285695L;
+    private static final long serialVersionUID = 3962499996741180460L;
 
     private UserProject(String val) {
       super(StorageRpc.Option.USER_PROJECT, val);
@@ -1614,7 +1614,7 @@ final class UnifiedOpts {
   @Deprecated
   static final class Crc32cMatchExtractor implements ObjectOptExtractor<ObjectTargetOpt> {
     private static final Crc32cMatchExtractor INSTANCE = new Crc32cMatchExtractor();
-    private static final long serialVersionUID = 2222053443431466916L;
+    private static final long serialVersionUID = 7045998436157555676L;
 
     @Deprecated
     private Crc32cMatchExtractor() {}
@@ -1654,7 +1654,7 @@ final class UnifiedOpts {
   static final class DetectContentType implements ObjectOptExtractor<ObjectTargetOpt> {
     @Deprecated private static final DetectContentType INSTANCE = new DetectContentType();
     private static final FileNameMap FILE_NAME_MAP = URLConnection.getFileNameMap();
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = -1089120180148634090L;
 
     @Deprecated
     private DetectContentType() {}
@@ -1700,7 +1700,7 @@ final class UnifiedOpts {
   @Deprecated
   static final class GenerationMatchExtractor implements ObjectOptExtractor<GenerationMatch> {
     private static final GenerationMatchExtractor INSTANCE = new GenerationMatchExtractor();
-    private static final long serialVersionUID = -4016709200925410921L;
+    private static final long serialVersionUID = -7211192249703566097L;
 
     @Deprecated
     private GenerationMatchExtractor() {}
@@ -1734,7 +1734,7 @@ final class UnifiedOpts {
   @Deprecated
   static final class GenerationNotMatchExtractor implements ObjectOptExtractor<GenerationNotMatch> {
     private static final GenerationNotMatchExtractor INSTANCE = new GenerationNotMatchExtractor();
-    private static final long serialVersionUID = 2419121370772040679L;
+    private static final long serialVersionUID = -107520114846569713L;
 
     @Deprecated
     private GenerationNotMatchExtractor() {}
@@ -1768,7 +1768,7 @@ final class UnifiedOpts {
   @Deprecated
   static final class Md5MatchExtractor implements ObjectOptExtractor<ObjectTargetOpt> {
     private static final Md5MatchExtractor INSTANCE = new Md5MatchExtractor();
-    private static final long serialVersionUID = -227445210555345030L;
+    private static final long serialVersionUID = 8375506989224962531L;
 
     @Deprecated
     private Md5MatchExtractor() {}
@@ -1804,7 +1804,7 @@ final class UnifiedOpts {
   static final class MetagenerationMatchExtractor
       implements ObjectOptExtractor<ObjectTargetOpt>, BucketOptExtractor<MetagenerationMatch> {
     private static final MetagenerationMatchExtractor INSTANCE = new MetagenerationMatchExtractor();
-    private static final long serialVersionUID = -9012665484224118046L;
+    private static final long serialVersionUID = -4165372534008844973L;
 
     @Deprecated
     private MetagenerationMatchExtractor() {}
@@ -1851,7 +1851,7 @@ final class UnifiedOpts {
       implements ObjectOptExtractor<ObjectTargetOpt>, BucketOptExtractor<MetagenerationNotMatch> {
     private static final MetagenerationNotMatchExtractor INSTANCE =
         new MetagenerationNotMatchExtractor();
-    private static final long serialVersionUID = -732561730735045523L;
+    private static final long serialVersionUID = 6544628474151482319L;
 
     @Deprecated
     private MetagenerationNotMatchExtractor() {}
@@ -1894,7 +1894,7 @@ final class UnifiedOpts {
   @VisibleForTesting
   static final class NoOpObjectTargetOpt implements ObjectTargetOpt {
     @VisibleForTesting static final NoOpObjectTargetOpt INSTANCE = new NoOpObjectTargetOpt();
-    private static final long serialVersionUID = -3702724179751638748L;
+    private static final long serialVersionUID = -5356245440686012545L;
 
     private NoOpObjectTargetOpt() {}
 
@@ -1923,7 +1923,7 @@ final class UnifiedOpts {
    */
   @Deprecated
   abstract static class OptionShim<O extends Opt> implements Serializable {
-    private static final long serialVersionUID = -1026813326366179926L;
+    private static final long serialVersionUID = 3410752214075057852L;
     private final O opt;
 
     OptionShim(O opt) {
@@ -1964,7 +1964,7 @@ final class UnifiedOpts {
    * @param <T>
    */
   private abstract static class RpcOptVal<T> implements Opt {
-    private static final long serialVersionUID = -86698141922923191L;
+    private static final long serialVersionUID = 9170283346051824148L;
     protected final StorageRpc.Option key;
     protected final T val;
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/UniformStorageRetryStrategy.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/UniformStorageRetryStrategy.java
@@ -24,7 +24,7 @@ import com.google.api.gax.retrying.ResultRetryAlgorithm;
  */
 final class UniformStorageRetryStrategy implements StorageRetryStrategy {
 
-  private static final long serialVersionUID = -1656941189344618393L;
+  private static final long serialVersionUID = -8606685654893234472L;
   private final ResultRetryAlgorithm<?> algorithm;
 
   public UniformStorageRetryStrategy(ResultRetryAlgorithm<?> algorithm) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/SerializationTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/SerializationTest.java
@@ -108,7 +108,7 @@ public class SerializationTest extends BaseSerializationTest {
             .build();
     StorageOptions optionsHttp2 = optionsHttp1.toBuilder().setProjectId("http2").build();
     StorageOptions optionsGrpc1 =
-        StorageOptions.http()
+        StorageOptions.grpc()
             .setProjectId("grpc1")
             .setCredentials(NoCredentials.getInstance())
             .build();
@@ -191,7 +191,6 @@ public class SerializationTest extends BaseSerializationTest {
 
   @Override
   protected Restorable<?>[] restorableObjects() {
-    // TODO: Think about this some more
     HttpStorageOptions options = HttpStorageOptions.newBuilder().setProjectId("p2").build();
     ResultRetryAlgorithm<?> algorithm =
         options.getRetryAlgorithmManager().getForResumableUploadSessionWrite(EMPTY_RPC_OPTIONS);


### PR DESCRIPTION
* Update javadocs on all new @BetaApi methods to state they are preview apis and subject to breaking changes
* Update TransportCompatibility annotations to apply to more classes and methods
* Regenerate all serialVersionUID values to ensure no leaking version numbers compared with other classes

