### PR TITLE
fix(java): avoid unexpected initialization of `JacksonParser` in Graal 22.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.0.0')
+implementation platform('com.google.cloud:libraries-bom:26.1.3')
 
 implementation 'com.google.cloud:google-cloud-storage'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-storage:2.10.0'
+implementation 'com.google.cloud:google-cloud-storage:2.13.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "2.10.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "2.13.0"
 ```
 
 ## Authentication

--- a/google-cloud-storage/src/main/resources/META-INF/native-image/com/google/cloud/storage/native-image.properties
+++ b/google-cloud-storage/src/main/resources/META-INF/native-image/com/google/cloud/storage/native-image.properties
@@ -1,2 +1,0 @@
-Args = --initialize-at-build-time=com.google.api.client.json.jackson2.JacksonParser$,\
-  com.fasterxml.jackson.core.JsonToken

--- a/google-cloud-storage/src/main/resources/META-INF/native-image/com/google/cloud/storage/native-image.properties
+++ b/google-cloud-storage/src/main/resources/META-INF/native-image/com/google/cloud/storage/native-image.properties
@@ -1,0 +1,2 @@
+Args = --initialize-at-build-time=com.google.api.client.json.jackson2.JacksonParser$,\
+  com.fasterxml.jackson.core.JsonToken

--- a/google-cloud-storage/src/test/resources/META-INF/native-image/com/google/cloud/storage/native-image.properties
+++ b/google-cloud-storage/src/test/resources/META-INF/native-image/com/google/cloud/storage/native-image.properties
@@ -4,7 +4,8 @@
 # and other classes ITRetryConformanceTest references to also be initialized at
 # build time. Initializing these classes explicitly at build time results in a
 # successful build.
-Args = --initialize-at-build-time=com.google.cloud.conformance.storage.v1,\
+Args = \
+  --initialize-at-build-time=com.google.cloud.conformance.storage.v1,\
   com.google.protobuf,\
   com.google.auth.oauth2,\
   com.google.cloud.storage.conformance.retry,\
@@ -12,6 +13,7 @@ Args = --initialize-at-build-time=com.google.cloud.conformance.storage.v1,\
   com.google.gson.stream.JsonReader,\
   com.google.api.client.util,\
   com.google.api.client.http.javanet.NetHttpTransport,\
+  com.google.api.client.http.HttpTransport,\
   com.google.api.client.json.JsonParser$1,\
   com.google.api.client.json.gson.GsonParser$1,\
   com.google.common.io.BaseEncoding,\
@@ -25,5 +27,4 @@ Args = --initialize-at-build-time=com.google.cloud.conformance.storage.v1,\
   com.google.gson.internal,\
   com.google.gson.internal.sql.SqlTypesSupport,\
   com.google.gson.FieldNamingPolicy$3,\
-  com.google.gson.LongSerializationPolicy$2 \
-  --trace-class-initialization=com.fasterxml.jackson.core.JsonToken
+  com.google.gson.LongSerializationPolicy$2

--- a/google-cloud-storage/src/test/resources/META-INF/native-image/com/google/cloud/storage/native-image.properties
+++ b/google-cloud-storage/src/test/resources/META-INF/native-image/com/google/cloud/storage/native-image.properties
@@ -4,8 +4,7 @@
 # and other classes ITRetryConformanceTest references to also be initialized at
 # build time. Initializing these classes explicitly at build time results in a
 # successful build.
-Args = \
- --initialize-at-build-time=com.google.cloud.conformance.storage.v1,\
+Args = --initialize-at-build-time=com.google.cloud.conformance.storage.v1,\
   com.google.protobuf,\
   com.google.auth.oauth2,\
   com.google.cloud.storage.conformance.retry,\
@@ -13,8 +12,8 @@ Args = \
   com.google.gson.stream.JsonReader,\
   com.google.api.client.util,\
   com.google.api.client.http.javanet.NetHttpTransport,\
-  com.google.api.client.http.HttpTransport,\
-  com.google.api.client.json,\
+  com.google.api.client.json.JsonParser$1,\
+  com.google.api.client.json.gson.GsonParser$1,\
   com.google.common.io.BaseEncoding,\
   com.google.common.math.IntMath$1,\
   com.google.common.collect.Platform,\
@@ -26,4 +25,5 @@ Args = \
   com.google.gson.internal,\
   com.google.gson.internal.sql.SqlTypesSupport,\
   com.google.gson.FieldNamingPolicy$3,\
-  com.google.gson.LongSerializationPolicy$2
+  com.google.gson.LongSerializationPolicy$2 \
+  --trace-class-initialization=com.fasterxml.jackson.core.JsonToken

--- a/google-cloud-storage/src/test/resources/META-INF/native-image/com/google/cloud/storage/native-image.properties
+++ b/google-cloud-storage/src/test/resources/META-INF/native-image/com/google/cloud/storage/native-image.properties
@@ -26,9 +26,4 @@ Args = \
   com.google.gson.internal,\
   com.google.gson.internal.sql.SqlTypesSupport,\
   com.google.gson.FieldNamingPolicy$3,\
-  com.google.gson.LongSerializationPolicy$2,\
-  com.google.api.client.json.jackson2.JacksonParser$,\
-  com.fasterxml.jackson.core.JsonToken
-
-
-
+  com.google.gson.LongSerializationPolicy$2

--- a/google-cloud-storage/src/test/resources/META-INF/native-image/com/google/cloud/storage/native-image.properties
+++ b/google-cloud-storage/src/test/resources/META-INF/native-image/com/google/cloud/storage/native-image.properties
@@ -26,7 +26,9 @@ Args = \
   com.google.gson.internal,\
   com.google.gson.internal.sql.SqlTypesSupport,\
   com.google.gson.FieldNamingPolicy$3,\
-  com.google.gson.LongSerializationPolicy$2
+  com.google.gson.LongSerializationPolicy$2,\
+  com.google.api.client.json.jackson2.JacksonParser$,\
+  com.fasterxml.jackson.core.JsonToken
 
 
 


### PR DESCRIPTION
Running storage tests in GraalVM 22.2.0 results in:
```
Error: Classes that should be initialized at run time got initialized during image building:
com.fasterxml.jackson.core.JsonToken was unintentionally initialized at build time. com.google.api.client.json.jackson2.JacksonParser$1 caused initialization of this class with the following trace: 
	at com.fasterxml.jackson.core.JsonToken.<clinit>(JsonToken.java:31)
	at com.google.api.client.json.jackson2.JacksonParser$1.<clinit>(JacksonParser.java:121)
```
The root cause was the specification of `com.google.api.client.json` where we were initializing the whole package at build time.  This PR initializes only the necessary classes at build time to resolve this.