### PR TITLE
fix: update BucketInfo.LifecycleRule#fromPb to wire through MatchesPrefix & MatchesSuffix

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BucketInfo.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BucketInfo.java
@@ -663,9 +663,8 @@ public class BucketInfo implements Serializable {
               .setNoncurrentTimeBefore(condition.getNoncurrentTimeBefore())
               .setCustomTimeBefore(condition.getCustomTimeBefore())
               .setDaysSinceCustomTime(condition.getDaysSinceCustomTime())
-                  .setMatchesPrefix(condition.getMatchesPrefix())
-                  .setMatchesSuffix(condition.getMatchesSuffix());
-
+              .setMatchesPrefix(condition.getMatchesPrefix())
+              .setMatchesSuffix(condition.getMatchesSuffix());
 
       return new LifecycleRule(lifecycleAction, conditionBuilder.build());
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BucketInfo.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BucketInfo.java
@@ -662,7 +662,10 @@ public class BucketInfo implements Serializable {
               .setDaysSinceNoncurrentTime(condition.getDaysSinceNoncurrentTime())
               .setNoncurrentTimeBefore(condition.getNoncurrentTimeBefore())
               .setCustomTimeBefore(condition.getCustomTimeBefore())
-              .setDaysSinceCustomTime(condition.getDaysSinceCustomTime());
+              .setDaysSinceCustomTime(condition.getDaysSinceCustomTime())
+                  .setMatchesPrefix(condition.getMatchesPrefix())
+                  .setMatchesSuffix(condition.getMatchesSuffix());
+
 
       return new LifecycleRule(lifecycleAction, conditionBuilder.build());
     }


### PR DESCRIPTION
fix: Fixing the issue of MatchPrefix and Matchsuffix properties set in the GCP Console not being picked up by the API (BucketInfo).

Fixes #1715  ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
