### PR TITLE
test: add more scenarios to be validated for checksum support

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ChecksummedTestContent.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ChecksummedTestContent.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.it;
+
+import com.google.common.hash.Hashing;
+import com.google.common.io.BaseEncoding;
+import com.google.common.primitives.Ints;
+import com.google.protobuf.ByteString;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+
+final class ChecksummedTestContent {
+
+  private final byte[] bytes;
+  private final int crc32c;
+  private final String md5Base64;
+
+  private ChecksummedTestContent(byte[] bytes, int crc32c, String md5Base64) {
+    this.bytes = bytes;
+    this.crc32c = crc32c;
+    this.md5Base64 = md5Base64;
+  }
+
+  public byte[] getBytes() {
+    return bytes;
+  }
+
+  public int getCrc32c() {
+    return crc32c;
+  }
+
+  public ByteString getMd5Bytes() {
+    return ByteString.copyFrom(BaseEncoding.base64().decode(md5Base64));
+  }
+
+  public String getMd5Base64() {
+    return md5Base64;
+  }
+
+  public String getCrc32cBase64() {
+    return Base64.getEncoder().encodeToString(Ints.toByteArray(crc32c));
+  }
+
+  public byte[] concat(char c) {
+    return concat((byte) c);
+  }
+
+  public byte[] concat(byte b) {
+    int lenOrig = bytes.length;
+    int lenNew = lenOrig + 1;
+    byte[] newBytes = Arrays.copyOf(bytes, lenNew);
+    newBytes[lenOrig] = b;
+    return newBytes;
+  }
+
+  public ByteArrayInputStream bytesAsInputStream() {
+    return new ByteArrayInputStream(bytes);
+  }
+
+  public static ChecksummedTestContent of(String content) {
+    byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+    return of(bytes);
+  }
+
+  public static ChecksummedTestContent of(byte[] bytes) {
+    int crc32c = Hashing.crc32c().hashBytes(bytes).asInt();
+    String md5Base64 = Base64.getEncoder().encodeToString(Hashing.md5().hashBytes(bytes).asBytes());
+    return new ChecksummedTestContent(bytes, crc32c, md5Base64);
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectChecksumSupportTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectChecksumSupportTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.it;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+import com.google.cloud.WriteChannel;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketFixture;
+import com.google.cloud.storage.DataGenerator;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobWriteOption;
+import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.StorageFixture;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.ByteStreams;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public final class ITObjectChecksumSupportTest {
+
+  @ClassRule(order = 1)
+  public static final StorageFixture storageFixtureHttp = StorageFixture.defaultHttp();
+
+  @ClassRule(order = 1)
+  public static final StorageFixture storageFixtureGrpc = StorageFixture.defaultGrpc();
+
+  @ClassRule(order = 2)
+  public static final BucketFixture bucketFixtureHttp =
+      BucketFixture.newBuilder()
+          .setBucketNameFmtString("java-storage-http-%s")
+          .setHandle(storageFixtureHttp::getInstance)
+          .build();
+
+  @ClassRule(order = 2)
+  public static final BucketFixture bucketFixtureGrpc =
+      BucketFixture.newBuilder()
+          .setBucketNameFmtString("java-storage-grpc-%s")
+          .setHandle(storageFixtureHttp::getInstance)
+          .build();
+
+  @Rule public final TestName testName = new TestName();
+
+  private final String clientName;
+  private final Storage storage;
+  private final BucketFixture bucketFixture;
+  private final ChecksummedTestContent content;
+
+  public ITObjectChecksumSupportTest(
+      String clientName,
+      StorageFixture storageFixture,
+      BucketFixture bucketFixture,
+      ChecksummedTestContent content) {
+    this.clientName = clientName;
+    this.storage = storageFixture.getInstance();
+    this.bucketFixture = bucketFixture;
+    this.content = content;
+  }
+
+  @Parameters(name = "{0}")
+  public static Iterable<Object[]> parameters() {
+    ImmutableList<Object[]> clientsAndBuckets =
+        ImmutableList.of(
+            new Object[] {"JSON/Prod", storageFixtureHttp, bucketFixtureHttp},
+            new Object[] {"GRPC/Prod", storageFixtureGrpc, bucketFixtureGrpc});
+
+    DataGenerator gen = DataGenerator.base64Characters();
+    int _2MiB = 2 * 1024 * 1024;
+    int _24MiB = 24 * 1024 * 1024;
+    ImmutableList<ChecksummedTestContent> contents =
+        ImmutableList.of(
+            // small, single message single stream when resumable
+            ChecksummedTestContent.of(gen.genBytes(15)),
+            // med, multiple messages single stream when resumable
+            ChecksummedTestContent.of(gen.genBytes(_2MiB + 3)),
+            // large, multiple messages and multiple streams when resumable
+            ChecksummedTestContent.of(gen.genBytes(_24MiB + 5)));
+
+    ImmutableList.Builder<Object[]> cross = ImmutableList.builder();
+    for (Object[] cab : clientsAndBuckets) {
+      for (ChecksummedTestContent content : contents) {
+        cross.add(new Object[] {cab[0] + "/" + content.getBytes().length, cab[1], cab[2], content});
+      }
+    }
+    return cross.build();
+  }
+
+  @Test
+  public void testCrc32cValidated_createFrom_expectFailure() {
+    String blobName = testName.getMethodName();
+    BlobId blobId = BlobId.of(bucketFixture.getBucketInfo().getName(), blobName);
+    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setCrc32c(content.getCrc32cBase64()).build();
+
+    byte[] bytes = content.concat('x');
+    StorageException expected =
+        assertThrows(
+            StorageException.class,
+            () ->
+                storage.createFrom(
+                    blobInfo,
+                    new ByteArrayInputStream(bytes),
+                    BlobWriteOption.doesNotExist(),
+                    BlobWriteOption.crc32cMatch()));
+    assertThat(expected.getCode()).isEqualTo(400);
+  }
+
+  @Test
+  public void testCrc32cValidated_createFrom_expectSuccess() throws IOException {
+    String blobName = testName.getMethodName();
+    BlobId blobId = BlobId.of(bucketFixture.getBucketInfo().getName(), blobName);
+    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setCrc32c(content.getCrc32cBase64()).build();
+
+    byte[] bytes = content.getBytes();
+    Blob blob =
+        storage.createFrom(
+            blobInfo,
+            new ByteArrayInputStream(bytes),
+            BlobWriteOption.doesNotExist(),
+            BlobWriteOption.crc32cMatch());
+    assertThat(blob.getCrc32c()).isEqualTo(content.getCrc32cBase64());
+  }
+
+  @Test
+  public void testCrc32cValidated_writer_expectFailure() {
+    String blobName = testName.getMethodName();
+    BlobId blobId = BlobId.of(bucketFixture.getBucketInfo().getName(), blobName);
+    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setCrc32c(content.getCrc32cBase64()).build();
+
+    byte[] bytes = content.concat('x');
+    StorageException expected =
+        assertThrows(
+            StorageException.class,
+            () -> {
+              try (ReadableByteChannel src = Channels.newChannel(new ByteArrayInputStream(bytes));
+                  WriteChannel dst =
+                      storage.writer(
+                          blobInfo,
+                          BlobWriteOption.doesNotExist(),
+                          BlobWriteOption.crc32cMatch())) {
+                ByteStreams.copy(src, dst);
+              }
+            });
+    assertThat(expected.getCode()).isEqualTo(400);
+  }
+
+  @Test
+  public void testCrc32cValidated_writer_expectSuccess() throws IOException {
+    String blobName = testName.getMethodName();
+    BlobId blobId = BlobId.of(bucketFixture.getBucketInfo().getName(), blobName);
+    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setCrc32c(content.getCrc32cBase64()).build();
+
+    byte[] bytes = content.getBytes();
+
+    try (ReadableByteChannel src = Channels.newChannel(new ByteArrayInputStream(bytes));
+        WriteChannel dst =
+            storage.writer(
+                blobInfo, BlobWriteOption.doesNotExist(), BlobWriteOption.crc32cMatch())) {
+      ByteStreams.copy(src, dst);
+    }
+
+    Blob blob = storage.get(blobId);
+    assertThat(blob.getCrc32c()).isEqualTo(content.getCrc32cBase64());
+  }
+
+  @Test
+  @SuppressWarnings({"deprecation"})
+  public void testCreateBlobMd5Fail() {
+    // Error Handling for GRPC not complete
+    // b/247621346
+    assumeTrue(clientName.startsWith("JSON"));
+
+    String blobName = testName.getMethodName();
+    BlobInfo blob =
+        BlobInfo.newBuilder(bucketFixture.getBucketInfo(), blobName)
+            .setMd5("O1R4G1HJSDUISJjoIYmVhQ==")
+            .build();
+    ByteArrayInputStream stream = content.bytesAsInputStream();
+    try {
+      storage.create(blob, stream, Storage.BlobWriteOption.md5Match());
+      fail("StorageException was expected");
+    } catch (StorageException ex) {
+      // expected
+    }
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
@@ -56,15 +55,12 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
-import com.google.common.io.ByteStreams;
 import com.google.common.primitives.Ints;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
-import java.nio.channels.ReadableByteChannel;
 import java.security.Key;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -306,28 +302,6 @@ public class ITObjectTest {
     try {
       storage.create(
           wrongGenerationBlob, BLOB_BYTE_CONTENT, Storage.BlobTargetOption.generationMatch());
-      fail("StorageException was expected");
-    } catch (StorageException ex) {
-      // expected
-    }
-  }
-
-  @Test
-  @SuppressWarnings({"unchecked", "deprecation"})
-  public void testCreateBlobMd5Fail() {
-    // Error Handling for GRPC not complete
-    // b/247621346
-    assumeTrue(clientName.startsWith("JSON"));
-
-    String blobName = "test-create-blob-md5-fail";
-    BlobInfo blob =
-        BlobInfo.newBuilder(bucketFixture.getBucketInfo(), blobName)
-            .setContentType(CONTENT_TYPE)
-            .setMd5("O1R4G1HJSDUISJjoIYmVhQ==")
-            .build();
-    ByteArrayInputStream stream = new ByteArrayInputStream(BLOB_STRING_CONTENT.getBytes(UTF_8));
-    try {
-      storage.create(blob, stream, Storage.BlobWriteOption.md5Match());
       fail("StorageException was expected");
     } catch (StorageException ex) {
       // expected
@@ -1512,83 +1486,6 @@ public class ITObjectTest {
     }
     byte[] readBytes = blob.getContent(Blob.BlobSourceOption.decryptionKey(KEY));
     assertArrayEquals(BLOB_BYTE_CONTENT, readBytes);
-  }
-
-  @Test
-  public void testCrc32cValidated_createFrom_expectFailure() {
-    String blobName = testName.getMethodName();
-    BlobId blobId = BlobId.of(bucketFixture.getBucketInfo().getName(), blobName);
-    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setCrc32c(BLOB_STRING_CONTENT_CRC32C).build();
-
-    byte[] bytes = (BLOB_STRING_CONTENT + "x").getBytes(UTF_8);
-    StorageException expected =
-        assertThrows(
-            StorageException.class,
-            () ->
-                storage.createFrom(
-                    blobInfo,
-                    new ByteArrayInputStream(bytes),
-                    BlobWriteOption.doesNotExist(),
-                    BlobWriteOption.crc32cMatch()));
-    assertThat(expected.getCode()).isEqualTo(400);
-  }
-
-  @Test
-  public void testCrc32cValidated_createFrom_expectSuccess() throws IOException {
-    String blobName = testName.getMethodName();
-    BlobId blobId = BlobId.of(bucketFixture.getBucketInfo().getName(), blobName);
-    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setCrc32c(BLOB_STRING_CONTENT_CRC32C).build();
-
-    byte[] bytes = BLOB_STRING_CONTENT.getBytes(UTF_8);
-    Blob blob =
-        storage.createFrom(
-            blobInfo,
-            new ByteArrayInputStream(bytes),
-            BlobWriteOption.doesNotExist(),
-            BlobWriteOption.crc32cMatch());
-    assertThat(blob.getCrc32c()).isEqualTo(BLOB_STRING_CONTENT_CRC32C);
-  }
-
-  @Test
-  public void testCrc32cValidated_writer_expectFailure() {
-    String blobName = testName.getMethodName();
-    BlobId blobId = BlobId.of(bucketFixture.getBucketInfo().getName(), blobName);
-    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setCrc32c(BLOB_STRING_CONTENT_CRC32C).build();
-
-    byte[] bytes = (BLOB_STRING_CONTENT + "x").getBytes(UTF_8);
-    StorageException expected =
-        assertThrows(
-            StorageException.class,
-            () -> {
-              try (ReadableByteChannel src = Channels.newChannel(new ByteArrayInputStream(bytes));
-                  WriteChannel dst =
-                      storage.writer(
-                          blobInfo,
-                          BlobWriteOption.doesNotExist(),
-                          BlobWriteOption.crc32cMatch())) {
-                ByteStreams.copy(src, dst);
-              }
-            });
-    assertThat(expected.getCode()).isEqualTo(400);
-  }
-
-  @Test
-  public void testCrc32cValidated_writer_expectSuccess() throws IOException {
-    String blobName = testName.getMethodName();
-    BlobId blobId = BlobId.of(bucketFixture.getBucketInfo().getName(), blobName);
-    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setCrc32c(BLOB_STRING_CONTENT_CRC32C).build();
-
-    byte[] bytes = BLOB_STRING_CONTENT.getBytes(UTF_8);
-
-    try (ReadableByteChannel src = Channels.newChannel(new ByteArrayInputStream(bytes));
-        WriteChannel dst =
-            storage.writer(
-                blobInfo, BlobWriteOption.doesNotExist(), BlobWriteOption.crc32cMatch())) {
-      ByteStreams.copy(src, dst);
-    }
-
-    Blob blob = storage.get(blobId);
-    assertThat(blob.getCrc32c()).isEqualTo(BLOB_STRING_CONTENT_CRC32C);
   }
 
   private Blob createBlob(String method, BlobInfo blobInfo, boolean detectType) throws IOException {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITOptionRegressionTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITOptionRegressionTest.java
@@ -94,8 +94,9 @@ public final class ITOptionRegressionTest {
           .setHandle(storageFixture::getInstance)
           .build();
 
-  private static final Content CONTENT = Content.of("Hello, World!");
-  private static final Content CONTENT2 = Content.of("Goodbye, World!");
+  private static final ChecksummedTestContent CONTENT = ChecksummedTestContent.of("Hello, World!");
+  private static final ChecksummedTestContent CONTENT2 =
+      ChecksummedTestContent.of("Goodbye, World!");
   private static final CSEKSupport csekSupport = CSEKSupport.create();
   private static final ServiceAccount SERVICE_ACCOUNT = ServiceAccount.of("x@y.z");
 
@@ -121,11 +122,11 @@ public final class ITOptionRegressionTest {
             .build()
             .getService();
     b = s.get(bucketFixture.getBucketInfo().getName());
-    o = s.create(BlobInfo.newBuilder(b, "ddeeffaauulltt").build(), CONTENT.bytes);
+    o = s.create(BlobInfo.newBuilder(b, "ddeeffaauulltt").build(), CONTENT.getBytes());
     e =
         s.create(
             BlobInfo.newBuilder(b, "encrypteddetpyrcne").build(),
-            CONTENT.bytes,
+            CONTENT.getBytes(),
             Storage.BlobTargetOption.encryptionKey(csekSupport.getTuple().getKey()));
   }
 
@@ -138,7 +139,7 @@ public final class ITOptionRegressionTest {
   public void storage_BucketTargetOption_predefinedAcl_PredefinedAcl() {
     s.create(
         BlobInfo.newBuilder(b, objectName()).build(),
-        CONTENT.bytes,
+        CONTENT.getBytes(),
         Storage.BlobTargetOption.predefinedAcl(PredefinedAcl.PUBLIC_READ));
     requestAuditing.assertQueryParam("predefinedAcl", "publicRead");
   }
@@ -357,7 +358,7 @@ public final class ITOptionRegressionTest {
   public void storage_BlobTargetOption_predefinedAcl_PredefinedAcl() {
     s.create(
         BlobInfo.newBuilder(b, objectName()).build(),
-        CONTENT.bytes,
+        CONTENT.getBytes(),
         Storage.BlobTargetOption.predefinedAcl(PredefinedAcl.PUBLIC_READ));
     requestAuditing.assertQueryParam("predefinedAcl", "publicRead");
   }
@@ -366,7 +367,7 @@ public final class ITOptionRegressionTest {
   public void storage_BlobTargetOption_doesNotExist_() {
     s.create(
         BlobInfo.newBuilder(b, objectName()).build(),
-        CONTENT.bytes,
+        CONTENT.getBytes(),
         Storage.BlobTargetOption.doesNotExist());
     requestAuditing.assertQueryParam("ifGenerationMatch", "0");
   }
@@ -384,9 +385,9 @@ public final class ITOptionRegressionTest {
   public void storage_BlobTargetOption_generationNotMatch_() {
     Blob blob1 = s.create(BlobInfo.newBuilder(b, objectName()).build());
     Blob updated = blob1.toBuilder().setMetadata(ImmutableMap.of("foo", "bar")).build();
-    s.create(updated, CONTENT2.bytes);
+    s.create(updated, CONTENT2.getBytes());
     requestAuditing.clear();
-    s.create(updated, CONTENT.bytes, Storage.BlobTargetOption.generationNotMatch());
+    s.create(updated, CONTENT.getBytes(), Storage.BlobTargetOption.generationNotMatch());
     requestAuditing.assertQueryParam("ifGenerationNotMatch", blob1.getGeneration().toString());
   }
 
@@ -415,7 +416,7 @@ public final class ITOptionRegressionTest {
   public void storage_BlobTargetOption_disableGzipContent_() {
     s.create(
         BlobInfo.newBuilder(b, objectName()).build(),
-        CONTENT.bytes,
+        CONTENT.getBytes(),
         Storage.BlobTargetOption.disableGzipContent());
     requestAuditing.assertNoContentEncoding();
   }
@@ -424,7 +425,7 @@ public final class ITOptionRegressionTest {
   public void storage_BlobTargetOption_detectContentType_() {
     s.create(
         BlobInfo.newBuilder(b, objectName() + ".txt").build(),
-        CONTENT.bytes,
+        CONTENT.getBytes(),
         Storage.BlobTargetOption.detectContentType());
     requestAuditing.assertMultipartContentJsonAndText();
   }
@@ -433,7 +434,7 @@ public final class ITOptionRegressionTest {
   public void storage_BlobTargetOption_encryptionKey_Key() {
     s.create(
         BlobInfo.newBuilder(b, objectName()).build(),
-        CONTENT.bytes,
+        CONTENT.getBytes(),
         Storage.BlobTargetOption.encryptionKey(csekSupport.getKey()));
     requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
   }
@@ -442,7 +443,7 @@ public final class ITOptionRegressionTest {
   public void storage_BlobTargetOption_userProject_String() {
     s.create(
         BlobInfo.newBuilder(b, objectName()).build(),
-        CONTENT.bytes,
+        CONTENT.getBytes(),
         Storage.BlobTargetOption.userProject("proj"));
     requestAuditing.assertQueryParam("userProject", "proj");
   }
@@ -451,7 +452,7 @@ public final class ITOptionRegressionTest {
   public void storage_BlobTargetOption_encryptionKey_String() {
     s.create(
         BlobInfo.newBuilder(b, objectName()).build(),
-        CONTENT.bytes,
+        CONTENT.getBytes(),
         Storage.BlobTargetOption.encryptionKey(csekSupport.getTuple().getKey()));
     requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
   }
@@ -460,7 +461,7 @@ public final class ITOptionRegressionTest {
   public void storage_BlobTargetOption_kmsKeyName_String() {
     s.create(
         BlobInfo.newBuilder(b, objectName()).build(),
-        CONTENT.bytes,
+        CONTENT.getBytes(),
         Storage.BlobTargetOption.kmsKeyName("kms-key"));
     requestAuditing.assertQueryParam("kmsKeyName", "kms-key");
   }
@@ -469,7 +470,7 @@ public final class ITOptionRegressionTest {
   public void storage_BlobWriteOption_predefinedAcl_PredefinedAcl() {
     s.create(
         BlobInfo.newBuilder(b, objectName()).build(),
-        CONTENT.inputStream(),
+        CONTENT.bytesAsInputStream(),
         Storage.BlobWriteOption.predefinedAcl(PredefinedAcl.PUBLIC_READ));
     requestAuditing.assertQueryParam("predefinedAcl", "publicRead");
   }
@@ -478,7 +479,7 @@ public final class ITOptionRegressionTest {
   public void storage_BlobWriteOption_doesNotExist_() {
     s.create(
         BlobInfo.newBuilder(b, objectName()).build(),
-        CONTENT.inputStream(),
+        CONTENT.bytesAsInputStream(),
         Storage.BlobWriteOption.doesNotExist());
     requestAuditing.assertQueryParam("ifGenerationMatch", "0");
   }
@@ -493,7 +494,7 @@ public final class ITOptionRegressionTest {
             .setMd5(null)
             .setCrc32c(null)
             .build();
-    s.create(updated, CONTENT2.inputStream(), Storage.BlobWriteOption.generationMatch());
+    s.create(updated, CONTENT2.bytesAsInputStream(), Storage.BlobWriteOption.generationMatch());
     requestAuditing.assertQueryParam("ifGenerationMatch", blob.getGeneration().toString());
   }
 
@@ -507,9 +508,9 @@ public final class ITOptionRegressionTest {
             .setMd5(null)
             .setCrc32c(null)
             .build();
-    s.create(updated, CONTENT2.bytes);
+    s.create(updated, CONTENT2.getBytes());
     requestAuditing.clear();
-    s.create(updated, CONTENT.inputStream(), Storage.BlobWriteOption.generationNotMatch());
+    s.create(updated, CONTENT.bytesAsInputStream(), Storage.BlobWriteOption.generationNotMatch());
     requestAuditing.assertQueryParam("ifGenerationNotMatch", blob1.getGeneration().toString());
   }
 
@@ -523,7 +524,7 @@ public final class ITOptionRegressionTest {
             .setMd5(null)
             .setCrc32c(null)
             .build();
-    s.create(updated, CONTENT2.inputStream(), Storage.BlobWriteOption.metagenerationMatch());
+    s.create(updated, CONTENT2.bytesAsInputStream(), Storage.BlobWriteOption.metagenerationMatch());
     requestAuditing.assertQueryParam("ifMetagenerationMatch", blob.getMetageneration().toString());
   }
 
@@ -541,30 +542,31 @@ public final class ITOptionRegressionTest {
     requestAuditing.clear();
     s.create(
         updated.toBuilder().setStorageClass(StorageClass.COLDLINE).build(),
-        CONTENT2.inputStream(),
+        CONTENT2.bytesAsInputStream(),
         Storage.BlobWriteOption.metagenerationNotMatch());
     requestAuditing.assertQueryParam("ifMetagenerationNotMatch", "1");
   }
 
   @Test
   public void storage_BlobWriteOption_md5Match_() {
-    BlobInfo info = BlobInfo.newBuilder(b, objectName()).setMd5(CONTENT.md5Base64).build();
-    s.create(info, CONTENT.inputStream(), Storage.BlobWriteOption.md5Match());
-    requestAuditing.assertMultipartJsonField("md5Hash", CONTENT.md5Base64);
+    BlobInfo info = BlobInfo.newBuilder(b, objectName()).setMd5(CONTENT.getMd5Base64()).build();
+    s.create(info, CONTENT.bytesAsInputStream(), Storage.BlobWriteOption.md5Match());
+    requestAuditing.assertMultipartJsonField("md5Hash", CONTENT.getMd5Base64());
   }
 
   @Test
   public void storage_BlobWriteOption_crc32cMatch_() {
-    BlobInfo info = BlobInfo.newBuilder(b, objectName()).setCrc32c(CONTENT.crc32cBase64()).build();
-    s.create(info, CONTENT.inputStream(), Storage.BlobWriteOption.crc32cMatch());
-    requestAuditing.assertMultipartJsonField("crc32c", CONTENT.crc32cBase64());
+    BlobInfo info =
+        BlobInfo.newBuilder(b, objectName()).setCrc32c(CONTENT.getCrc32cBase64()).build();
+    s.create(info, CONTENT.bytesAsInputStream(), Storage.BlobWriteOption.crc32cMatch());
+    requestAuditing.assertMultipartJsonField("crc32c", CONTENT.getCrc32cBase64());
   }
 
   @Test
   public void storage_BlobWriteOption_encryptionKey_Key() {
     s.create(
         BlobInfo.newBuilder(b, objectName()).build(),
-        CONTENT.inputStream(),
+        CONTENT.bytesAsInputStream(),
         Storage.BlobWriteOption.encryptionKey(csekSupport.getKey()));
     requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
   }
@@ -573,7 +575,7 @@ public final class ITOptionRegressionTest {
   public void storage_BlobWriteOption_encryptionKey_String() {
     s.create(
         BlobInfo.newBuilder(b, objectName()).build(),
-        CONTENT.inputStream(),
+        CONTENT.bytesAsInputStream(),
         Storage.BlobWriteOption.encryptionKey(csekSupport.getTuple().getKey()));
     requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
   }
@@ -582,7 +584,7 @@ public final class ITOptionRegressionTest {
   public void storage_BlobWriteOption_kmsKeyName_String() {
     s.create(
         BlobInfo.newBuilder(b, objectName()).build(),
-        CONTENT.inputStream(),
+        CONTENT.bytesAsInputStream(),
         Storage.BlobWriteOption.kmsKeyName("kms-key"));
     requestAuditing.assertQueryParam("kmsKeyName", "kms-key");
   }
@@ -591,7 +593,7 @@ public final class ITOptionRegressionTest {
   public void storage_BlobWriteOption_userProject_String() {
     s.create(
         BlobInfo.newBuilder(b, objectName()).build(),
-        CONTENT.inputStream(),
+        CONTENT.bytesAsInputStream(),
         Storage.BlobWriteOption.userProject("proj"));
     requestAuditing.assertQueryParam("userProject", "proj");
   }
@@ -600,7 +602,7 @@ public final class ITOptionRegressionTest {
   public void storage_BlobWriteOption_disableGzipContent_() {
     s.create(
         BlobInfo.newBuilder(b, objectName()).build(),
-        CONTENT.inputStream(),
+        CONTENT.bytesAsInputStream(),
         Storage.BlobWriteOption.disableGzipContent());
     requestAuditing.assertNoContentEncoding();
   }
@@ -609,7 +611,7 @@ public final class ITOptionRegressionTest {
   public void storage_BlobWriteOption_detectContentType_() {
     s.create(
         BlobInfo.newBuilder(b, objectName() + ".txt").build(),
-        CONTENT.inputStream(),
+        CONTENT.bytesAsInputStream(),
         Storage.BlobWriteOption.detectContentType());
     requestAuditing.assertMultipartContentJsonAndText();
   }
@@ -958,43 +960,46 @@ public final class ITOptionRegressionTest {
   @Test
   public void bucket_BlobTargetOption_predefinedAcl_PredefinedAcl() {
     b.create(
-        objectName(), CONTENT.bytes, BlobTargetOption.predefinedAcl(PredefinedAcl.PUBLIC_READ));
+        objectName(),
+        CONTENT.getBytes(),
+        BlobTargetOption.predefinedAcl(PredefinedAcl.PUBLIC_READ));
     requestAuditing.assertQueryParam("predefinedAcl", "publicRead");
   }
 
   @Test
   public void bucket_BlobTargetOption_doesNotExist_() {
-    b.create(objectName(), CONTENT.bytes, BlobTargetOption.doesNotExist());
+    b.create(objectName(), CONTENT.getBytes(), BlobTargetOption.doesNotExist());
     requestAuditing.assertQueryParam("ifGenerationMatch", "0");
   }
 
   @Test
   public void bucket_BlobTargetOption_generationMatch_long() {
-    b.create(objectName(), CONTENT.bytes, BlobTargetOption.generationMatch(0));
+    b.create(objectName(), CONTENT.getBytes(), BlobTargetOption.generationMatch(0));
     requestAuditing.assertQueryParam("ifGenerationMatch", "0");
   }
 
   @Test
   public void bucket_BlobTargetOption_generationNotMatch_long() {
-    b.create(objectName(), CONTENT.bytes, BlobTargetOption.generationNotMatch(1L));
+    b.create(objectName(), CONTENT.getBytes(), BlobTargetOption.generationNotMatch(1L));
     requestAuditing.assertQueryParam("ifGenerationNotMatch", "1");
   }
 
   @Test
   public void bucket_BlobTargetOption_metagenerationMatch_long() {
-    b.create(objectName(), CONTENT.bytes, BlobTargetOption.metagenerationMatch(0));
+    b.create(objectName(), CONTENT.getBytes(), BlobTargetOption.metagenerationMatch(0));
     requestAuditing.assertQueryParam("ifMetagenerationMatch", "0");
   }
 
   @Test
   public void bucket_BlobTargetOption_metagenerationNotMatch_long() {
-    b.create(objectName(), CONTENT.bytes, BlobTargetOption.metagenerationNotMatch(1L));
+    b.create(objectName(), CONTENT.getBytes(), BlobTargetOption.metagenerationNotMatch(1L));
     requestAuditing.assertQueryParam("ifMetagenerationNotMatch", "1");
   }
 
   @Test
   public void bucket_BlobTargetOption_encryptionKey_Key() {
-    b.create(objectName(), CONTENT.bytes, BlobTargetOption.encryptionKey(csekSupport.getKey()));
+    b.create(
+        objectName(), CONTENT.getBytes(), BlobTargetOption.encryptionKey(csekSupport.getKey()));
     requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
   }
 
@@ -1002,20 +1007,20 @@ public final class ITOptionRegressionTest {
   public void bucket_BlobTargetOption_encryptionKey_String() {
     b.create(
         objectName(),
-        CONTENT.bytes,
+        CONTENT.getBytes(),
         BlobTargetOption.encryptionKey(csekSupport.getTuple().getKey()));
     requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
   }
 
   @Test
   public void bucket_BlobTargetOption_kmsKeyName_String() {
-    b.create(objectName(), CONTENT.bytes, BlobTargetOption.kmsKeyName("kms-key"));
+    b.create(objectName(), CONTENT.getBytes(), BlobTargetOption.kmsKeyName("kms-key"));
     requestAuditing.assertQueryParam("kmsKeyName", "kms-key");
   }
 
   @Test
   public void bucket_BlobTargetOption_userProject_String() {
-    b.create(objectName(), CONTENT.bytes, BlobTargetOption.userProject("proj"));
+    b.create(objectName(), CONTENT.getBytes(), BlobTargetOption.userProject("proj"));
     requestAuditing.assertQueryParam("userProject", "proj");
   }
 
@@ -1023,58 +1028,66 @@ public final class ITOptionRegressionTest {
   public void bucket_BlobWriteOption_predefinedAcl_PredefinedAcl() {
     b.create(
         objectName(),
-        CONTENT.inputStream(),
+        CONTENT.bytesAsInputStream(),
         BlobWriteOption.predefinedAcl(PredefinedAcl.PUBLIC_READ));
     requestAuditing.assertQueryParam("predefinedAcl", "publicRead");
   }
 
   @Test
   public void bucket_BlobWriteOption_doesNotExist_() {
-    b.create(objectName(), CONTENT.inputStream(), BlobWriteOption.doesNotExist());
+    b.create(objectName(), CONTENT.bytesAsInputStream(), BlobWriteOption.doesNotExist());
     requestAuditing.assertQueryParam("ifGenerationMatch", "0");
   }
 
   @Test
   public void bucket_BlobWriteOption_generationMatch_long() {
-    b.create(objectName(), CONTENT.inputStream(), BlobWriteOption.generationMatch(0));
+    b.create(objectName(), CONTENT.bytesAsInputStream(), BlobWriteOption.generationMatch(0));
     requestAuditing.assertQueryParam("ifGenerationMatch", "0");
   }
 
   @Test
   public void bucket_BlobWriteOption_generationNotMatch_long() {
-    b.create(objectName(), CONTENT.inputStream(), BlobWriteOption.generationNotMatch(1L));
+    b.create(objectName(), CONTENT.bytesAsInputStream(), BlobWriteOption.generationNotMatch(1L));
     requestAuditing.assertQueryParam("ifGenerationNotMatch", "1");
   }
 
   @Test
   public void bucket_BlobWriteOption_metagenerationMatch_long() {
-    b.create(objectName(), CONTENT.inputStream(), BlobWriteOption.metagenerationMatch(0));
+    b.create(objectName(), CONTENT.bytesAsInputStream(), BlobWriteOption.metagenerationMatch(0));
     requestAuditing.assertQueryParam("ifMetagenerationMatch", "0");
   }
 
   @Test
   public void bucket_BlobWriteOption_metagenerationNotMatch_long() {
-    b.create(objectName(), CONTENT.inputStream(), BlobWriteOption.metagenerationNotMatch(1L));
+    b.create(
+        objectName(), CONTENT.bytesAsInputStream(), BlobWriteOption.metagenerationNotMatch(1L));
     requestAuditing.assertQueryParam("ifMetagenerationNotMatch", "1");
   }
 
   @Test
   public void bucket_BlobWriteOption_md5Match_String() {
-    b.create(objectName(), CONTENT.inputStream(), BlobWriteOption.md5Match(CONTENT.md5Base64));
-    requestAuditing.assertMultipartJsonField("md5Hash", CONTENT.md5Base64);
+    b.create(
+        objectName(),
+        CONTENT.bytesAsInputStream(),
+        BlobWriteOption.md5Match(CONTENT.getMd5Base64()));
+    requestAuditing.assertMultipartJsonField("md5Hash", CONTENT.getMd5Base64());
   }
 
   @Test
   public void bucket_BlobWriteOption_crc32cMatch_String() {
     b.create(
-        objectName(), CONTENT.inputStream(), BlobWriteOption.crc32cMatch(CONTENT.crc32cBase64()));
-    requestAuditing.assertMultipartJsonField("crc32c", CONTENT.crc32cBase64());
+        objectName(),
+        CONTENT.bytesAsInputStream(),
+        BlobWriteOption.crc32cMatch(CONTENT.getCrc32cBase64()));
+    requestAuditing.assertMultipartJsonField("crc32c", CONTENT.getCrc32cBase64());
   }
 
   @Test
   public void bucket_BlobWriteOption_encryptionKey_Key() {
     b.create(
-        objectName(), CONTENT.inputStream(), BlobWriteOption.encryptionKey(csekSupport.getKey()));
+        objectName(),
+        CONTENT.bytesAsInputStream(),
+        BlobWriteOption.encryptionKey(csekSupport.getKey()));
     requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
   }
 
@@ -1082,14 +1095,14 @@ public final class ITOptionRegressionTest {
   public void bucket_BlobWriteOption_encryptionKey_String() {
     b.create(
         objectName(),
-        CONTENT.inputStream(),
+        CONTENT.bytesAsInputStream(),
         BlobWriteOption.encryptionKey(csekSupport.getTuple().getKey()));
     requestAuditing.assertEncryptionKeyHeaders(csekSupport.getTuple());
   }
 
   @Test
   public void bucket_BlobWriteOption_userProject_String() {
-    b.create(objectName(), CONTENT.inputStream(), BlobWriteOption.userProject("proj"));
+    b.create(objectName(), CONTENT.bytesAsInputStream(), BlobWriteOption.userProject("proj"));
     requestAuditing.assertQueryParam("userProject", "proj");
   }
 
@@ -1166,7 +1179,7 @@ public final class ITOptionRegressionTest {
 
   @Test
   public void storage_ComposeRequest() {
-    Blob obj = b.create(objectName(), CONTENT.bytes, BlobTargetOption.doesNotExist());
+    Blob obj = b.create(objectName(), CONTENT.getBytes(), BlobTargetOption.doesNotExist());
     requestAuditing.clear();
     Blob updated = obj.toBuilder().setMd5(null).setCrc32c(null).build();
     ComposeRequest request =


### PR DESCRIPTION
* Define 3 new content size scenarios to be validated
  1. data is small enough to fit within a single message of a single stream
  2. data requires multiple messages within a single stream
  3. data requires multiple messages within multiple streams
* Refactor checksum validation centric tests out of ITObjectTest into new ITObjectChecksumSupportTest
* Move ITOptionRegressionTest.Content to top level as ChecksummedTestContent and flush it out a bit more for cross usage by ITObjectChecksumSupportTest

