### PR TITLE
test: add tests to cover the MatchesPrefix and MatchesSuffix in LifeCyleRules

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BucketInfoTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BucketInfoTest.java
@@ -328,12 +328,29 @@ public class BucketInfoTest {
     Rule deleteLifecycleRule =
         new LifecycleRule(
                 LifecycleAction.newDeleteAction(),
-                LifecycleCondition.newBuilder().setAge(10).build())
+                LifecycleCondition.newBuilder().setAge(10).setMatchesPrefix(Arrays.asList("abc", "ijk")).setMatchesSuffix(Arrays.asList("xyz")).build())
             .toPb();
 
     assertEquals(
         LifecycleRule.DeleteLifecycleAction.TYPE, deleteLifecycleRule.getAction().getType());
     assertEquals(10, deleteLifecycleRule.getCondition().getAge().intValue());
+    assertEquals(2, deleteLifecycleRule.getCondition().getMatchesPrefix().size());
+    assertEquals("abc", (String)deleteLifecycleRule.getCondition().getMatchesPrefix().get(0));
+    assertEquals("ijk", (String)deleteLifecycleRule.getCondition().getMatchesPrefix().get(1));
+    assertEquals(1, deleteLifecycleRule.getCondition().getMatchesSuffix().size());
+    assertEquals("xyz", deleteLifecycleRule.getCondition().getMatchesSuffix().get(0));
+
+    LifecycleRule lcr = LifecycleRule.fromPb(deleteLifecycleRule);
+    assertEquals(
+            LifecycleRule.DeleteLifecycleAction.TYPE, lcr.getAction().getActionType());
+    assertEquals(10, lcr.getCondition().getAge().intValue());
+    assertEquals(2, git .getCondition().getMatchesPrefix().size());
+    assertEquals("abc", (String)lcr.getCondition().getMatchesPrefix().get(0));
+    assertEquals("ijk", (String)lcr.getCondition().getMatchesPrefix().get(1));
+    assertEquals(1, lcr.getCondition().getMatchesSuffix().size());
+    assertEquals("xyz", lcr.getCondition().getMatchesSuffix().get(0));
+
+
     assertTrue(
         LifecycleRule.fromPb(deleteLifecycleRule).getAction() instanceof DeleteLifecycleAction);
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BucketInfoTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BucketInfoTest.java
@@ -344,7 +344,7 @@ public class BucketInfoTest {
     assertEquals(
             LifecycleRule.DeleteLifecycleAction.TYPE, lcr.getAction().getActionType());
     assertEquals(10, lcr.getCondition().getAge().intValue());
-    assertEquals(2, git .getCondition().getMatchesPrefix().size());
+    assertEquals(2, lcr.getCondition().getMatchesPrefix().size());
     assertEquals("abc", (String)lcr.getCondition().getMatchesPrefix().get(0));
     assertEquals("ijk", (String)lcr.getCondition().getMatchesPrefix().get(1));
     assertEquals(1, lcr.getCondition().getMatchesSuffix().size());

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BucketInfoTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BucketInfoTest.java
@@ -328,28 +328,30 @@ public class BucketInfoTest {
     Rule deleteLifecycleRule =
         new LifecycleRule(
                 LifecycleAction.newDeleteAction(),
-                LifecycleCondition.newBuilder().setAge(10).setMatchesPrefix(Arrays.asList("abc", "ijk")).setMatchesSuffix(Arrays.asList("xyz")).build())
+                LifecycleCondition.newBuilder()
+                    .setAge(10)
+                    .setMatchesPrefix(Arrays.asList("abc", "ijk"))
+                    .setMatchesSuffix(Arrays.asList("xyz"))
+                    .build())
             .toPb();
 
     assertEquals(
         LifecycleRule.DeleteLifecycleAction.TYPE, deleteLifecycleRule.getAction().getType());
     assertEquals(10, deleteLifecycleRule.getCondition().getAge().intValue());
     assertEquals(2, deleteLifecycleRule.getCondition().getMatchesPrefix().size());
-    assertEquals("abc", (String)deleteLifecycleRule.getCondition().getMatchesPrefix().get(0));
-    assertEquals("ijk", (String)deleteLifecycleRule.getCondition().getMatchesPrefix().get(1));
+    assertEquals("abc", (String) deleteLifecycleRule.getCondition().getMatchesPrefix().get(0));
+    assertEquals("ijk", (String) deleteLifecycleRule.getCondition().getMatchesPrefix().get(1));
     assertEquals(1, deleteLifecycleRule.getCondition().getMatchesSuffix().size());
     assertEquals("xyz", deleteLifecycleRule.getCondition().getMatchesSuffix().get(0));
 
     LifecycleRule lcr = LifecycleRule.fromPb(deleteLifecycleRule);
-    assertEquals(
-            LifecycleRule.DeleteLifecycleAction.TYPE, lcr.getAction().getActionType());
+    assertEquals(LifecycleRule.DeleteLifecycleAction.TYPE, lcr.getAction().getActionType());
     assertEquals(10, lcr.getCondition().getAge().intValue());
     assertEquals(2, lcr.getCondition().getMatchesPrefix().size());
-    assertEquals("abc", (String)lcr.getCondition().getMatchesPrefix().get(0));
-    assertEquals("ijk", (String)lcr.getCondition().getMatchesPrefix().get(1));
+    assertEquals("abc", (String) lcr.getCondition().getMatchesPrefix().get(0));
+    assertEquals("ijk", (String) lcr.getCondition().getMatchesPrefix().get(1));
     assertEquals(1, lcr.getCondition().getMatchesSuffix().size());
     assertEquals("xyz", lcr.getCondition().getMatchesSuffix().get(0));
-
 
     assertTrue(
         LifecycleRule.fromPb(deleteLifecycleRule).getAction() instanceof DeleteLifecycleAction);


### PR DESCRIPTION
Follow up to https://github.com/googleapis/java-storage/pull/1717