### PR TITLE
fix: properly implement GrpcBlobReadChannel#isOpen

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITReadMaskTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITReadMaskTest.java
@@ -183,7 +183,8 @@ public final class ITReadMaskTest {
                   BucketField.RPO,
                   (jsonT, grpcT) -> {
                     assertThat(jsonT.getRpo()).isEqualTo(Rpo.DEFAULT);
-                    assertThat(grpcT.getRpo()).isNull();
+                    // TODO: cleanup allowed null value in mid nov
+                    assertThat(grpcT.getRpo()).isAnyOf(Rpo.DEFAULT, null);
                   }),
               new Args<>(
                   BucketField.SELF_LINK,


### PR DESCRIPTION
Previously a subbed method was still being used, now it will check the lazy channel.

Removed duplicate memoization of channel factory

* chore: update assertion for possible RPO values via gRPC