### PR TITLE
fix: update GrpcStorageImpl#get(BlobId) to return null on 404

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -417,7 +417,13 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
     return Retrying.run(
         getOptions(),
         retryAlgorithmManager.getFor(req),
-        () -> storageClient.getObjectCallable().call(req, grpcCallContext),
+        () -> {
+          try {
+            return storageClient.getObjectCallable().call(req, grpcCallContext);
+          } catch (NotFoundException ignore) {
+            return null;
+          }
+        },
         syntaxDecoders.blob.andThen(opts.clearBlobFields()));
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
@@ -19,6 +19,7 @@ package com.google.cloud.storage;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.BucketInfo.BuilderImpl;
+import com.google.common.collect.ImmutableList;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -72,5 +73,9 @@ public final class PackagePrivateMethodWorkarounds {
 
   public static <T1, T2> void ifNonNull(@Nullable T1 t, Function<T1, T2> map, Consumer<T2> c) {
     Utils.ifNonNull(t, map, c);
+  }
+
+  public static BlobInfo noAcl(BlobInfo bi) {
+    return bi.toBuilder().setOwner(null).setAcl(ImmutableList.of()).build();
   }
 }


### PR DESCRIPTION
Update GrpcStorageImpl#get(BlobId) to match the behavior of StorageImpl#get(BlobId) and return a null values when 404 is encountered.

