### PR TITLE
test: update StorageITRunner behavior along with @ClassRule

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/annotations/CrossRun.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/annotations/CrossRun.java
@@ -70,4 +70,18 @@ public @interface CrossRun {
 
     TransportCompatibility.Transport[] transports() default {};
   }
+
+  /**
+   * When using {@link CrossRun} a class scope will be created for each permutation, this can break
+   * expectations of scope/lifecycle for {@link org.junit.ClassRule}s. In an abundance of caution,
+   * we consider the use of a {@link org.junit.ClassRule} along with {@link CrossRun} an invalid
+   * class definition.
+   *
+   * <p>In order to allow the use of a {@link org.junit.ClassRule} along with the caveats mentioned
+   * above, a class can be annotated with {@link AllowClassRule} to suppress the error and proceed
+   * running the test class with the rule.
+   */
+  @Target({ElementType.TYPE})
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface AllowClassRule {}
 }


### PR DESCRIPTION
Update initialization logic of StorageITRunner to by default disallow use of @ClassRules. Add new annotation @CrossRun.AllowClassRule to allow use of a rule in the event it may be necessary.

Cleanup of TODO from https://github.com/googleapis/java-storage/pull/1785
