### PR TITLE
test: add new Generator#randomObjectName

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobReadChannelV2RetryTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobReadChannelV2RetryTest.java
@@ -36,6 +36,7 @@ import com.google.cloud.storage.it.runner.annotations.Backend;
 import com.google.cloud.storage.it.runner.annotations.Inject;
 import com.google.cloud.storage.it.runner.annotations.SingleBackend;
 import com.google.cloud.storage.it.runner.annotations.StorageFixture;
+import com.google.cloud.storage.it.runner.registry.Generator;
 import com.google.cloud.storage.it.runner.registry.TestBench;
 import com.google.cloud.storage.it.runner.registry.TestBench.RetryTestResource;
 import com.google.common.collect.ImmutableList;
@@ -44,9 +45,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 @RunWith(StorageITRunner.class)
@@ -55,8 +54,6 @@ public final class ITBlobReadChannelV2RetryTest {
 
   private static final int _512KiB = 512 * 1024;
 
-  @Rule public TestName testName = new TestName();
-
   @Inject public TestBench testBench;
 
   @Inject
@@ -64,6 +61,7 @@ public final class ITBlobReadChannelV2RetryTest {
   public Storage storage;
 
   @Inject public BucketInfo bucket;
+  @Inject public Generator generator;
 
   @Test
   public void generationIsLockedForRetries() throws Exception {
@@ -71,7 +69,7 @@ public final class ITBlobReadChannelV2RetryTest {
     StorageOptions baseOptions = storage.getOptions();
     byte[] bytes = DataGenerator.base64Characters().genBytes(_512KiB);
 
-    BlobId id = BlobId.of(bucket.getName(), testName.getMethodName());
+    BlobId id = BlobId.of(bucket.getName(), generator.randomObjectName());
     Blob gen1 =
         storage.create(BlobInfo.newBuilder(id).build(), bytes, BlobTargetOption.doesNotExist());
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobWriteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobWriteChannelTest.java
@@ -45,6 +45,7 @@ import com.google.cloud.storage.it.runner.StorageITRunner;
 import com.google.cloud.storage.it.runner.annotations.Backend;
 import com.google.cloud.storage.it.runner.annotations.Inject;
 import com.google.cloud.storage.it.runner.annotations.SingleBackend;
+import com.google.cloud.storage.it.runner.registry.Generator;
 import com.google.cloud.storage.it.runner.registry.TestBench;
 import com.google.cloud.storage.it.runner.registry.TestBench.RetryTestResource;
 import com.google.cloud.storage.spi.StorageRpcFactory;
@@ -62,7 +63,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.threeten.bp.Clock;
 import org.threeten.bp.Instant;
@@ -73,6 +73,7 @@ import org.threeten.bp.format.DateTimeFormatter;
 @RunWith(StorageITRunner.class)
 @SingleBackend(Backend.TEST_BENCH)
 public final class ITBlobWriteChannelTest {
+
   private static final Logger LOGGER = Logger.getLogger(ITBlobWriteChannelTest.class.getName());
   private static final String NOW_STRING;
   private static final String BLOB_STRING_CONTENT = "Hello Google Cloud Storage!";
@@ -86,7 +87,7 @@ public final class ITBlobWriteChannelTest {
 
   @Inject public TestBench testBench;
 
-  @Rule public final TestName testName = new TestName();
+  @Inject public Generator generator;
 
   @Rule public final DataGeneration dataGeneration = new DataGeneration(new Random(1234567890));
 
@@ -146,7 +147,7 @@ public final class ITBlobWriteChannelTest {
         DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.from(ZoneOffset.UTC));
     String nowString = formatter.format(now);
     BucketInfo bucketInfo = BucketInfo.of(dataGeneration.getBucketName());
-    String blobPath = String.format("%s/%s/blob", testName.getMethodName(), nowString);
+    String blobPath = String.format("%s/%s/blob", generator.randomObjectName(), nowString);
     BlobId blobId = BlobId.of(dataGeneration.getBucketName(), blobPath);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
     storage.create(bucketInfo);
@@ -161,7 +162,7 @@ public final class ITBlobWriteChannelTest {
   }
 
   private void doJsonUnexpectedEOFTest(int contentSize, int cappedByteCount) throws IOException {
-    String blobPath = String.format("%s/%s/blob", testName.getMethodName(), NOW_STRING);
+    String blobPath = String.format("%s/%s/blob", generator.randomObjectName(), NOW_STRING);
 
     BucketInfo bucketInfo = BucketInfo.of(dataGeneration.getBucketName());
     BlobInfo blobInfoGen0 = BlobInfo.newBuilder(bucketInfo, blobPath, 0L).build();
@@ -260,7 +261,7 @@ public final class ITBlobWriteChannelTest {
         DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.from(ZoneOffset.UTC));
     String nowString = formatter.format(now);
     BucketInfo bucketInfo = BucketInfo.of(dataGeneration.getBucketName());
-    String blobPath = String.format("%s/%s/blob", testName.getMethodName(), nowString);
+    String blobPath = String.format("%s/%s/blob", generator.randomObjectName(), nowString);
     BlobId blobId = BlobId.of(dataGeneration.getBucketName(), blobPath);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBucketLifecycleRulesTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBucketLifecycleRulesTest.java
@@ -33,9 +33,7 @@ import com.google.cloud.storage.it.runner.annotations.Inject;
 import com.google.cloud.storage.it.runner.registry.Generator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 @RunWith(StorageITRunner.class)
@@ -44,10 +42,9 @@ import org.junit.runner.RunWith;
     backends = {Backend.PROD})
 public final class ITBucketLifecycleRulesTest {
 
-  @Rule public final TestName testName = new TestName();
+  @Inject public Generator generator;
 
   @Inject public Storage storage;
-  @Inject public Generator generator;
 
   @Test
   public void deleteRule_addingALabelToABucketWithASingleDeleteRuleOnlyModifiesTheLabels()

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
@@ -52,9 +52,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 @RunWith(StorageITRunner.class)
@@ -69,8 +67,6 @@ public final class ITGrpcTest {
 
   @Inject public Generator generator;
 
-  @Rule public final TestName testName = new TestName();
-
   @Test
   public void testCreateBucket() {
     String bucketName = generator.randomBucketName();
@@ -81,7 +77,7 @@ public final class ITGrpcTest {
   @Test
   public void listBlobs() {
     byte[] content = "Hello, World!".getBytes(StandardCharsets.UTF_8);
-    String prefix = testName.getMethodName();
+    String prefix = generator.randomObjectName();
     List<Blob> blobs =
         IntStream.rangeClosed(1, 10)
             .mapToObj(i -> String.format("%s/%02d", prefix, i))
@@ -182,7 +178,7 @@ public final class ITGrpcTest {
 
   @Test
   public void objectWrite_storage_create() {
-    BlobInfo info = BlobInfo.newBuilder(bucketInfo, testName.getMethodName()).build();
+    BlobInfo info = BlobInfo.newBuilder(bucketInfo, generator.randomObjectName()).build();
     byte[] content = "Hello, World!".getBytes(StandardCharsets.UTF_8);
     Blob blob = storage.create(info, content, BlobTargetOption.doesNotExist());
     byte[] actual = blob.getContent();
@@ -191,7 +187,7 @@ public final class ITGrpcTest {
 
   @Test
   public void objectWrite_storage_create_stream() {
-    BlobInfo info = BlobInfo.newBuilder(bucketInfo, testName.getMethodName()).build();
+    BlobInfo info = BlobInfo.newBuilder(bucketInfo, generator.randomObjectName()).build();
     byte[] content = "Hello, World!".getBytes(StandardCharsets.UTF_8);
     Blob blob =
         storage.create(info, new ByteArrayInputStream(content), BlobWriteOption.doesNotExist());
@@ -201,7 +197,7 @@ public final class ITGrpcTest {
 
   @Test
   public void objectWrite_storage_writer() throws IOException {
-    BlobInfo info = BlobInfo.newBuilder(bucketInfo, testName.getMethodName()).build();
+    BlobInfo info = BlobInfo.newBuilder(bucketInfo, generator.randomObjectName()).build();
     byte[] content = "Hello, World!".getBytes(StandardCharsets.UTF_8);
     try (WriteChannel c = storage.writer(info, BlobWriteOption.doesNotExist())) {
       c.write(ByteBuffer.wrap(content));
@@ -216,10 +212,12 @@ public final class ITGrpcTest {
 
     byte[] expected = "Hello, World!".getBytes(StandardCharsets.UTF_8);
 
-    BlobInfo info = BlobInfo.newBuilder(bucketInfo, testName.getMethodName() + "copy/src").build();
+    BlobInfo info =
+        BlobInfo.newBuilder(bucketInfo, generator.randomObjectName() + "copy/src").build();
     Blob cpySrc = s.create(info, expected, BlobTargetOption.doesNotExist());
 
-    BlobInfo dst = BlobInfo.newBuilder(bucketInfo, testName.getMethodName() + "copy/dst").build();
+    BlobInfo dst =
+        BlobInfo.newBuilder(bucketInfo, generator.randomObjectName() + "copy/dst").build();
 
     CopyRequest copyRequest =
         CopyRequest.newBuilder()

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectAclTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectAclTest.java
@@ -44,15 +44,14 @@ import com.google.cloud.storage.it.runner.annotations.Backend;
 import com.google.cloud.storage.it.runner.annotations.CrossRun;
 import com.google.cloud.storage.it.runner.annotations.Inject;
 import com.google.cloud.storage.it.runner.annotations.ParallelFriendly;
+import com.google.cloud.storage.it.runner.registry.Generator;
 import com.google.cloud.storage.it.runner.registry.ObjectsFixture;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 @RunWith(StorageITRunner.class)
@@ -62,7 +61,7 @@ import org.junit.runner.RunWith;
 @ParallelFriendly
 public final class ITObjectAclTest {
 
-  @Rule public final TestName testName = new TestName();
+  @Inject public Generator generator;
 
   @Inject public Storage storage;
 
@@ -325,7 +324,7 @@ public final class ITObjectAclTest {
   }
 
   private BlobId tmpId() {
-    return BlobId.of(bucketInfo.getName(), testName.getMethodName());
+    return BlobId.of(bucketInfo.getName(), generator.randomObjectName());
   }
 
   private Blob tmpObject() {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectChecksumSupportTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectChecksumSupportTest.java
@@ -37,15 +37,14 @@ import com.google.cloud.storage.it.runner.annotations.Inject;
 import com.google.cloud.storage.it.runner.annotations.Parameterized;
 import com.google.cloud.storage.it.runner.annotations.Parameterized.Parameter;
 import com.google.cloud.storage.it.runner.annotations.Parameterized.ParametersProvider;
+import com.google.cloud.storage.it.runner.registry.Generator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 
 @RunWith(StorageITRunner.class)
@@ -55,7 +54,7 @@ import org.junit.runner.RunWith;
 @Parameterized(ChecksummedTestContentProvider.class)
 public final class ITObjectChecksumSupportTest {
 
-  @Rule public final TestName testName = new TestName();
+  @Inject public Generator generator;
 
   @Inject public Storage storage;
   @Inject public BucketInfo bucket;
@@ -65,6 +64,7 @@ public final class ITObjectChecksumSupportTest {
   @Parameter public ChecksummedTestContent content;
 
   public static final class ChecksummedTestContentProvider implements ParametersProvider {
+
     @Override
     public ImmutableList<?> parameters() {
       DataGenerator gen = DataGenerator.base64Characters();
@@ -83,7 +83,7 @@ public final class ITObjectChecksumSupportTest {
 
   @Test
   public void testCrc32cValidated_createFrom_expectFailure() {
-    String blobName = testName.getMethodName();
+    String blobName = generator.randomObjectName();
     BlobId blobId = BlobId.of(bucket.getName(), blobName);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setCrc32c(content.getCrc32cBase64()).build();
 
@@ -102,7 +102,7 @@ public final class ITObjectChecksumSupportTest {
 
   @Test
   public void testCrc32cValidated_createFrom_expectSuccess() throws IOException {
-    String blobName = testName.getMethodName();
+    String blobName = generator.randomObjectName();
     BlobId blobId = BlobId.of(bucket.getName(), blobName);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setCrc32c(content.getCrc32cBase64()).build();
 
@@ -118,7 +118,7 @@ public final class ITObjectChecksumSupportTest {
 
   @Test
   public void testCrc32cValidated_writer_expectFailure() {
-    String blobName = testName.getMethodName();
+    String blobName = generator.randomObjectName();
     BlobId blobId = BlobId.of(bucket.getName(), blobName);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setCrc32c(content.getCrc32cBase64()).build();
 
@@ -141,7 +141,7 @@ public final class ITObjectChecksumSupportTest {
 
   @Test
   public void testCrc32cValidated_writer_expectSuccess() throws IOException {
-    String blobName = testName.getMethodName();
+    String blobName = generator.randomObjectName();
     BlobId blobId = BlobId.of(bucket.getName(), blobName);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setCrc32c(content.getCrc32cBase64()).build();
 
@@ -160,7 +160,7 @@ public final class ITObjectChecksumSupportTest {
 
   @Test
   public void testMd5Validated_createFrom_expectFailure() {
-    String blobName = testName.getMethodName();
+    String blobName = generator.randomObjectName();
     BlobId blobId = BlobId.of(bucket.getName(), blobName);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setMd5(content.getMd5Base64()).build();
 
@@ -179,7 +179,7 @@ public final class ITObjectChecksumSupportTest {
 
   @Test
   public void testMd5Validated_createFrom_expectSuccess() throws IOException {
-    String blobName = testName.getMethodName();
+    String blobName = generator.randomObjectName();
     BlobId blobId = BlobId.of(bucket.getName(), blobName);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setMd5(content.getMd5Base64()).build();
 
@@ -195,7 +195,7 @@ public final class ITObjectChecksumSupportTest {
 
   @Test
   public void testMd5Validated_writer_expectFailure() {
-    String blobName = testName.getMethodName();
+    String blobName = generator.randomObjectName();
     BlobId blobId = BlobId.of(bucket.getName(), blobName);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setMd5(content.getMd5Base64()).build();
 
@@ -216,7 +216,7 @@ public final class ITObjectChecksumSupportTest {
 
   @Test
   public void testMd5Validated_writer_expectSuccess() throws IOException {
-    String blobName = testName.getMethodName();
+    String blobName = generator.randomObjectName();
     BlobId blobId = BlobId.of(bucket.getName(), blobName);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setMd5(content.getMd5Base64()).build();
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/Registry.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/Registry.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.runner.Description;
 import org.junit.runner.notification.RunListener;
 import org.junit.runners.model.FrameworkField;
 import org.junit.runners.model.RunnerScheduler;
@@ -85,6 +87,7 @@ public final class Registry extends RunListener {
   private final ImmutableSet<Class<?>> injectableTypes =
       entries.stream().map(RegistryEntry::getType).collect(ImmutableSet.toImmutableSet());
   private final String injectableTypesString = Joiner.on("|").join(injectableTypes);
+  private final ThreadLocal<Description> currentTest = new ThreadLocal<>();
 
   private Registry() {}
 
@@ -110,6 +113,21 @@ public final class Registry extends RunListener {
 
   TestBench testBench() {
     return testBench.get();
+  }
+
+  @Nullable
+  public Description getCurrentTest() {
+    return currentTest.get();
+  }
+
+  @Override
+  public void testStarted(Description description) {
+    currentTest.set(description);
+  }
+
+  @Override
+  public void testFinished(Description description) {
+    currentTest.remove();
   }
 
   public RunnerScheduler parallelScheduler() {


### PR DESCRIPTION
In order to facilitate running tests in parallel, even across configurations object names need to be unique to a test. This new method encapsulates reliably generating test unique object names.

Generated tests names will look of the form: `testName[HTTP][PROD]-0001`

Replace usages of `TestName#getMethodName()` with `Generator#randomObjectName()`