### PR TITLE
chore: introduce ByteRangeSpec#endOffsetInclusive

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ByteRangeSpec.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ByteRangeSpec.java
@@ -50,6 +50,8 @@ abstract class ByteRangeSpec implements Serializable {
 
   abstract long endOffset() throws ArithmeticException;
 
+  abstract long endOffsetInclusive() throws ArithmeticException;
+
   abstract long length() throws ArithmeticException;
 
   // TODO: add validation to this if it ever becomes public
@@ -97,9 +99,7 @@ abstract class ByteRangeSpec implements Serializable {
 
   @Override
   public String toString() {
-    return append(MoreObjects.toStringHelper(""))
-        .add("httpRangeHeader", getHttpRangeHeader())
-        .toString();
+    return append(MoreObjects.toStringHelper("ByteRangeSpec")).toString();
   }
 
   protected abstract MoreObjects.ToStringHelper append(MoreObjects.ToStringHelper tsh);
@@ -162,6 +162,11 @@ abstract class ByteRangeSpec implements Serializable {
 
     @Override
     long endOffset() throws ArithmeticException {
+      return Math.addExact(beginOffset, length);
+    }
+
+    @Override
+    long endOffsetInclusive() throws ArithmeticException {
       return Math.addExact(beginOffset, length) - 1;
     }
 
@@ -209,7 +214,7 @@ abstract class ByteRangeSpec implements Serializable {
 
     @Override
     protected String fmtAsHttpRangeHeader() throws ArithmeticException {
-      return String.format("bytes=%d-%d", beginOffset, endOffset());
+      return String.format("bytes=%d-%d", beginOffset, endOffsetInclusive());
     }
 
     @Override
@@ -240,8 +245,13 @@ abstract class ByteRangeSpec implements Serializable {
     }
 
     @Override
+    long endOffsetInclusive() throws ArithmeticException {
+      return Math.subtractExact(endOffsetExclusive, 1);
+    }
+
+    @Override
     long length() throws ArithmeticException {
-      return endOffsetExclusive - beginOffset;
+      return Math.subtractExact(endOffsetExclusive, beginOffset);
     }
 
     @Override
@@ -284,7 +294,7 @@ abstract class ByteRangeSpec implements Serializable {
 
     @Override
     protected String fmtAsHttpRangeHeader() throws ArithmeticException {
-      return String.format("bytes=%d-%d", beginOffset, endOffsetExclusive - 1);
+      return String.format("bytes=%d-%d", beginOffset, endOffsetInclusive());
     }
 
     @Override
@@ -311,12 +321,17 @@ abstract class ByteRangeSpec implements Serializable {
 
     @Override
     long endOffset() throws ArithmeticException {
+      return Math.addExact(endOffsetInclusive, 1L);
+    }
+
+    @Override
+    long endOffsetInclusive() throws ArithmeticException {
       return endOffsetInclusive;
     }
 
     @Override
     long length() throws ArithmeticException {
-      return endOffsetInclusive - beginOffset;
+      return Math.addExact(Math.subtractExact(endOffsetInclusive, beginOffset), 1);
     }
 
     @Override
@@ -346,7 +361,7 @@ abstract class ByteRangeSpec implements Serializable {
     @Override
     ByteRangeSpec withNewEndOffsetClosed(long endOffsetInclusive) {
       if (endOffsetInclusive != this.endOffsetInclusive) {
-        return new LeftClosedRightOpenByteRangeSpec(beginOffset, endOffsetInclusive);
+        return new LeftClosedRightClosedByteRangeSpec(beginOffset, endOffsetInclusive);
       } else {
         return this;
       }
@@ -384,6 +399,11 @@ abstract class ByteRangeSpec implements Serializable {
 
     @Override
     long endOffset() throws ArithmeticException {
+      return EFFECTIVE_INFINITY;
+    }
+
+    @Override
+    long endOffsetInclusive() throws ArithmeticException {
       return EFFECTIVE_INFINITY;
     }
 
@@ -452,6 +472,11 @@ abstract class ByteRangeSpec implements Serializable {
 
     @Override
     long endOffset() throws ArithmeticException {
+      return EFFECTIVE_INFINITY;
+    }
+
+    @Override
+    long endOffsetInclusive() throws ArithmeticException {
       return EFFECTIVE_INFINITY;
     }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ByteRangeSpecTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ByteRangeSpecTest.java
@@ -556,7 +556,9 @@ public final class ByteRangeSpecTest {
                   ByteRangeSpec.explicit(4L, 10L),
                   ByteRangeSpec.explicitClosed(4L, 9L));
 
+      // variable name should be read as "effective max minus zero"
       long effectiveMax_0 = EFFECTIVE_INFINITY - 1;
+      // variable name should be read as "effective max minus one"
       long effectiveMax_1 = effectiveMax_0 - 1;
       // edge cases near default values
       Stream<RangeScenario> edgeCases =
@@ -716,6 +718,9 @@ public final class ByteRangeSpecTest {
           return "Long.MAX_VALUE";
         } else {
           long diff = Long.MAX_VALUE - l;
+          // When testing near the upperbound of Long it can be challenging to read how close we are
+          // to the max value at a glance. In an effort to help this, for any value that is within
+          // 20 of Long.MAX_VALUE format it as a difference.
           if (diff <= 20) {
             return String.format("(Long.MAX_VALUE - %d)", diff);
           } else {


### PR DESCRIPTION
There are some cases where endOffset and endOffsetInclusive are both necessary and externally being able to differentiate is needed.

### Test Refactor

As part of this change, I've update the declaration of ByteRangeSpec.RangeScenario to be more verbose and easier to read, as well as have a more direct description for the test name.

This does add a fair number of lines of code, but I think it brings some clarity compared to a method with 4 different long arguments. It also reduces (and possible errors in declaration) between related scenarios.

In general the new pattern is: define the four properties of any range (beginOffset, endOffset, endOffsetInclusive, length) then specify those ByteRangeSpecs for which it should be applicable.

