### PR TITLE
feat: update GrpcBlobReadChannel to allow seek/limit after read

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BaseStorageReadChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BaseStorageReadChannel.java
@@ -127,12 +127,12 @@ abstract class BaseStorageReadChannel<T> implements StorageReadChannel {
 
   protected abstract LazyReadChannel<T> newLazyReadChannel();
 
-  private void maybeResetChannel(boolean umallocBuffer) throws IOException {
+  private void maybeResetChannel(boolean freeBuffer) throws IOException {
     if (lazyReadChannel != null && lazyReadChannel.isOpen()) {
       try (BufferedReadableByteChannel ignore = lazyReadChannel.getChannel()) {
-        if (bufferHandle != null && !umallocBuffer) {
+        if (bufferHandle != null && !freeBuffer) {
           bufferHandle.get().clear();
-        } else if (umallocBuffer) {
+        } else if (freeBuffer) {
           bufferHandle = null;
         }
         lazyReadChannel = null;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BaseStorageReadChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BaseStorageReadChannel.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.cloud.storage.ByteSizeConstants._2MiB;
+import static java.util.Objects.requireNonNull;
+
+import com.google.cloud.storage.BufferedReadableByteChannelSession.BufferedReadableByteChannel;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+abstract class BaseStorageReadChannel<T> implements StorageReadChannel {
+
+  private ByteRangeSpec byteRangeSpec;
+  private int chunkSize = _2MiB;
+  private BufferHandle bufferHandle;
+  private LazyReadChannel<T> lazyReadChannel;
+
+  @Nullable private T resolvedObject;
+
+  protected BaseStorageReadChannel() {
+    this.byteRangeSpec = ByteRangeSpec.nullRange();
+  }
+
+  @Override
+  public final synchronized void setChunkSize(int chunkSize) {
+    StorageException.wrapIOException(() -> maybeResetChannel(true));
+    this.chunkSize = chunkSize;
+  }
+
+  @Override
+  public final synchronized boolean isOpen() {
+    if (lazyReadChannel == null) {
+      return true;
+    } else {
+      LazyReadChannel<T> tmp = internalGetLazyChannel();
+      return tmp.isOpen();
+    }
+  }
+
+  @Override
+  public final synchronized void close() {
+    if (internalGetLazyChannel().isOpen()) {
+      StorageException.wrapIOException(internalGetLazyChannel().getChannel()::close);
+    }
+  }
+
+  @Override
+  public final synchronized StorageReadChannel setByteRangeSpec(ByteRangeSpec byteRangeSpec) {
+    requireNonNull(byteRangeSpec, "byteRangeSpec must be non null");
+    StorageException.wrapIOException(() -> maybeResetChannel(false));
+    this.byteRangeSpec = byteRangeSpec;
+    return this;
+  }
+
+  @Override
+  public final ByteRangeSpec getByteRangeSpec() {
+    return byteRangeSpec;
+  }
+
+  @Override
+  public final synchronized int read(ByteBuffer dst) throws IOException {
+    long diff = byteRangeSpec.length();
+    if (diff <= 0) {
+      close();
+      return -1;
+    }
+    try {
+      int read = internalGetLazyChannel().getChannel().read(dst);
+      if (read != -1) {
+        byteRangeSpec = byteRangeSpec.withShiftBeginOffset(read);
+      } else {
+        close();
+      }
+      return read;
+    } catch (StorageException e) {
+      if (e.getCode() == 416) {
+        // HttpStorageRpc turns 416 into a null etag with an empty byte array, leading
+        // BlobReadChannel to believe it read 0 bytes, returning -1 and leaving the channel open.
+        // Emulate that same behavior here to preserve behavior compatibility, though this should
+        // be removed in the next major version.
+        return -1;
+      } else {
+        throw new IOException(e);
+      }
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IOException(StorageException.coalesce(e));
+    }
+  }
+
+  protected final BufferHandle getBufferHandle() {
+    if (bufferHandle == null) {
+      bufferHandle = BufferHandle.allocate(chunkSize);
+    }
+    return bufferHandle;
+  }
+
+  protected final int getChunkSize() {
+    return chunkSize;
+  }
+
+  @Nullable
+  protected T getResolvedObject() {
+    return resolvedObject;
+  }
+
+  protected void setResolvedObject(@Nullable T resolvedObject) {
+    this.resolvedObject = resolvedObject;
+  }
+
+  protected abstract LazyReadChannel<T> newLazyReadChannel();
+
+  private void maybeResetChannel(boolean umallocBuffer) throws IOException {
+    if (lazyReadChannel != null && lazyReadChannel.isOpen()) {
+      try (BufferedReadableByteChannel ignore = lazyReadChannel.getChannel()) {
+        if (bufferHandle != null && !umallocBuffer) {
+          bufferHandle.get().clear();
+        } else if (umallocBuffer) {
+          bufferHandle = null;
+        }
+        lazyReadChannel = null;
+      }
+    }
+  }
+
+  private LazyReadChannel<T> internalGetLazyChannel() {
+    if (lazyReadChannel == null) {
+      lazyReadChannel = newLazyReadChannel();
+    }
+    return lazyReadChannel;
+  }
+}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ByteRangeSpec.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ByteRangeSpec.java
@@ -19,6 +19,7 @@ package com.google.cloud.storage;
 import com.google.api.core.InternalApi;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
+import com.google.storage.v2.ReadObjectRequest;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.function.BiFunction;
@@ -79,6 +80,8 @@ abstract class ByteRangeSpec implements Serializable {
     }
     return httpRangeHeader;
   }
+
+  abstract ReadObjectRequest.Builder seekReadObjectRequest(ReadObjectRequest.Builder b);
 
   @Nullable
   protected abstract String fmtAsHttpRangeHeader() throws ArithmeticException;
@@ -213,6 +216,11 @@ abstract class ByteRangeSpec implements Serializable {
     }
 
     @Override
+    public ReadObjectRequest.Builder seekReadObjectRequest(ReadObjectRequest.Builder b) {
+      return b.setReadOffset(beginOffset()).setReadLimit(length());
+    }
+
+    @Override
     protected String fmtAsHttpRangeHeader() throws ArithmeticException {
       return String.format("bytes=%d-%d", beginOffset, endOffsetInclusive());
     }
@@ -290,6 +298,11 @@ abstract class ByteRangeSpec implements Serializable {
     @Override
     ByteRangeSpec withNewRelativeLength(long relativeLength) {
       return new RelativeByteRangeSpec(beginOffset, relativeLength);
+    }
+
+    @Override
+    public ReadObjectRequest.Builder seekReadObjectRequest(ReadObjectRequest.Builder b) {
+      return b.setReadOffset(beginOffset()).setReadLimit(length());
     }
 
     @Override
@@ -373,6 +386,11 @@ abstract class ByteRangeSpec implements Serializable {
     }
 
     @Override
+    public ReadObjectRequest.Builder seekReadObjectRequest(ReadObjectRequest.Builder b) {
+      return b.setReadOffset(beginOffset()).setReadLimit(length());
+    }
+
+    @Override
     protected String fmtAsHttpRangeHeader() throws ArithmeticException {
       return String.format("bytes=%d-%d", beginOffset, endOffsetInclusive);
     }
@@ -443,6 +461,11 @@ abstract class ByteRangeSpec implements Serializable {
     @Override
     ByteRangeSpec withNewRelativeLength(long relativeLength) {
       return new RelativeByteRangeSpec(beginOffset, relativeLength);
+    }
+
+    @Override
+    public ReadObjectRequest.Builder seekReadObjectRequest(ReadObjectRequest.Builder b) {
+      return b.setReadOffset(beginOffset());
     }
 
     @Override
@@ -528,6 +551,11 @@ abstract class ByteRangeSpec implements Serializable {
       } else {
         return this;
       }
+    }
+
+    @Override
+    public ReadObjectRequest.Builder seekReadObjectRequest(ReadObjectRequest.Builder b) {
+      return b;
     }
 
     @Override

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
@@ -34,7 +34,6 @@ import com.google.cloud.BatchResult;
 import com.google.cloud.PageImpl;
 import com.google.cloud.PageImpl.NextPageFetcher;
 import com.google.cloud.Policy;
-import com.google.cloud.ReadChannel;
 import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.Acl.Entity;
 import com.google.cloud.storage.BlobReadChannelV2.BlobReadChannelContext;
@@ -581,12 +580,12 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
   }
 
   @Override
-  public ReadChannel reader(String bucket, String blob, BlobSourceOption... options) {
+  public StorageReadChannel reader(String bucket, String blob, BlobSourceOption... options) {
     return reader(BlobId.of(bucket, blob), options);
   }
 
   @Override
-  public ReadChannel reader(BlobId blob, BlobSourceOption... options) {
+  public StorageReadChannel reader(BlobId blob, BlobSourceOption... options) {
     Opts<ObjectSourceOpt> opts = Opts.unwrap(options).resolveFrom(blob);
     StorageObject storageObject = Conversions.apiary().blobId().encode(blob);
     ImmutableMap<StorageRpc.Option, ?> optionsMap = opts.getRpcOptions();


### PR DESCRIPTION
### Refactoring
Extract the majority of BlobReadChannelV2 to a new abstract base class BaseStorageReadChannel which effectively adapts a LazyReadChannel to a StorageReadChannel.

BaseStorageReadChannel now defines an abstract method newLazyReadChannel which each implementation is responsible for implementing to integrate into the lifecycle.

