### PR TITLE
chore: refactor BlobReadChannel to plumb the sparse object metadata included in a read media response for both json and grpc

### DIFF
--- a/google-cloud-storage/clirr-ignored-differences.xml
+++ b/google-cloud-storage/clirr-ignored-differences.xml
@@ -19,4 +19,11 @@
     <className>com/google/cloud/storage/Hasher$ConstantConcatValueHasher</className>
   </difference>
 
+  <!-- Not breaking, internal only class -->
+  <difference>
+    <differenceType>7002</differenceType>
+    <className>com/google/cloud/storage/HttpDownloadSessionBuilder$ReadableByteChannelSessionBuilder</className>
+    <method>com.google.cloud.storage.HttpDownloadSessionBuilder$ReadableByteChannelSessionBuilder setCallback(java.util.function.Consumer)</method>
+  </difference>
+
 </differences>

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannel.java
@@ -142,6 +142,10 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
     }
   }
 
+  private void setXGoogGeneration(long xGoogGeneration) {
+    this.xGoogGeneration = xGoogGeneration;
+  }
+
   private ScatteringByteChannel open() {
     try {
       Boolean b =
@@ -159,7 +163,8 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
         if (xGoogGenHeader != null) {
           StorageObject clone = apiaryReadRequest.getObject().clone();
           ifNonNull(xGoogGenHeader, Long::valueOf, clone::setGeneration);
-          ifNonNull(xGoogGenHeader, Long::valueOf, g -> this.xGoogGeneration = g);
+          // store xGoogGeneration ourselves incase we need to retry
+          ifNonNull(xGoogGenHeader, Long::valueOf, this::setXGoogGeneration);
           ifNonNull(
               getHeaderValue(responseHeaders, "x-goog-metageneration"),
               Long::valueOf,

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannel.java
@@ -27,6 +27,7 @@ import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.Storage.Objects;
 import com.google.api.services.storage.Storage.Objects.Get;
 import com.google.api.services.storage.model.StorageObject;
+import com.google.cloud.BaseServiceException;
 import com.google.cloud.storage.UnbufferedReadableByteChannelSession.UnbufferedReadableByteChannel;
 import com.google.cloud.storage.spi.v1.StorageRpc;
 import com.google.common.annotations.VisibleForTesting;
@@ -42,15 +43,17 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.io.StringReader;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.annotation.concurrent.Immutable;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChannel {
 
@@ -59,7 +62,6 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
   private final SettableApiFuture<StorageObject> result;
   private final HttpStorageOptions options;
   private final ResultRetryAlgorithm<?> resultRetryAlgorithm;
-  private final Consumer<StorageObject> resolvedObjectCallback;
 
   private long position;
   private ScatteringByteChannel sbc;
@@ -73,14 +75,12 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
       Storage storage,
       SettableApiFuture<StorageObject> result,
       HttpStorageOptions options,
-      ResultRetryAlgorithm<?> resultRetryAlgorithm,
-      Consumer<StorageObject> resolvedObjectCallback) {
+      ResultRetryAlgorithm<?> resultRetryAlgorithm) {
     this.apiaryReadRequest = apiaryReadRequest;
     this.storage = storage;
     this.result = result;
     this.options = options;
     this.resultRetryAlgorithm = resultRetryAlgorithm;
-    this.resolvedObjectCallback = resolvedObjectCallback;
     this.open = true;
     this.position =
         apiaryReadRequest.getByteRangeSpec() != null
@@ -154,15 +154,34 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
       InputStream content = media.getContent();
       if (xGoogGeneration == null) {
         HttpHeaders responseHeaders = media.getHeaders();
-        //noinspection unchecked
-        List<String> xGoogGenHeader = (List<String>) responseHeaders.get("x-goog-generation");
-        // TODO: wire in result metadata population
-        if (xGoogGenHeader != null && !xGoogGenHeader.isEmpty()) {
-          String s = xGoogGenHeader.get(0);
-          Long generation = Long.valueOf(s);
-          this.xGoogGeneration = generation;
-          resolvedObjectCallback.accept(
-              apiaryReadRequest.getObject().clone().setGeneration(generation));
+
+        String xGoogGenHeader = getHeaderValue(responseHeaders, "x-goog-generation");
+        if (xGoogGenHeader != null) {
+          StorageObject clone = apiaryReadRequest.getObject().clone();
+          ifNonNull(xGoogGenHeader, Long::valueOf, clone::setGeneration);
+          ifNonNull(xGoogGenHeader, Long::valueOf, g -> this.xGoogGeneration = g);
+          ifNonNull(
+              getHeaderValue(responseHeaders, "x-goog-metageneration"),
+              Long::valueOf,
+              clone::setMetageneration);
+          ifNonNull(
+              getHeaderValue(responseHeaders, "x-goog-storage-class"), clone::setStorageClass);
+          ifNonNull(
+              getHeaderValue(responseHeaders, "x-goog-stored-content-length"),
+              BigInteger::new,
+              clone::setSize);
+          ifNonNull(
+              getHeaderValue(responseHeaders, "content-disposition"), clone::setContentDisposition);
+          ifNonNull(getHeaderValue(responseHeaders, "content-type"), clone::setContentType);
+          ifNonNull(getHeaderValue(responseHeaders, "etag"), clone::setEtag);
+
+          String encoding = getHeaderValue(responseHeaders, "x-goog-stored-content-encoding");
+          if (encoding != null && !encoding.equalsIgnoreCase("identity")) {
+            clone.setContentEncoding(encoding);
+          }
+          if (!result.isDone()) {
+            result.set(clone);
+          }
         }
       }
 
@@ -175,11 +194,17 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
           throw new StorageException(404, "Failure while trying to resume download", e);
         }
       }
-      throw StorageException.translate(e);
+      StorageException translate = StorageException.translate(e);
+      result.setException(translate);
+      throw translate;
     } catch (IOException e) {
-      throw StorageException.translate(e);
+      StorageException translate = StorageException.translate(e);
+      result.setException(translate);
+      throw translate;
     } catch (Throwable t) {
-      throw StorageException.coalesce(t);
+      BaseServiceException coalesce = StorageException.coalesce(t);
+      result.setException(coalesce);
+      throw coalesce;
     }
   }
 
@@ -245,6 +270,28 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
   @SuppressWarnings("unchecked")
   private static <T> T cast(Object o) {
     return (T) o;
+  }
+
+  @Nullable
+  @SuppressWarnings("unchecked")
+  private static String getHeaderValue(@NonNull HttpHeaders headers, @NonNull String headerName) {
+    Object o = headers.get(headerName);
+    if (o == null) {
+      return null;
+    } else if (o instanceof List) {
+      List<String> list = (List<String>) o;
+      if (list.isEmpty()) {
+        return null;
+      } else {
+        return list.get(0);
+      }
+    } else if (o instanceof String) {
+      return (String) o;
+    } else {
+      throw new IllegalStateException(
+          String.format(
+              "Unexpected header type '%s' for header %s", o.getClass().getName(), headerName));
+    }
   }
 
   @Immutable

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobReadChannelV2.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobReadChannelV2.java
@@ -37,6 +37,7 @@ final class BlobReadChannelV2 extends BaseStorageReadChannel<StorageObject> {
       StorageObject storageObject,
       Map<StorageRpc.Option, ?> opts,
       BlobReadChannelContext blobReadChannelContext) {
+    super(Conversions.apiary().blobInfo());
     this.storageObject = storageObject;
     this.opts = opts;
     this.blobReadChannelContext = blobReadChannelContext;
@@ -55,7 +56,6 @@ final class BlobReadChannelV2 extends BaseStorageReadChannel<StorageObject> {
             ResumableMedia.http()
                 .read()
                 .byteChannel(blobReadChannelContext)
-                .setCallback(this::setResolvedObject)
                 .buffered(getBufferHandle())
                 .setApiaryReadRequest(getApiaryReadRequest())
                 .build());
@@ -66,7 +66,7 @@ final class BlobReadChannelV2 extends BaseStorageReadChannel<StorageObject> {
     return new ApiaryReadRequest(object, opts, getByteRangeSpec());
   }
 
-  static class BlobReadChannelV2State implements RestorableState<ReadChannel>, Serializable {
+  static final class BlobReadChannelV2State implements RestorableState<ReadChannel>, Serializable {
 
     private static final long serialVersionUID = -7595661593080505431L;
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedReadableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedReadableByteChannel.java
@@ -237,12 +237,26 @@ final class GapicUnbufferedReadableByteChannel
 
     @Override
     public boolean hasNext() {
-      return ensureResponseIteratorOpen().hasNext();
+      try {
+        return ensureResponseIteratorOpen().hasNext();
+      } catch (RuntimeException e) {
+        if (!result.isDone()) {
+          result.setException(StorageException.coalesce(e));
+        }
+        throw e;
+      }
     }
 
     @Override
     public ReadObjectResponse next() {
-      return ensureResponseIteratorOpen().next();
+      try {
+        return ensureResponseIteratorOpen().next();
+      } catch (RuntimeException e) {
+        if (!result.isDone()) {
+          result.setException(StorageException.coalesce(e));
+        }
+        throw e;
+      }
     }
 
     @Override

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcBlobReadChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcBlobReadChannel.java
@@ -34,6 +34,7 @@ final class GrpcBlobReadChannel extends BaseStorageReadChannel<Object> {
       ServerStreamingCallable<ReadObjectRequest, ReadObjectResponse> read,
       ReadObjectRequest request,
       boolean autoGzipDecompression) {
+    super(Conversions.grpc().blobInfo());
     this.read = read;
     this.request = request;
     this.autoGzipDecompression = autoGzipDecompression;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
@@ -20,7 +20,6 @@ import static com.google.cloud.storage.Utils.bucketNameCodec;
 import static com.google.cloud.storage.Utils.ifNonNull;
 import static com.google.cloud.storage.Utils.lift;
 import static com.google.cloud.storage.Utils.projectNameCodec;
-import static com.google.cloud.storage.Utils.toImmutableListOf;
 
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.cloud.Binding;
@@ -64,6 +63,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 final class GrpcConversions {
   static final GrpcConversions INSTANCE = new GrpcConversions();
@@ -1022,5 +1022,14 @@ final class GrpcConversions {
 
   private static <T> T todo() {
     throw new IllegalStateException("Not yet implemented");
+  }
+
+  /**
+   * Several properties are translating lists of one type to another. This convenience method allows
+   * specifying a mapping function and composing as part of an {@code #isNonNull} definition.
+   */
+  private static <T1, T2> Function<List<T1>, ImmutableList<T2>> toImmutableListOf(
+      Function<T1, T2> f) {
+    return l -> l.stream().map(f).collect(ImmutableList.toImmutableList());
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -1670,7 +1670,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
         + ")";
   }
 
-  private ReadObjectRequest getReadObjectRequest(BlobId blob, Opts<ObjectSourceOpt> opts) {
+  ReadObjectRequest getReadObjectRequest(BlobId blob, Opts<ObjectSourceOpt> opts) {
     Object object = codecs.blobId().encode(blob);
 
     ReadObjectRequest.Builder builder =

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpDownloadSessionBuilder.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpDownloadSessionBuilder.java
@@ -27,7 +27,6 @@ import com.google.cloud.storage.BufferedReadableByteChannelSession.BufferedReada
 import com.google.cloud.storage.UnbufferedReadableByteChannelSession.UnbufferedReadableByteChannel;
 import java.nio.ByteBuffer;
 import java.util.function.BiFunction;
-import java.util.function.Consumer;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
@@ -53,15 +52,9 @@ final class HttpDownloadSessionBuilder {
 
     private final BlobReadChannelContext blobReadChannelContext;
     // private Hasher hasher; // TODO: wire in Hasher
-    private Consumer<StorageObject> callback;
 
     private ReadableByteChannelSessionBuilder(BlobReadChannelContext blobReadChannelContext) {
       this.blobReadChannelContext = blobReadChannelContext;
-    }
-
-    public ReadableByteChannelSessionBuilder setCallback(Consumer<StorageObject> callback) {
-      this.callback = callback;
-      return this;
     }
 
     public BufferedReadableByteChannelSessionBuilder buffered() {
@@ -90,8 +83,7 @@ final class HttpDownloadSessionBuilder {
               blobReadChannelContext.getApiaryClient(),
               resultFuture,
               blobReadChannelContext.getStorageOptions(),
-              blobReadChannelContext.getRetryAlgorithmManager().idempotent(),
-              callback);
+              blobReadChannelContext.getRetryAlgorithmManager().idempotent());
     }
 
     public static final class BufferedReadableByteChannelSessionBuilder {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageException.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageException.java
@@ -17,9 +17,11 @@
 package com.google.cloud.storage;
 
 import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.core.ApiFuture;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.grpc.GrpcStatusCode;
 import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.ApiExceptions;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.cloud.BaseServiceException;
 import com.google.cloud.RetryHelper.RetryHelperException;
@@ -176,6 +178,14 @@ public final class StorageException extends BaseHttpServiceException {
     try {
       r.run();
     } catch (IOException e) {
+      throw StorageException.coalesce(e);
+    }
+  }
+
+  static <T> T wrapFutureGet(ApiFuture<T> f) {
+    try {
+      return ApiExceptions.callAndTranslateApiException(f);
+    } catch (Exception e) {
       throw StorageException.coalesce(e);
     }
   }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageReadChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageReadChannel.java
@@ -18,12 +18,19 @@ package com.google.cloud.storage;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.api.core.ApiFuture;
 import com.google.cloud.ReadChannel;
 import java.io.IOException;
 
 interface StorageReadChannel extends ReadChannel {
 
   StorageReadChannel setByteRangeSpec(ByteRangeSpec byteRangeSpec);
+
+  /**
+   * Return a Future which resolves to the sparse object metadata included in the response headers
+   * when opening the read.
+   */
+  ApiFuture<BlobInfo> getObject();
 
   default ByteRangeSpec getByteRangeSpec() {
     return ByteRangeSpec.nullRange();

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Utils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Utils.java
@@ -23,7 +23,6 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.storage.Conversions.Codec;
 import com.google.cloud.storage.UnifiedOpts.NamedField;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import com.google.common.io.BaseEncoding;
@@ -36,7 +35,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -210,15 +208,6 @@ final class Utils {
   @InternalApi
   static <T1, T2> Function<T1, T2> lift(Function<T1, T2> f) {
     return f;
-  }
-
-  /**
-   * Several properties are translating lists of one type to another. This convenience method allows
-   * specifying a mapping function and composing as part of an {@code #isNonNull} definition.
-   */
-  @InternalApi
-  static <T1, T2> Function<List<T1>, ImmutableList<T2>> toImmutableListOf(Function<T1, T2> f) {
-    return l -> l.stream().map(f).collect(ImmutableList.toImmutableList());
   }
 
   /**

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/LazyReadChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/LazyReadChannelTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.storage.BufferedReadableByteChannelSession.BufferedReadableByteChannel;
+import com.google.common.base.MoreObjects;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+public final class LazyReadChannelTest {
+
+  private final AtomicInteger counter = new AtomicInteger(1);
+
+  @Test
+  public void repeatedCallsOfGetSessionMustReturnTheSameInstance() {
+    LazyReadChannel<String> lrc = new LazyReadChannel<>(this::newTestSession);
+
+    BufferedReadableByteChannelSession<String> session1 = lrc.getSession();
+    BufferedReadableByteChannelSession<String> session2 = lrc.getSession();
+    assertThat(session1).isSameInstanceAs(session2);
+  }
+
+  @Test
+  public void repeatedCallsOfGetChannelMustReturnTheSameInstance() {
+    LazyReadChannel<String> lrc = new LazyReadChannel<>(this::newTestSession);
+
+    BufferedReadableByteChannel channel1 = lrc.getChannel();
+    BufferedReadableByteChannel channel2 = lrc.getChannel();
+    assertThat(channel1).isSameInstanceAs(channel2);
+  }
+
+  @Test
+  public void isNotOpenUntilGetChannelIsCalled() {
+    LazyReadChannel<String> lrc = new LazyReadChannel<>(this::newTestSession);
+
+    assertThat(lrc.isOpen()).isFalse();
+    BufferedReadableByteChannel channel = lrc.getChannel();
+    assertThat(channel.isOpen()).isTrue();
+
+    assertThat(lrc.isOpen()).isTrue();
+  }
+
+  @Test
+  public void closingUnderlyingChannelClosesTheLazyReadChannel() throws IOException {
+    LazyReadChannel<String> lrc = new LazyReadChannel<>(this::newTestSession);
+
+    BufferedReadableByteChannel channel = lrc.getChannel();
+    assertThat(channel.isOpen()).isTrue();
+    channel.close();
+    assertThat(lrc.isOpen()).isFalse();
+  }
+
+  private TestSession newTestSession() {
+    return new TestSession(String.format("test-%02d", counter.getAndIncrement()));
+  }
+
+  private static final class TestSession implements BufferedReadableByteChannelSession<String> {
+
+    private final String s;
+    private final ApiFuture<BufferedReadableByteChannel> channel;
+    private final ApiFuture<String> result;
+
+    private TestSession(String s) {
+      this.s = s;
+      this.channel = ApiFutures.immediateFuture(new TestChannel());
+      this.result = ApiFutures.immediateFuture(s);
+    }
+
+    @Override
+    public ApiFuture<BufferedReadableByteChannel> openAsync() {
+      return channel;
+    }
+
+    @Override
+    public ApiFuture<String> getResult() {
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("s", s)
+          .add("channel", channel)
+          .add("result", result)
+          .toString();
+    }
+  }
+
+  private static final class TestChannel implements BufferedReadableByteChannel {
+
+    boolean open = true;
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+      if (!open) {
+        throw new ClosedChannelException();
+      }
+      return 0;
+    }
+
+    @Override
+    public boolean isOpen() {
+      return open;
+    }
+
+    @Override
+    public void close() {
+      open = false;
+    }
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
@@ -16,7 +16,10 @@
 
 package com.google.cloud.storage;
 
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
 import com.google.api.services.storage.model.StorageObject;
+import com.google.cloud.ReadChannel;
 import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.BucketInfo.BuilderImpl;
 import com.google.common.collect.ImmutableList;
@@ -65,6 +68,16 @@ public final class PackagePrivateMethodWorkarounds {
         return Optional.empty();
       }
     };
+  }
+
+  public static ApiFuture<BlobInfo> getBlobInfoFromReadChannelFunction(ReadChannel c) {
+    if (c instanceof StorageReadChannel) {
+      StorageReadChannel src = (StorageReadChannel) c;
+      return src.getObject();
+    } else {
+      return ApiFutures.immediateFailedFuture(
+          new IllegalStateException("Unsupported ReadChannel Type " + c.getClass().getName()));
+    }
   }
 
   public static <T> void ifNonNull(@Nullable T t, Consumer<T> c) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageReadChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageReadChannelTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.it;
+
+import static com.google.cloud.storage.PackagePrivateMethodWorkarounds.getBlobInfoFromReadChannelFunction;
+import static com.google.cloud.storage.TestUtils.assertAll;
+import static com.google.cloud.storage.TestUtils.gzipBytes;
+import static com.google.cloud.storage.TestUtils.xxd;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.ReadChannel;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.DataGenerator;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobSourceOption;
+import com.google.cloud.storage.Storage.BlobTargetOption;
+import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.TransportCompatibility.Transport;
+import com.google.cloud.storage.it.runner.StorageITRunner;
+import com.google.cloud.storage.it.runner.annotations.Backend;
+import com.google.cloud.storage.it.runner.annotations.CrossRun;
+import com.google.cloud.storage.it.runner.annotations.Inject;
+import com.google.cloud.storage.it.runner.registry.Generator;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(StorageITRunner.class)
+@CrossRun(
+    backends = Backend.PROD,
+    transports = {Transport.HTTP, Transport.GRPC})
+public final class ITStorageReadChannelTest {
+
+  @Inject public Storage storage;
+
+  @Inject public BucketInfo bucket;
+
+  @Inject public Generator generator;
+
+  @Test
+  public void storageReadChannel_getObject_returns() throws Exception {
+    int _512KiB = 512 * 1024;
+    int _1MiB = 1024 * 1024;
+
+    final BlobInfo info;
+    ChecksummedTestContent content;
+    {
+      byte[] uncompressedBytes = DataGenerator.base64Characters().genBytes(_512KiB);
+      byte[] gzipBytes = gzipBytes(uncompressedBytes);
+      content = ChecksummedTestContent.of(gzipBytes);
+      BlobInfo tmp =
+          BlobInfo.newBuilder(bucket, generator.randomObjectName())
+              // define an object with explicit content type and encoding.
+              // JSON and gRPC have differing default behavior returning these values if they are
+              // either undefined, or match HTTP defaults.
+              .setContentType("text/plain")
+              .setContentEncoding("gzip")
+              .build();
+
+      Blob gen1 = storage.create(tmp, content.getBytes(), BlobTargetOption.doesNotExist());
+      info = gen1.asBlobInfo();
+    }
+
+    try (ReadChannel c =
+        storage.reader(info.getBlobId(), BlobSourceOption.shouldReturnRawInputStream(true))) {
+
+      ApiFuture<BlobInfo> infoFuture = getBlobInfoFromReadChannelFunction(c);
+
+      ByteBuffer buf = ByteBuffer.allocate(_1MiB);
+      c.read(buf);
+      String actual = xxd(buf);
+      String expected = xxd(content.getBytes());
+      assertThat(actual).isEqualTo(expected);
+
+      BlobInfo blobInfo = infoFuture.get(3, TimeUnit.SECONDS);
+      assertAll(
+          () -> equalForField(blobInfo, info, BlobInfo::getName),
+          () -> equalForField(blobInfo, info, BlobInfo::getBucket),
+          () -> equalForField(blobInfo, info, BlobInfo::getGeneration),
+          () -> equalForField(blobInfo, info, BlobInfo::getMetageneration),
+          () -> equalForField(blobInfo, info, BlobInfo::getSize),
+          () -> equalForField(blobInfo, info, BlobInfo::getContentType),
+          () -> equalForField(blobInfo, info, BlobInfo::getContentEncoding));
+    }
+  }
+
+  @Test
+  public void storageReadChannel_getObject_404() {
+    BlobId id = BlobId.of(bucket.getName(), generator.randomObjectName());
+
+    try (ReadChannel c = storage.reader(id)) {
+      ApiFuture<BlobInfo> infoFuture = getBlobInfoFromReadChannelFunction(c);
+      IOException ioException =
+          assertThrows(IOException.class, () -> c.read(ByteBuffer.allocate(10)));
+      assertThat(ioException).hasCauseThat().isInstanceOf(StorageException.class);
+      ExecutionException ee =
+          assertThrows(ExecutionException.class, () -> infoFuture.get(3, TimeUnit.SECONDS));
+      assertThat(ee).hasCauseThat().isInstanceOf(StorageException.class);
+      StorageException cause = (StorageException) ee.getCause();
+      assertThat(cause.getCode()).isEqualTo(404);
+    }
+  }
+
+  private static <T, F> void equalForField(T actual, T expected, Function<T, F> f) {
+    F aF = f.apply(actual);
+    F eF = f.apply(expected);
+    assertThat(aF).isEqualTo(eF);
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/ObjectsFixture.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/ObjectsFixture.java
@@ -112,7 +112,7 @@ public final class ObjectsFixture implements ManagedLifecycle {
     this.info3 = s.get(blobId3).asBlobInfo();
     this.info4 = s.get(blobId4).asBlobInfo();
 
-    byte[] bytes = DataGenerator.base64Characters().genBytes(512);
+    byte[] bytes = DataGenerator.base64Characters().genBytes(512 * 1024);
     Blob obj512KiB =
         s.create(
             BlobInfo.newBuilder(bucket, "obj512KiB").build(),


### PR DESCRIPTION
Publicly exposing this is gated on how/when we are able to expose StorageReadChannel.
