### PR TITLE
fix: update BlobReadChannelV2 handling to correctly restart for decompressed object

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BaseStorageReadChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BaseStorageReadChannel.java
@@ -120,7 +120,7 @@ abstract class BaseStorageReadChannel<T> implements StorageReadChannel {
   }
 
   @Override
-  public ApiFuture<BlobInfo> getObject() {
+  public final ApiFuture<BlobInfo> getObject() {
     return ApiFutures.transform(result, objectDecoder::decode, MoreExecutors.directExecutor());
   }
 
@@ -136,7 +136,7 @@ abstract class BaseStorageReadChannel<T> implements StorageReadChannel {
   }
 
   @Nullable
-  protected T getResolvedObject() {
+  protected final T getResolvedObject() {
     if (result.isDone()) {
       return StorageException.wrapFutureGet(result);
     } else {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultBufferedReadableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultBufferedReadableByteChannel.java
@@ -41,7 +41,7 @@ final class DefaultBufferedReadableByteChannel implements BufferedReadableByteCh
     if (retEOF) {
       retEOF = false;
       return -1;
-    } else if (!channel.isOpen()) {
+    } else if (!enqueuedBytes() && !channel.isOpen()) {
       throw new ClosedChannelException();
     }
 
@@ -133,7 +133,7 @@ final class DefaultBufferedReadableByteChannel implements BufferedReadableByteCh
 
   @Override
   public boolean isOpen() {
-    return !retEOF && channel.isOpen();
+    return enqueuedBytes() || (!retEOF && channel.isOpen());
   }
 
   @Override

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicDownloadSessionBuilder.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicDownloadSessionBuilder.java
@@ -23,6 +23,7 @@ import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.cloud.storage.BufferedReadableByteChannelSession.BufferedReadableByteChannel;
 import com.google.cloud.storage.UnbufferedReadableByteChannelSession.UnbufferedReadableByteChannel;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.storage.v2.Object;
 import com.google.storage.v2.ReadObjectRequest;
 import com.google.storage.v2.ReadObjectResponse;
@@ -99,7 +100,9 @@ final class GapicDownloadSessionBuilder {
       return (object, resultFuture) -> {
         if (autoGzipDecompression) {
           return new GzipReadableByteChannel(
-              new GapicUnbufferedReadableByteChannel(resultFuture, read, object, hasher));
+              new GapicUnbufferedReadableByteChannel(resultFuture, read, object, hasher),
+              ApiFutures.transform(
+                  resultFuture, Object::getContentEncoding, MoreExecutors.directExecutor()));
         } else {
           return new GapicUnbufferedReadableByteChannel(resultFuture, read, object, hasher);
         }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobReadChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobReadChannelTest.java
@@ -427,7 +427,7 @@ public final class ITBlobReadChannelTest {
       String xxd1 = xxd(bytes1);
       assertThat(xxd1).isEqualTo(xxdExpected1);
 
-      // seek forward to a new offset
+      // change the limit
       reader.limit(10);
 
       // read again

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobReadChannelV2RetryTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobReadChannelV2RetryTest.java
@@ -16,10 +16,12 @@
 
 package com.google.cloud.storage.it;
 
+import static com.google.cloud.storage.TestUtils.assertAll;
 import static com.google.cloud.storage.TestUtils.slice;
 import static com.google.cloud.storage.TestUtils.xxd;
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.api.client.http.HttpRequest;
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.cloud.ReadChannel;
 import com.google.cloud.storage.Blob;
@@ -28,8 +30,10 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.DataGenerator;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobSourceOption;
 import com.google.cloud.storage.Storage.BlobTargetOption;
 import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.storage.TestUtils;
 import com.google.cloud.storage.TransportCompatibility.Transport;
 import com.google.cloud.storage.it.runner.StorageITRunner;
 import com.google.cloud.storage.it.runner.annotations.Backend;
@@ -41,10 +45,15 @@ import com.google.cloud.storage.it.runner.registry.TestBench;
 import com.google.cloud.storage.it.runner.registry.TestBench.RetryTestResource;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.ByteStreams;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
+import java.util.Random;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -125,6 +134,70 @@ public final class ITBlobReadChannelV2RetryTest {
       String xxd2 = xxd(buf2);
       assertThat(xxd2).isEqualTo(xxdExpected2);
       requestAuditing.assertQueryParam("generation", gen1.getGeneration(), Long::new);
+    }
+  }
+
+  @Test
+  public void restartingAStreamForGzipContentIsAtTheCorrectOffset() throws Exception {
+
+    StorageOptions baseOptions = storage.getOptions();
+    Random rand = new Random(918273645);
+
+    ChecksummedTestContent uncompressed;
+    ChecksummedTestContent gzipped;
+    {
+      // must use random strategy, base64 characters compress too well. 512KiB uncompressed becomes
+      // ~1600 bytes which is smaller than our 'return-broken-stream-after-256K' rule
+      byte[] bytes = DataGenerator.rand(rand).genBytes(_512KiB);
+      uncompressed = ChecksummedTestContent.of(bytes);
+      gzipped = ChecksummedTestContent.of(TestUtils.gzipBytes(bytes));
+    }
+    BlobId id = BlobId.of(bucket.getName(), generator.randomObjectName());
+    BlobInfo info =
+        BlobInfo.newBuilder(id)
+            .setCrc32c(gzipped.getCrc32cBase64())
+            .setContentType("application/vnd.j.bytes")
+            .setContentEncoding("gzip")
+            .build();
+    Blob gen1 = storage.create(info, gzipped.getBytes(), BlobTargetOption.doesNotExist());
+    String uri = gen1.getBlobId().toGsUtilUri();
+    System.out.println("uri = " + uri);
+
+    JsonObject instructions = new JsonObject();
+    JsonArray value = new JsonArray();
+    value.add("return-broken-stream-after-256K");
+    instructions.add("storage.objects.get", value);
+    RetryTestResource retryTestResource = new RetryTestResource(instructions);
+    RetryTestResource retryTest = testBench.createRetryTest(retryTestResource);
+
+    ImmutableMap<String, String> headers = ImmutableMap.of("x-retry-test-id", retryTest.id);
+
+    RequestAuditing requestAuditing = new RequestAuditing();
+    StorageOptions testStorageOptions =
+        baseOptions
+            .toBuilder()
+            .setTransportOptions(requestAuditing)
+            .setHeaderProvider(FixedHeaderProvider.create(headers))
+            .build();
+
+    String expected = xxd(uncompressed.getBytes());
+
+    // explicitly set reader to decompress
+    BlobSourceOption option = BlobSourceOption.shouldReturnRawInputStream(false);
+    try (Storage testStorage = testStorageOptions.getService();
+        ReadChannel r = testStorage.reader(gen1.getBlobId(), option);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        WritableByteChannel w = Channels.newChannel(baos)) {
+      long copy = ByteStreams.copy(r, w);
+      String actual = xxd(baos.toByteArray());
+      ImmutableList<HttpRequest> requests = requestAuditing.getRequests();
+      assertAll(
+          () -> assertThat(copy).isEqualTo(uncompressed.getBytes().length),
+          () -> assertThat(actual).isEqualTo(expected),
+          () -> assertThat(requests.get(0).getHeaders().get("range")).isNull(),
+          () ->
+              assertThat(requests.get(1).getHeaders().get("range"))
+                  .isEqualTo(ImmutableList.of(String.format("bytes=%d-", 256 * 1024))));
     }
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestBench.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestBench.java
@@ -413,7 +413,7 @@ public final class TestBench implements ManagedLifecycle {
     private static final String DEFAULT_GRPC_BASE_URI = "http://localhost:9005";
     private static final String DEFAULT_IMAGE_NAME =
         "gcr.io/cloud-devrel-public-resources/storage-testbench";
-    private static final String DEFAULT_IMAGE_TAG = "v0.32.0";
+    private static final String DEFAULT_IMAGE_TAG = "v0.33.0";
     private static final String DEFAULT_CONTAINER_NAME = "default";
 
     private boolean ignorePullError;

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestBench.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestBench.java
@@ -288,7 +288,7 @@ public final class TestBench implements ManagedLifecycle {
   public void stop() {
     try {
       process.destroy();
-      process.waitFor(5, TimeUnit.SECONDS);
+      process.waitFor(2, TimeUnit.SECONDS);
       boolean attemptForceStopContainer = false;
       try {
         int processExitValue = process.exitValue();
@@ -298,7 +298,6 @@ public final class TestBench implements ManagedLifecycle {
         System.out.println("processExitValue = " + processExitValue);
         LOGGER.warning("Container exit value = " + processExitValue);
       } catch (IllegalThreadStateException e) {
-        e.printStackTrace(System.out);
         attemptForceStopContainer = true;
       }
 


### PR DESCRIPTION
When downloading bytes from gcs and decompressing them, a restart of the stream needs to pickup from the offset within the compressed bytes not the decompressed bytes.

Prior to this change http-client was automatically applying gzip decompression to the stream it returns to us thereby causing our tracking to be off.

This change updates our interaction with http client to always request the raw bytes without any transform applied to them, we then at a higher level can handle whether gzip decompression needs to be plumbed in.

Fix up a couple channel closed state subtleties when buffering is used with decompression.

Add a new test leveraging the testbench which forces a broken stream on some compressed object bytes. _NOTE_ This test depends on the next release of testbench and will be failing until we get that release.

