### PR TITLE
feat: add Storage.BlobWriteOption.{meta,}generation{Not,}Match(long) methods to allow literal value construction

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
@@ -777,12 +777,30 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     }
 
     /**
+     * Returns an option for blob's data generation match. If this option is used the request will
+     * fail if blob's generation does not match the provided value.
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static BlobWriteOption generationMatch(long generation) {
+      return new BlobWriteOption(UnifiedOpts.generationMatch(generation));
+    }
+
+    /**
      * Returns an option for blob's data generation mismatch. If this option is used the request
      * will fail if generation matches.
      */
     @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption generationNotMatch() {
       return new BlobWriteOption(UnifiedOpts.generationNotMatchExtractor());
+    }
+
+    /**
+     * Returns an option for blob's data generation mismatch. If this option is used the request
+     * will fail if blob's generation does not match the provided value.
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static BlobWriteOption generationNotMatch(long generation) {
+      return new BlobWriteOption(UnifiedOpts.generationNotMatch(generation));
     }
 
     /**
@@ -795,12 +813,30 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     }
 
     /**
+     * Returns an option for blob's metageneration match. If this option is used the request will
+     * fail if blob's generation does not match the provided value.
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static BlobWriteOption metagenerationMatch(long metageneration) {
+      return new BlobWriteOption(UnifiedOpts.metagenerationMatch(metageneration));
+    }
+
+    /**
      * Returns an option for blob's metageneration mismatch. If this option is used the request will
      * fail if metageneration matches.
      */
     @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobWriteOption metagenerationNotMatch() {
       return new BlobWriteOption(UnifiedOpts.metagenerationNotMatchExtractor());
+    }
+
+    /**
+     * Returns an option for blob's metageneration mismatch. If this option is used the request will
+     * fail if blob's generation does not match the provided value.
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static BlobWriteOption metagenerationNotMatch(long metageneration) {
+      return new BlobWriteOption(UnifiedOpts.metagenerationNotMatch(metageneration));
     }
 
     /**

--- a/samples/snippets/src/main/java/com/example/storage/object/UploadObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/UploadObject.java
@@ -48,20 +48,20 @@ public class UploadObject {
     // Optional: set a generation-match precondition to avoid potential race
     // conditions and data corruptions. The request returns a 412 error if the
     // preconditions are not met.
-    Storage.BlobTargetOption precondition;
+    Storage.BlobWriteOption precondition;
     if (storage.get(bucketName, objectName) == null) {
       // For a target object that does not yet exist, set the DoesNotExist precondition.
       // This will cause the request to fail if the object is created before the request runs.
-      precondition = Storage.BlobTargetOption.doesNotExist();
+      precondition = Storage.BlobWriteOption.doesNotExist();
     } else {
       // If the destination already exists in your bucket, instead set a generation-match
       // precondition. This will cause the request to fail if the existing object's generation
       // changes before the request runs.
       precondition =
-          Storage.BlobTargetOption.generationMatch(
+          Storage.BlobWriteOption.generationMatch(
               storage.get(bucketName, objectName).getGeneration());
     }
-    storage.create(blobInfo, Files.readAllBytes(Paths.get(filePath)), precondition);
+    storage.createFrom(blobInfo, Paths.get(filePath), precondition);
 
     System.out.println(
         "File " + filePath + " uploaded to bucket " + bucketName + " as " + objectName);


### PR DESCRIPTION

#### New Methods
* com.google.cloud.storage.Storage.BlobWriteOption.generationMatch(long)
* com.google.cloud.storage.Storage.BlobWriteOption.generationNotMatch(long)
* com.google.cloud.storage.Storage.BlobWriteOption.metagenerationMatch(long)
* com.google.cloud.storage.Storage.BlobWriteOption.metagenerationNotMatch(long)

Update UploadObject sample to use createFrom rather than trying to read the entire file into memory.


