### PR TITLE
test: update ObjectsFixture to allow discrimination by @BucketFixture

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/BackendResources.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/BackendResources.java
@@ -47,6 +47,7 @@ final class BackendResources implements ManagedLifecycle {
       TestRunScopedInstance<BucketInfoShim> bucket,
       TestRunScopedInstance<BucketInfoShim> bucketRequesterPays,
       TestRunScopedInstance<ObjectsFixture> objectsFixture,
+      TestRunScopedInstance<ObjectsFixture> objectsFixtureRequesterPays,
       TestRunScopedInstance<KmsFixture> kmsFixture) {
     this.backend = backend;
     this.protectedBucketNames = protectedBucketNames;
@@ -63,8 +64,14 @@ final class BackendResources implements ManagedLifecycle {
                 backendIs(backend).and(isRequesterPaysBucket())),
             RegistryEntry.of(
                 7, BucketInfo.class, bucket, backendIs(backend).and(isDefaultBucket())),
-            RegistryEntry.of(8, ObjectsFixture.class, objectsFixture, backendIs(backend)),
-            RegistryEntry.of(9, KmsFixture.class, kmsFixture, backendIs(backend)));
+            RegistryEntry.of(
+                8, ObjectsFixture.class, objectsFixture, backendIs(backend).and(isDefaultBucket())),
+            RegistryEntry.of(
+                9,
+                ObjectsFixture.class,
+                objectsFixtureRequesterPays,
+                backendIs(backend).and(isRequesterPaysBucket())),
+            RegistryEntry.of(10, KmsFixture.class, kmsFixture, backendIs(backend)));
   }
 
   public ImmutableList<RegistryEntry<?>> getRegistryEntries() {
@@ -141,6 +148,11 @@ final class BackendResources implements ManagedLifecycle {
         TestRunScopedInstance.of(
             "OBJECTS_FIXTURE_" + backend.name(),
             () -> new ObjectsFixture(storageJson.get().getStorage(), bucket.get().getBucketInfo()));
+    TestRunScopedInstance<ObjectsFixture> objectsFixtureRequesterPays =
+        TestRunScopedInstance.of(
+            "OBJECTS_FIXTURE_REQUESTER_PAYS_" + backend.name(),
+            () ->
+                new ObjectsFixture(storageJson.get().getStorage(), bucketRp.get().getBucketInfo()));
     TestRunScopedInstance<KmsFixture> kmsFixture =
         TestRunScopedInstance.of(
             "KMS_FIXTURE_" + backend.name(), () -> KmsFixture.of(storageJson.get().getStorage()));
@@ -153,6 +165,7 @@ final class BackendResources implements ManagedLifecycle {
         bucket,
         bucketRp,
         objectsFixture,
+        objectsFixtureRequesterPays,
         kmsFixture);
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/ObjectsFixture.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/ObjectsFixture.java
@@ -22,6 +22,7 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.DataGenerator;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobGetOption;
 import com.google.cloud.storage.Storage.BlobTargetOption;
 import com.google.cloud.storage.Storage.ComposeRequest;
 import com.google.cloud.storage.it.ChecksummedTestContent;
@@ -34,6 +35,9 @@ public final class ObjectsFixture implements ManagedLifecycle {
   private final Storage s;
   private final BucketInfo bucket;
 
+  private final BlobTargetOption[] blobTargetOptions;
+  private final BlobGetOption[] blobGetOptions;
+
   private BlobInfo info1;
   private BlobInfo info2;
   private BlobInfo info3;
@@ -43,6 +47,21 @@ public final class ObjectsFixture implements ManagedLifecycle {
   ObjectsFixture(Storage s, BucketInfo bucket) {
     this.s = s;
     this.bucket = bucket;
+    boolean isRequesterPays = Boolean.TRUE.equals(bucket.requesterPays());
+    String projectId = s.getOptions().getProjectId();
+    if (isRequesterPays) {
+      blobTargetOptions =
+          new BlobTargetOption[] {
+            BlobTargetOption.doesNotExist(), BlobTargetOption.userProject(projectId)
+          };
+    } else {
+      blobTargetOptions = new BlobTargetOption[] {BlobTargetOption.doesNotExist()};
+    }
+    if (isRequesterPays) {
+      blobGetOptions = new BlobGetOption[] {BlobGetOption.userProject(projectId)};
+    } else {
+      blobGetOptions = new BlobGetOption[] {};
+    }
   }
 
   @Override
@@ -83,41 +102,38 @@ public final class ObjectsFixture implements ManagedLifecycle {
     BlobInfo info2 = BlobInfo.newBuilder(blobId2).setMetadata(ImmutableMap.of("pow", "2")).build();
     BlobInfo info3 = BlobInfo.newBuilder(blobId3).setMetadata(ImmutableMap.of("pow", "3")).build();
     BlobInfo info4 = BlobInfo.newBuilder(blobId4).setMetadata(ImmutableMap.of("pow", "4")).build();
-    s.create(info1, "A".getBytes(StandardCharsets.UTF_8), BlobTargetOption.doesNotExist());
+    s.create(info1, "A".getBytes(StandardCharsets.UTF_8), blobTargetOptions);
 
     ComposeRequest c2 =
         ComposeRequest.newBuilder()
             .addSource(blobId1.getName(), blobId1.getName())
             .setTarget(info2)
-            .setTargetOptions(BlobTargetOption.doesNotExist())
+            .setTargetOptions(blobTargetOptions)
             .build();
     ComposeRequest c3 =
         ComposeRequest.newBuilder()
             .addSource(blobId2.getName(), blobId2.getName())
             .setTarget(info3)
-            .setTargetOptions(BlobTargetOption.doesNotExist())
+            .setTargetOptions(blobTargetOptions)
             .build();
     ComposeRequest c4 =
         ComposeRequest.newBuilder()
             .addSource(blobId3.getName(), blobId3.getName())
             .setTarget(info4)
-            .setTargetOptions(BlobTargetOption.doesNotExist())
+            .setTargetOptions(blobTargetOptions)
             .build();
     s.compose(c2);
     s.compose(c3);
     s.compose(c4);
 
-    this.info1 = s.get(blobId1).asBlobInfo();
-    this.info2 = s.get(blobId2).asBlobInfo();
-    this.info3 = s.get(blobId3).asBlobInfo();
-    this.info4 = s.get(blobId4).asBlobInfo();
+    this.info1 = s.get(blobId1, blobGetOptions).asBlobInfo();
+    this.info2 = s.get(blobId2, blobGetOptions).asBlobInfo();
+    this.info3 = s.get(blobId3, blobGetOptions).asBlobInfo();
+    this.info4 = s.get(blobId4, blobGetOptions).asBlobInfo();
 
     byte[] bytes = DataGenerator.base64Characters().genBytes(512 * 1024);
     Blob obj512KiB =
-        s.create(
-            BlobInfo.newBuilder(bucket, "obj512KiB").build(),
-            bytes,
-            BlobTargetOption.doesNotExist());
+        s.create(BlobInfo.newBuilder(bucket, "obj512KiB").build(), bytes, blobTargetOptions);
     this.obj512KiB = new ObjectAndContent(obj512KiB.asBlobInfo(), ChecksummedTestContent.of(bytes));
   }
 


### PR DESCRIPTION
Sometimes it's useful to specify that the ObjectsFixture should use the RequesterPays bucket

This change is needed from a followup PR which performs some operations on a requester pays bucket, but itself does not need to create objects.
