### PR TITLE
fix: update bucket creation to set project as `bucket.project`

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcConversions.java
@@ -209,7 +209,7 @@ final class GrpcConversions {
 
   private BucketInfo bucketInfoDecode(Bucket from) {
     BucketInfo.Builder to = new BucketInfo.BuilderImpl(bucketNameCodec.decode(from.getName()));
-    to.setProject(from.getProject());
+    to.setProject(projectNameCodec.decode(from.getProject()));
     to.setGeneratedId(from.getBucketId());
     maybeDecodeRetentionPolicy(from, to);
     ifNonNull(from.getLocation(), to::setLocation);
@@ -302,6 +302,7 @@ final class GrpcConversions {
   private Bucket bucketInfoEncode(BucketInfo from) {
     Bucket.Builder to = Bucket.newBuilder();
     to.setName(bucketNameCodec.encode(from.getName()));
+    ifNonNull(from.getProject(), projectNameCodec::encode, to::setProject);
     ifNonNull(from.getGeneratedId(), to::setBucketId);
     maybeEncodeRetentionPolicy(from, to);
     ifNonNull(from.getLocation(), to::setLocation);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -99,7 +99,6 @@ import com.google.storage.v2.LockBucketRetentionPolicyRequest;
 import com.google.storage.v2.Object;
 import com.google.storage.v2.ObjectAccessControl;
 import com.google.storage.v2.ObjectChecksums;
-import com.google.storage.v2.ProjectName;
 import com.google.storage.v2.ReadObjectRequest;
 import com.google.storage.v2.RewriteObjectRequest;
 import com.google.storage.v2.RewriteResponse;
@@ -190,12 +189,15 @@ final class GrpcStorageImpl extends BaseService<StorageOptions> implements Stora
     Opts<BucketTargetOpt> opts = Opts.unwrap(options).resolveFrom(bucketInfo).prepend(defaultOpts);
     GrpcCallContext grpcCallContext =
         opts.grpcMetadataMapper().apply(GrpcCallContext.createDefault());
+    if (bucketInfo.getProject() == null || bucketInfo.getProject().trim().isEmpty()) {
+      bucketInfo = bucketInfo.toBuilder().setProject(getOptions().getProjectId()).build();
+    }
     com.google.storage.v2.Bucket bucket = codecs.bucketInfo().encode(bucketInfo);
     CreateBucketRequest.Builder builder =
         CreateBucketRequest.newBuilder()
             .setBucket(bucket)
             .setBucketId(bucketInfo.getName())
-            .setParent(ProjectName.format(getOptions().getProjectId()));
+            .setParent("projects/_");
     CreateBucketRequest req = opts.createBucketsRequest().apply(builder).build();
     return Retrying.run(
         getOptions(),

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestBench.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestBench.java
@@ -413,7 +413,7 @@ public final class TestBench implements ManagedLifecycle {
     private static final String DEFAULT_GRPC_BASE_URI = "http://localhost:9005";
     private static final String DEFAULT_IMAGE_NAME =
         "gcr.io/cloud-devrel-public-resources/storage-testbench";
-    private static final String DEFAULT_IMAGE_TAG = "v0.33.0";
+    private static final String DEFAULT_IMAGE_TAG = "v0.35.0";
     private static final String DEFAULT_CONTAINER_NAME = "default";
 
     private boolean ignorePullError;

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/jqwik/BucketArbitraryProvider.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/jqwik/BucketArbitraryProvider.java
@@ -18,8 +18,10 @@ package com.google.cloud.storage.jqwik;
 
 import static com.google.cloud.storage.PackagePrivateMethodWorkarounds.ifNonNull;
 
+import com.google.cloud.storage.jqwik.StorageArbitraries.ProjectID;
 import com.google.storage.v2.Bucket;
 import com.google.storage.v2.BucketName;
+import com.google.storage.v2.ProjectName;
 import java.util.Collections;
 import java.util.Set;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -72,9 +74,15 @@ public final class BucketArbitraryProvider implements ArbitraryProvider {
                         StorageArbitraries.buckets().iamConfig().injectNull(0.5),
                         StorageArbitraries.buckets().labels(),
                         StorageArbitraries.etag())
+                    .as(Tuple::of),
+                Combinators.combine(
+                        StorageArbitraries.projectID().map(ProjectID::toProjectName),
+                        StorageArbitraries
+                            .alnum() // ignored for now, tuples can't be a single element
+                        )
                     .as(Tuple::of))
             .as(
-                (t1, t2, t3) -> {
+                (t1, t2, t3, t4) -> {
                   Bucket.Builder b = Bucket.newBuilder();
                   ifNonNull(t1.get1(), BucketName::getBucket, b::setBucketId);
                   ifNonNull(t1.get2(), BucketName::toString, b::setName);
@@ -100,6 +108,7 @@ public final class BucketArbitraryProvider implements ArbitraryProvider {
                   ifNonNull(t3.get6(), b::setIamConfig);
                   ifNonNull(t3.get7(), b::putAllLabels);
                   ifNonNull(t3.get8(), b::setEtag);
+                  ifNonNull(t4.get1(), ProjectName::toString, b::setProject);
                   // TODO: add CustomPlacementConfig
                   return b.build();
                 });

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/jqwik/StorageArbitraries.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/jqwik/StorageArbitraries.java
@@ -37,6 +37,7 @@ import com.google.storage.v2.CustomerEncryption;
 import com.google.storage.v2.ObjectAccessControl;
 import com.google.storage.v2.ObjectChecksums;
 import com.google.storage.v2.Owner;
+import com.google.storage.v2.ProjectName;
 import com.google.storage.v2.ProjectTeam;
 import com.google.type.Date;
 import java.math.BigInteger;
@@ -436,6 +437,10 @@ public final class StorageArbitraries {
 
     public String get() {
       return value;
+    }
+
+    public ProjectName toProjectName() {
+      return ProjectName.of(value);
     }
   }
 


### PR DESCRIPTION
Creation of a bucket is modifying which field is used to specify the project a bucket is associated with. Changing from `parent` to `bucket.project`. This change updates our handling to use this new field.

The existing `parent` is set to the sentinel value `projects/_` which was previously only implicitly found in the bucket name.

Update testbench tag to v0.35.0 which includes the new field behavior.

ApiaryConversions have been updated to track the project attribute when cross converting as the property `.x_project`; this value should avoid any possible collision if the field name project is supported in the future while the client is operating in this intervening time. If/when StorageObject receives its own project field we should switch to using it.

Fix associated with b/254678990

This PR is a preemptive fix for the change which will rollout to fix http://b/254678990
