### PR TITLE
feat: Apply BlobWriteOptions to UploadMany operations

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerImpl.java
@@ -44,8 +44,7 @@ public final class TransferManagerImpl implements TransferManager {
       if (Files.isDirectory(file)) throw new IllegalStateException("Directories are not supported");
       String blobName = TransferManagerUtils.createBlobName(opts, file);
       BlobInfo blobInfo = BlobInfo.newBuilder(opts.getBucketName(), blobName).build();
-      // TODO: Apply opts per request
-      UploadCallable callable = new UploadCallable(transferManagerConfig, blobInfo, file);
+      UploadCallable callable = new UploadCallable(transferManagerConfig, blobInfo, file, opts);
       uploadTasks.add(executor.submit(callable));
     }
     return UploadJob.newBuilder()


### PR DESCRIPTION
Small PR to add BlobWriteOptions to UploadMany operations, for downloadMany this was included in the first pass but was left out of the first pass for UploadMany. 

See: https://github.com/googleapis/java-storage/pull/1945
