### PR TITLE
feat: make it possible to disable the buffer of ReadChannels returned from Storage.reader

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/LazyReadChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/LazyReadChannel.java
@@ -16,26 +16,26 @@
 
 package com.google.cloud.storage;
 
-import com.google.cloud.storage.BufferedReadableByteChannelSession.BufferedReadableByteChannel;
+import java.nio.channels.ReadableByteChannel;
 import java.util.function.Supplier;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-final class LazyReadChannel<T> {
+final class LazyReadChannel<RBC extends ReadableByteChannel, T> {
 
-  private final Supplier<BufferedReadableByteChannelSession<T>> sessionSupplier;
+  private final Supplier<ReadableByteChannelSession<RBC, T>> sessionSupplier;
 
-  @MonotonicNonNull private volatile BufferedReadableByteChannelSession<T> session;
-  @MonotonicNonNull private volatile BufferedReadableByteChannel channel;
+  @MonotonicNonNull private volatile ReadableByteChannelSession<RBC, T> session;
+  @MonotonicNonNull private volatile RBC channel;
 
   private boolean open = false;
 
-  LazyReadChannel(Supplier<BufferedReadableByteChannelSession<T>> sessionSupplier) {
+  LazyReadChannel(Supplier<ReadableByteChannelSession<RBC, T>> sessionSupplier) {
     this.sessionSupplier = sessionSupplier;
   }
 
   @NonNull
-  BufferedReadableByteChannel getChannel() {
+  RBC getChannel() {
     if (channel != null) {
       return channel;
     } else {
@@ -50,7 +50,7 @@ final class LazyReadChannel<T> {
   }
 
   @NonNull
-  BufferedReadableByteChannelSession<T> getSession() {
+  ReadableByteChannelSession<RBC, T> getSession() {
     if (session != null) {
       return session;
     } else {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/LazyReadChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/LazyReadChannelTest.java
@@ -34,16 +34,18 @@ public final class LazyReadChannelTest {
 
   @Test
   public void repeatedCallsOfGetSessionMustReturnTheSameInstance() {
-    LazyReadChannel<String> lrc = new LazyReadChannel<>(this::newTestSession);
+    LazyReadChannel<BufferedReadableByteChannel, String> lrc =
+        new LazyReadChannel<>(this::newTestSession);
 
-    BufferedReadableByteChannelSession<String> session1 = lrc.getSession();
-    BufferedReadableByteChannelSession<String> session2 = lrc.getSession();
+    ReadableByteChannelSession<BufferedReadableByteChannel, String> session1 = lrc.getSession();
+    ReadableByteChannelSession<BufferedReadableByteChannel, String> session2 = lrc.getSession();
     assertThat(session1).isSameInstanceAs(session2);
   }
 
   @Test
   public void repeatedCallsOfGetChannelMustReturnTheSameInstance() {
-    LazyReadChannel<String> lrc = new LazyReadChannel<>(this::newTestSession);
+    LazyReadChannel<BufferedReadableByteChannel, String> lrc =
+        new LazyReadChannel<>(this::newTestSession);
 
     BufferedReadableByteChannel channel1 = lrc.getChannel();
     BufferedReadableByteChannel channel2 = lrc.getChannel();
@@ -52,7 +54,8 @@ public final class LazyReadChannelTest {
 
   @Test
   public void isNotOpenUntilGetChannelIsCalled() {
-    LazyReadChannel<String> lrc = new LazyReadChannel<>(this::newTestSession);
+    LazyReadChannel<BufferedReadableByteChannel, String> lrc =
+        new LazyReadChannel<>(this::newTestSession);
 
     assertThat(lrc.isOpen()).isFalse();
     BufferedReadableByteChannel channel = lrc.getChannel();
@@ -63,7 +66,8 @@ public final class LazyReadChannelTest {
 
   @Test
   public void closingUnderlyingChannelClosesTheLazyReadChannel() throws IOException {
-    LazyReadChannel<String> lrc = new LazyReadChannel<>(this::newTestSession);
+    LazyReadChannel<BufferedReadableByteChannel, String> lrc =
+        new LazyReadChannel<>(this::newTestSession);
 
     BufferedReadableByteChannel channel = lrc.getChannel();
     assertThat(channel.isOpen()).isTrue();


### PR DESCRIPTION
For some scenarios, an external client needs the ability to manage buffer blocking itself. To support this, providing 0 to ReadChannel#setChunkSize will disable buffering allowing for client to avoid the need to alight multiple levels of buffer alignments.

Because the buffering is disabled, that means reads can be much more variable in size and individually more impacted by small network latencies (with buffering these can be amortized by the buffer making followup read faster). This is considered advanced usage and will require more work from the client integrator.

