### PR TITLE
fix: make Blob and Bucket update diff aware

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
@@ -2328,6 +2328,16 @@ final class UnifiedOpts {
       return new Opts<>(list);
     }
 
+    /**
+     * Create a new instance of {@code Opts<R>} consisting of those {@code Opt}s which are also an
+     * {@code R}.
+     *
+     * <p>i.e. Given {@code Opts<ObjectTargetOpt>} produce {@code Opts<ObjectSourceOpt>}
+     */
+    <R extends Opt> Opts<R> constrainTo(Class<R> c) {
+      return new Opts<>(filterTo(c).collect(ImmutableList.toImmutableList()));
+    }
+
     private Mapper<ImmutableMap.Builder<StorageRpc.Option, Object>> rpcOptionMapper() {
       return fuseMappers(RpcOptVal.class, RpcOptVal::mapper);
     }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectTest.java
@@ -1497,4 +1497,15 @@ public class ITObjectTest {
         .isEqualTo(updatedBlob1.getTimeStorageClassUpdated());
     assertThat(updatedBlob2.delete()).isTrue();
   }
+
+  @Test
+  public void testUpdateBlob_noModification() {
+    BlobInfo info = BlobInfo.newBuilder(bucket, generator.randomObjectName()).build();
+
+    // in grpc, create will return acls but update does not. re-get the metadata with default fields
+    Blob gen1 = storage.create(info);
+    gen1 = storage.get(gen1.getBlobId());
+    Blob gen2 = storage.update(gen1);
+    assertThat(gen2).isEqualTo(gen1);
+  }
 }


### PR DESCRIPTION
If a Blob or Bucket update does not actually contain a diff, instead of sending the empty update refresh the metadata.

Add integration tests to verify behavior of updating object or bucket with no modification


