### PR TITLE
chore(deps): update ghcr.io/graalvm/graalvm-ce docker tag to v22.3.2

### DIFF
--- a/.kokoro/presubmit/graalvm-native-17.cfg
+++ b/.kokoro/presubmit/graalvm-native-17.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.0"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.2"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native.cfg
+++ b/.kokoro/presubmit/graalvm-native.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.0"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.2"
 }
 
 env_vars: {


### PR DESCRIPTION
Update was made in synthtool (https://github.com/googleapis/synthtool/pull/1793) but not propagated to java-storage because of [owlbot exclusion](https://github.com/googleapis/java-storage/blob/f745562c207faec4ce0411683d9dd41d99f787a5/owlbot.py#L30). 
