### PR TITLE
chore: attempt to make TestBench docker image renovateable

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/SneakyException.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/SneakyException.java
@@ -23,7 +23,7 @@ package com.google.cloud.storage.it.runner;
  * <p>This class provides some utility methods to sneakily (not method declared) throw exceptions
  * and later unwrap any sneakily wrapped exception if it's needed.
  */
-final class SneakyException extends RuntimeException {
+public final class SneakyException extends RuntimeException {
 
   public SneakyException(Throwable cause) {
     super(cause);

--- a/google-cloud-storage/src/test/resources/com/google/cloud/storage/it/runner/registry/Dockerfile
+++ b/google-cloud-storage/src/test/resources/com/google/cloud/storage/it/runner/registry/Dockerfile
@@ -1,0 +1,1 @@
+FROM gcr.io/cloud-devrel-public-resources/storage-testbench:v0.35.0


### PR DESCRIPTION
Renovate-bot does not look into java files for docker images. Add a Dockerfile into our test resources that is loaded on TestBench class initialization.


