### PR TITLE
fix: validateBlob failure fallsback to direct download

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerImpl.java
@@ -99,7 +99,8 @@ final class TransferManagerImpl implements TransferManager {
                   .build();
 
           List<ApiFuture<DownloadSegment>> downloadSegmentTasks =
-              computeRanges(validatedBlob.getSize(), transferManagerConfig.getPerWorkerBufferSize()).stream()
+              computeRanges(validatedBlob.getSize(), transferManagerConfig.getPerWorkerBufferSize())
+                  .stream()
                   .map(
                       r ->
                           new ChunkedDownloadCallable(

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerImpl.java
@@ -91,17 +91,15 @@ final class TransferManagerImpl implements TransferManager {
     } else {
       for (BlobInfo blob : blobs) {
         BlobInfo validatedBlob = retrieveSizeAndGeneration(storage, blob, config.getBucketName());
-        Path destPath = TransferManagerUtils.createDestPath(config, validatedBlob);
-        long size = validatedBlob.getSize();
-        if (qos.divideAndConquer(size)) {
-
+        Path destPath = TransferManagerUtils.createDestPath(config, blob);
+        if (validatedBlob != null && qos.divideAndConquer(validatedBlob.getSize())) {
           DownloadResult optimisticResult =
               DownloadResult.newBuilder(validatedBlob, TransferStatus.SUCCESS)
                   .setOutputDestination(destPath)
                   .build();
 
           List<ApiFuture<DownloadSegment>> downloadSegmentTasks =
-              computeRanges(size, transferManagerConfig.getPerWorkerBufferSize()).stream()
+              computeRanges(validatedBlob.getSize(), transferManagerConfig.getPerWorkerBufferSize()).stream()
                   .map(
                       r ->
                           new ChunkedDownloadCallable(

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
@@ -65,7 +65,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(StorageITRunner.class)
 @CrossRun(
-    transports = {Transport.HTTP, Transport.GRPC},
+    transports = {Transport.HTTP},
     backends = {Backend.PROD})
 public class ITTransferManagerTest {
 


### PR DESCRIPTION
If we are unable to get information about a blob (ie. if the get call fails) we should still try and download the blob but we can simply do a direct download. This actually was causing the integration tests to fail with an NPE however in previous PRs these tests were not configured to run.