### PR TITLE
feat: Resolve API futures on getDownload/UploadResults calls

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/DownloadJob.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/DownloadJob.java
@@ -19,6 +19,8 @@ package com.google.cloud.storage.transfermanager;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.rpc.ApiExceptions;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
@@ -39,8 +41,8 @@ public final class DownloadJob {
     this.parallelDownloadConfig = parallelDownloadConfig;
   }
 
-  public @NonNull List<ApiFuture<DownloadResult>> getDownloadResults() {
-    return downloadResults;
+  public @NonNull List<DownloadResult> getDownloadResults() {
+    return ApiExceptions.callAndTranslateApiException(ApiFutures.allAsList(downloadResults));
   }
 
   public @NonNull ParallelDownloadConfig getParallelDownloadConfig() {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/UploadJob.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/UploadJob.java
@@ -19,6 +19,8 @@ package com.google.cloud.storage.transfermanager;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.rpc.ApiExceptions;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
@@ -28,19 +30,19 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 
 public final class UploadJob {
 
-  @NonNull private final List<ApiFuture<UploadResult>> uploadResponses;
+  @NonNull private final List<ApiFuture<UploadResult>> uploadResults;
 
   @NonNull private final ParallelUploadConfig parallelUploadConfig;
 
   private UploadJob(
-      @NonNull List<ApiFuture<UploadResult>> successResponses,
+      @NonNull List<ApiFuture<UploadResult>> uploadResults,
       @NonNull ParallelUploadConfig parallelUploadConfig) {
-    this.uploadResponses = successResponses;
+    this.uploadResults = uploadResults;
     this.parallelUploadConfig = parallelUploadConfig;
   }
 
-  public List<ApiFuture<UploadResult>> getUploadResponses() {
-    return uploadResponses;
+  public List<UploadResult> getUploadResults() {
+    return ApiExceptions.callAndTranslateApiException(ApiFutures.allAsList(uploadResults));
   }
 
   public ParallelUploadConfig getParallelUploadConfig() {
@@ -56,19 +58,19 @@ public final class UploadJob {
       return false;
     }
     UploadJob uploadJob = (UploadJob) o;
-    return uploadResponses.equals(uploadJob.uploadResponses)
+    return uploadResults.equals(uploadJob.uploadResults)
         && parallelUploadConfig.equals(uploadJob.parallelUploadConfig);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(uploadResponses, parallelUploadConfig);
+    return Objects.hash(uploadResults, parallelUploadConfig);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("successResponses", uploadResponses)
+        .add("uploadResults", uploadResults)
         .add("parallelUploadConfig", parallelUploadConfig)
         .toString();
   }
@@ -79,16 +81,16 @@ public final class UploadJob {
 
   public static final class Builder {
 
-    private @NonNull List<ApiFuture<UploadResult>> uploadResponses;
+    private @NonNull List<ApiFuture<UploadResult>> uploadResults;
 
     private @MonotonicNonNull ParallelUploadConfig parallelUploadConfig;
 
     private Builder() {
-      this.uploadResponses = ImmutableList.of();
+      this.uploadResults = ImmutableList.of();
     }
 
-    public Builder setUploadResponses(@NonNull List<ApiFuture<UploadResult>> uploadResponses) {
-      this.uploadResponses = ImmutableList.copyOf(uploadResponses);
+    public Builder setUploadResponses(@NonNull List<ApiFuture<UploadResult>> uploadResults) {
+      this.uploadResults = ImmutableList.copyOf(uploadResults);
       return this;
     }
 
@@ -98,9 +100,9 @@ public final class UploadJob {
     }
 
     public UploadJob build() {
-      checkNotNull(uploadResponses);
+      checkNotNull(uploadResults);
       checkNotNull(parallelUploadConfig);
-      return new UploadJob(uploadResponses, parallelUploadConfig);
+      return new UploadJob(uploadResults, parallelUploadConfig);
     }
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
@@ -316,7 +316,7 @@ public class ITTransferManagerTest {
               .setOptionsPerRequest(ImmutableList.of(BlobSourceOption.generationMatch(-1)))
               .build();
       DownloadJob job = transferManager.downloadBlobs(blobs, parallelDownloadConfig);
-      List<DownloadResult> downloadResults = ApiFutures.allAsList(job.getDownloadResults()).get();
+      List<DownloadResult> downloadResults = job.getDownloadResults();
       assertThat(downloadResults).hasSize(3);
       List<DownloadResult> failedToStart =
           downloadResults.stream()

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
@@ -18,7 +18,6 @@ package com.google.cloud.storage.it;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.api.core.ApiFutures;
 import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -130,7 +129,7 @@ public class ITTransferManagerTest {
       ParallelUploadConfig parallelUploadConfig =
           ParallelUploadConfig.newBuilder().setBucketName(bucketName).build();
       UploadJob job = transferManager.uploadFiles(files, parallelUploadConfig);
-      List<UploadResult> uploadResults = ApiFutures.allAsList(job.getUploadResponses()).get();
+      List<UploadResult> uploadResults = job.getUploadResults();
       assertThat(uploadResults).hasSize(3);
     }
   }
@@ -152,7 +151,7 @@ public class ITTransferManagerTest {
               .setWriteOptsPerRequest(Collections.singletonList(BlobWriteOption.doesNotExist()))
               .build();
       UploadJob job = transferManager.uploadFiles(files, parallelUploadConfig);
-      List<UploadResult> uploadResults = ApiFutures.allAsList(job.getUploadResponses()).get();
+      List<UploadResult> uploadResults = job.getUploadResults();
       assertThat(uploadResults).hasSize(3);
     }
   }
@@ -169,7 +168,7 @@ public class ITTransferManagerTest {
               .setDownloadDirectory(baseDir)
               .build();
       DownloadJob job = transferManager.downloadBlobs(blobs, parallelDownloadConfig);
-      List<DownloadResult> downloadResults = ApiFutures.allAsList(job.getDownloadResults()).get();
+      List<DownloadResult> downloadResults = job.getDownloadResults();
       try {
         assertThat(downloadResults).hasSize(3);
       } finally {
@@ -194,7 +193,7 @@ public class ITTransferManagerTest {
               .setDownloadDirectory(baseDir)
               .build();
       DownloadJob job = transferManager.downloadBlobs(blobs, parallelDownloadConfig);
-      List<DownloadResult> downloadResults = ApiFutures.allAsList(job.getDownloadResults()).get();
+      List<DownloadResult> downloadResults = job.getDownloadResults();
       assertThat(downloadResults).hasSize(3);
 
       List<String> expectedContents =
@@ -232,7 +231,7 @@ public class ITTransferManagerTest {
       ParallelUploadConfig parallelUploadConfig =
           ParallelUploadConfig.newBuilder().setBucketName(bucketName).build();
       UploadJob job = transferManager.uploadFiles(files, parallelUploadConfig);
-      List<UploadResult> uploadResults = ApiFutures.allAsList(job.getUploadResponses()).get();
+      List<UploadResult> uploadResults = job.getUploadResults();
       assertThat(uploadResults.get(0).getStatus()).isEqualTo(TransferStatus.FAILED_TO_START);
       assertThat(uploadResults.get(0).getException()).isInstanceOf(StorageException.class);
     }
@@ -248,7 +247,7 @@ public class ITTransferManagerTest {
       ParallelUploadConfig parallelUploadConfig =
           ParallelUploadConfig.newBuilder().setBucketName(bucketName).build();
       UploadJob job = transferManager.uploadFiles(files, parallelUploadConfig);
-      List<UploadResult> uploadResults = ApiFutures.allAsList(job.getUploadResponses()).get();
+      List<UploadResult> uploadResults = job.getUploadResults();
       assertThat(uploadResults.get(0).getStatus()).isEqualTo(TransferStatus.FAILED_TO_START);
       assertThat(uploadResults.get(0).getException()).isInstanceOf(NoSuchFileException.class);
     }
@@ -266,7 +265,7 @@ public class ITTransferManagerTest {
               .setDownloadDirectory(baseDir)
               .build();
       DownloadJob job = transferManager.downloadBlobs(blobs, parallelDownloadConfig);
-      List<DownloadResult> downloadResults = ApiFutures.allAsList(job.getDownloadResults()).get();
+      List<DownloadResult> downloadResults = job.getDownloadResults();
       List<DownloadResult> failedToStart =
           downloadResults.stream()
               .filter(x -> x.getStatus() == TransferStatus.FAILED_TO_START)
@@ -291,7 +290,7 @@ public class ITTransferManagerTest {
               .setDownloadDirectory(baseDir)
               .build();
       DownloadJob job = transferManager.downloadBlobs(blobs, parallelDownloadConfig);
-      List<DownloadResult> downloadResults = ApiFutures.allAsList(job.getDownloadResults()).get();
+      List<DownloadResult> downloadResults = job.getDownloadResults();
       assertThat(downloadResults).hasSize(3);
       List<DownloadResult> failedToStart =
           downloadResults.stream()


### PR DESCRIPTION
For the public API we will resolve the API Futures and return the result (ie. await the resolution and return the result). 