### PR TITLE
test(samples): update ITBucketSnippets to apply retries to update result assertions

### DIFF
--- a/samples/snippets/src/main/java/com/example/storage/bucket/DisableDefaultEventBasedHold.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DisableDefaultEventBasedHold.java
@@ -18,8 +18,9 @@ package com.example.storage.bucket;
 
 // [START storage_disable_default_event_based_hold]
 
-import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BucketTargetOption;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
@@ -33,7 +34,11 @@ public class DisableDefaultEventBasedHold {
     // String bucketName = "your-unique-bucket-name";
 
     Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
-    storage.update(BucketInfo.newBuilder(bucketName).setDefaultEventBasedHold(false).build());
+    // first look up the bucket, so we will have its metageneration
+    Bucket bucket = storage.get(bucketName);
+    storage.update(
+        bucket.toBuilder().setDefaultEventBasedHold(false).build(),
+        BucketTargetOption.metagenerationMatch());
 
     System.out.println("Default event-based hold was disabled for " + bucketName);
   }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/DisableLifecycleManagement.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DisableLifecycleManagement.java
@@ -19,6 +19,7 @@ package com.example.storage.bucket;
 // [START storage_disable_bucket_lifecycle_management]
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BucketTargetOption;
 import com.google.cloud.storage.StorageOptions;
 
 public class DisableLifecycleManagement {
@@ -30,8 +31,11 @@ public class DisableLifecycleManagement {
     // String bucketName = "your-unique-bucket-name";
 
     Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    // first look up the bucket, so we will have its metageneration
     Bucket bucket = storage.get(bucketName);
-    bucket.toBuilder().deleteLifecycleRules().build().update();
+    storage.update(
+        bucket.toBuilder().deleteLifecycleRules().build(),
+        BucketTargetOption.metagenerationMatch());
 
     System.out.println("Lifecycle management was disabled for bucket " + bucketName);
   }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/DisableUniformBucketLevelAccess.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DisableUniformBucketLevelAccess.java
@@ -18,8 +18,10 @@ package com.example.storage.bucket;
 
 // [START storage_disable_uniform_bucket_level_access]
 
+import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BucketTargetOption;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
@@ -33,12 +35,18 @@ public class DisableUniformBucketLevelAccess {
     // String bucketName = "your-unique-bucket-name";
 
     Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+
+    // first look up the bucket, so we will have its metageneration
+    Bucket bucket = storage.get(bucketName);
+
     BucketInfo.IamConfiguration iamConfiguration =
         BucketInfo.IamConfiguration.newBuilder()
             .setIsUniformBucketLevelAccessEnabled(false)
             .build();
 
-    storage.update(BucketInfo.newBuilder(bucketName).setIamConfiguration(iamConfiguration).build());
+    storage.update(
+        bucket.toBuilder().setIamConfiguration(iamConfiguration).build(),
+        BucketTargetOption.metagenerationMatch());
 
     System.out.println("Uniform bucket-level access was disabled for " + bucketName);
   }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/EnableDefaultEventBasedHold.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/EnableDefaultEventBasedHold.java
@@ -18,8 +18,9 @@ package com.example.storage.bucket;
 
 // [START storage_enable_default_event_based_hold]
 
-import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BucketTargetOption;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
@@ -33,7 +34,11 @@ public class EnableDefaultEventBasedHold {
     // String bucketName = "your-unique-bucket-name";
 
     Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
-    storage.update(BucketInfo.newBuilder(bucketName).setDefaultEventBasedHold(true).build());
+    // first look up the bucket, so we will have its metageneration
+    Bucket bucket = storage.get(bucketName);
+    storage.update(
+        bucket.toBuilder().setDefaultEventBasedHold(true).build(),
+        BucketTargetOption.metagenerationMatch());
 
     System.out.println("Default event-based hold was enabled for " + bucketName);
   }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/EnableUniformBucketLevelAccess.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/EnableUniformBucketLevelAccess.java
@@ -18,8 +18,10 @@ package com.example.storage.bucket;
 
 // [START storage_enable_uniform_bucket_level_access]
 
+import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BucketTargetOption;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
@@ -33,10 +35,16 @@ public class EnableUniformBucketLevelAccess {
     // String bucketName = "your-unique-bucket-name";
 
     Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+
+    // first look up the bucket, so we will have its metageneration
+    Bucket bucket = storage.get(bucketName);
+
     BucketInfo.IamConfiguration iamConfiguration =
         BucketInfo.IamConfiguration.newBuilder().setIsUniformBucketLevelAccessEnabled(true).build();
 
-    storage.update(BucketInfo.newBuilder(bucketName).setIamConfiguration(iamConfiguration).build());
+    storage.update(
+        bucket.toBuilder().setIamConfiguration(iamConfiguration).build(),
+        BucketTargetOption.metagenerationMatch());
 
     System.out.println("Uniform bucket-level access was enabled for " + bucketName);
   }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/EnableUniformBucketLevelAccess.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/EnableUniformBucketLevelAccess.java
@@ -43,7 +43,12 @@ public class EnableUniformBucketLevelAccess {
         BucketInfo.IamConfiguration.newBuilder().setIsUniformBucketLevelAccessEnabled(true).build();
 
     storage.update(
-        bucket.toBuilder().setIamConfiguration(iamConfiguration).build(),
+        bucket
+            .toBuilder()
+            .setIamConfiguration(iamConfiguration)
+            .setAcl(null)
+            .setDefaultAcl(null)
+            .build(),
         BucketTargetOption.metagenerationMatch());
 
     System.out.println("Uniform bucket-level access was enabled for " + bucketName);

--- a/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketDefaultKmsKey.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketDefaultKmsKey.java
@@ -19,6 +19,7 @@ package com.example.storage.bucket;
 // [START storage_bucket_delete_default_kms_key]
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BucketTargetOption;
 import com.google.cloud.storage.StorageOptions;
 
 public class RemoveBucketDefaultKmsKey {
@@ -30,8 +31,11 @@ public class RemoveBucketDefaultKmsKey {
     // String bucketName = "your-unique-bucket-name";
 
     Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    // first look up the bucket, so we will have its metageneration
     Bucket bucket = storage.get(bucketName);
-    bucket.toBuilder().setDefaultKmsKeyName(null).build().update();
+    storage.update(
+        bucket.toBuilder().setDefaultKmsKeyName(null).build(),
+        BucketTargetOption.metagenerationMatch());
 
     System.out.println("Default KMS key was removed from " + bucketName);
   }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetBucketDefaultKmsKey.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetBucketDefaultKmsKey.java
@@ -19,8 +19,8 @@ package com.example.storage.bucket;
 // [START storage_set_bucket_default_kms_key]
 
 import com.google.cloud.storage.Bucket;
-import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BucketTargetOption;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
@@ -38,13 +38,19 @@ public class SetBucketDefaultKmsKey {
     // "projects/your-project-id/locations/us/keyRings/my_key_ring/cryptoKeys/my_key"
 
     Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    // first look up the bucket, so we will have its metageneration
+    Bucket bucket = storage.get(bucketName);
 
-    BucketInfo bucketInfo =
-        BucketInfo.newBuilder(bucketName).setDefaultKmsKeyName(kmsKeyName).build();
-    Bucket bucket = storage.update(bucketInfo);
+    Bucket updated =
+        storage.update(
+            bucket.toBuilder().setDefaultKmsKeyName(kmsKeyName).build(),
+            BucketTargetOption.metagenerationMatch());
 
     System.out.println(
-        "KMS Key " + bucket.getDefaultKmsKeyName() + "was set to default for bucket " + bucketName);
+        "KMS Key "
+            + updated.getDefaultKmsKeyName()
+            + "was set to default for bucket "
+            + bucketName);
   }
 }
 // [END storage_set_bucket_default_kms_key]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetRetentionPolicy.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetRetentionPolicy.java
@@ -19,10 +19,11 @@ package com.example.storage.bucket;
 // [START storage_set_retention_policy]
 
 import com.google.cloud.storage.Bucket;
-import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BucketTargetOption;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
+import java.time.Duration;
 
 public class SetRetentionPolicy {
   public static void setRetentionPolicy(
@@ -38,15 +39,21 @@ public class SetRetentionPolicy {
 
     Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
 
+    // first look up the bucket so we will have its metageneration
+    Bucket bucket = storage.get(bucketName);
     Bucket bucketWithRetentionPolicy =
         storage.update(
-            BucketInfo.newBuilder(bucketName).setRetentionPeriod(retentionPeriodSeconds).build());
+            bucket
+                .toBuilder()
+                .setRetentionPeriodDuration(Duration.ofSeconds(retentionPeriodSeconds))
+                .build(),
+            BucketTargetOption.metagenerationMatch());
 
     System.out.println(
         "Retention period for "
             + bucketName
             + " is now "
-            + bucketWithRetentionPolicy.getRetentionPeriod());
+            + bucketWithRetentionPolicy.getRetentionPeriodDuration());
   }
 }
 // [END storage_set_retention_policy]

--- a/samples/snippets/src/test/java/com/example/storage/TestUtils.java
+++ b/samples/snippets/src/test/java/com/example/storage/TestUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.storage;
+
+import com.google.api.core.CurrentMillisClock;
+import com.google.api.gax.retrying.BasicResultRetryAlgorithm;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.cloud.RetryHelper;
+import com.google.cloud.RetryHelper.RetryHelperException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+
+public final class TestUtils {
+
+  private static final Logger log = Logger.getLogger(TestUtils.class.getName());
+  private static final Object SENTINEL = new Object();
+
+  private TestUtils() {}
+
+  public static void retryAssert(RetrySettings rs, RetryRunnable f) throws Throwable {
+    AtomicInteger counter = new AtomicInteger(1);
+    try {
+      RetryHelper.runWithRetries(
+          () -> {
+            try {
+              int c = counter.getAndIncrement();
+              if (c > 1) {
+                log.warning(String.format("Retrying assertion for the %d time", c));
+              }
+              f.run();
+              return SENTINEL;
+            } catch (Throwable e) {
+              throw new TunnelThrowable(e);
+            }
+          },
+          rs,
+          new BasicResultRetryAlgorithm<Object>() {
+            @Override
+            public boolean shouldRetry(Throwable previousThrowable, Object previousResponse) {
+              return previousResponse != SENTINEL && previousThrowable != null;
+            }
+          },
+          CurrentMillisClock.getDefaultClock());
+    } catch (RetryHelperException e) {
+      if (e.getCause() instanceof TunnelThrowable) {
+        TunnelThrowable cause = (TunnelThrowable) e.getCause();
+        throw cause.getCause();
+      }
+      throw e.getCause();
+    }
+  }
+
+  @FunctionalInterface
+  public interface RetryRunnable {
+
+    void run() throws Throwable;
+  }
+
+  private static final class TunnelThrowable extends Exception {
+    private TunnelThrowable(Throwable cause) {
+      super(cause);
+    }
+  }
+}

--- a/samples/snippets/src/test/java/com/example/storage/TestUtilsTest.java
+++ b/samples/snippets/src/test/java/com/example/storage/TestUtilsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.storage;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.api.gax.retrying.RetrySettings;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+
+public class TestUtilsTest {
+
+  private static final RetrySettings RETRY_SETTINGS =
+      RetrySettings.newBuilder().setMaxAttempts(3).build();
+
+  @Test
+  public void noException() throws Throwable {
+    TestUtils.retryAssert(RETRY_SETTINGS, () -> assertThat(true).isTrue());
+  }
+
+  @Test
+  public void assertionFailureOnce() throws Throwable {
+    System.out.println("TestUtilsTest.assertionFailureOnce");
+    AtomicInteger c = new AtomicInteger(1);
+    TestUtils.retryAssert(RETRY_SETTINGS, () -> assertThat(c.getAndIncrement()).isGreaterThan(1));
+  }
+
+  @Test
+  public void assertionError_exhausted() throws Throwable {
+    AtomicInteger c = new AtomicInteger(1);
+    try {
+      TestUtils.retryAssert(
+          RETRY_SETTINGS, () -> assertThat(c.getAndIncrement()).isGreaterThan(10));
+      throw new Throwable("expected AssertionError");
+    } catch (AssertionError ignore) {
+      // expected
+    }
+  }
+
+  @Test
+  public void runtimeException_exhausted() {
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            TestUtils.retryAssert(
+                RETRY_SETTINGS,
+                () -> {
+                  throw new RuntimeException("kaboom");
+                }));
+  }
+}


### PR DESCRIPTION
When asserting a bucket update has taken place, sometime there can be a lag between when the update RPC succeeds and when it actually takes effect. Update our test assertions to retry if they fail up to a configured maximum duration.

Fixes #2060
Fixes #2068
Fixes #2069
Fixes #2070

