### PR TITLE
fix: update UploadCallable to use createFrom to avoid NPE trying to resolve resulting object

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
@@ -64,7 +64,6 @@ public final class PackagePrivateMethodWorkarounds {
     return (w) -> {
       BlobWriteChannel blobWriteChannel;
       if (w instanceof BlobWriteChannel) {
-
         blobWriteChannel = (BlobWriteChannel) w;
         return Optional.of(blobWriteChannel.getStorageObject())
             .map(Conversions.apiary().blobInfo()::decode);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
@@ -64,6 +64,7 @@ public final class PackagePrivateMethodWorkarounds {
     return (w) -> {
       BlobWriteChannel blobWriteChannel;
       if (w instanceof BlobWriteChannel) {
+
         blobWriteChannel = (BlobWriteChannel) w;
         return Optional.of(blobWriteChannel.getStorageObject())
             .map(Conversions.apiary().blobInfo()::decode);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/ParallelUploadConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/ParallelUploadConfig.java
@@ -47,7 +47,7 @@ public final class ParallelUploadConfig {
     this.prefix = prefix;
     this.bucketName = bucketName;
     this.targetOptsPerRequest = targetOptsPerRequest;
-    this.writeOptsPerRequest = writeOptsPerRequest;
+    this.writeOptsPerRequest = applySkipIfExists(skipIfExists, writeOptsPerRequest);
   }
 
   /** If a corresponding object already exists skip uploading the object */
@@ -113,6 +113,17 @@ public final class ParallelUploadConfig {
   @BetaApi
   public static Builder newBuilder() {
     return new Builder();
+  }
+
+  private static List<BlobWriteOption> applySkipIfExists(
+      boolean skipIfExists, List<BlobWriteOption> writeOptsPerRequest) {
+    if (skipIfExists) {
+      return writeOptsPerRequest.isEmpty()
+          ? ImmutableList.of(BlobWriteOption.generationMatch(0))
+          : ImmutableList.copyOf(
+              BlobWriteOption.dedupe(writeOptsPerRequest, BlobWriteOption.generationMatch(0L)));
+    }
+    return writeOptsPerRequest;
   }
 
   @BetaApi

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/ParallelUploadConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/ParallelUploadConfig.java
@@ -118,10 +118,8 @@ public final class ParallelUploadConfig {
   private static List<BlobWriteOption> applySkipIfExists(
       boolean skipIfExists, List<BlobWriteOption> writeOptsPerRequest) {
     if (skipIfExists) {
-      return writeOptsPerRequest.isEmpty()
-          ? ImmutableList.of(BlobWriteOption.generationMatch(0))
-          : ImmutableList.copyOf(
-              BlobWriteOption.dedupe(writeOptsPerRequest, BlobWriteOption.generationMatch(0L)));
+      return ImmutableList.copyOf(
+          BlobWriteOption.dedupe(writeOptsPerRequest, BlobWriteOption.doesNotExist()));
     }
     return writeOptsPerRequest;
   }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
@@ -131,6 +131,11 @@ public class ITTransferManagerTest {
       UploadJob job = transferManager.uploadFiles(files, parallelUploadConfig);
       List<UploadResult> uploadResults = job.getUploadResults();
       assertThat(uploadResults).hasSize(3);
+      assertThat(
+              uploadResults.stream()
+                  .filter(result -> result.getStatus() == TransferStatus.SUCCESS)
+                  .collect(Collectors.toList()))
+          .hasSize(3);
     }
   }
 
@@ -153,6 +158,11 @@ public class ITTransferManagerTest {
       UploadJob job = transferManager.uploadFiles(files, parallelUploadConfig);
       List<UploadResult> uploadResults = job.getUploadResults();
       assertThat(uploadResults).hasSize(3);
+      assertThat(
+              uploadResults.stream()
+                  .filter(result -> result.getStatus() == TransferStatus.SUCCESS)
+                  .collect(Collectors.toList()))
+          .hasSize(3);
     }
   }
 
@@ -181,6 +191,11 @@ public class ITTransferManagerTest {
                   .filter(x -> x.getStatus() == TransferStatus.FAILED_TO_START)
                   .collect(Collectors.toList()))
           .hasSize(1);
+      assertThat(
+              uploadResults.stream()
+                  .filter(result -> result.getStatus() == TransferStatus.SUCCESS)
+                  .collect(Collectors.toList()))
+          .hasSize(3);
     }
   }
 
@@ -214,6 +229,25 @@ public class ITTransferManagerTest {
       List<UploadResult> uploadResults = job.getUploadResults();
       assertThat(uploadResults.get(0).getStatus()).isEqualTo(TransferStatus.FAILED_TO_START);
       assertThat(uploadResults.get(0).getException()).isInstanceOf(NoSuchFileException.class);
+    }
+  }
+
+  @Test
+  public void uploadFailsSkipIfExists() throws Exception {
+    TransferManagerConfig config =
+        TransferManagerConfigTestingInstances.defaults(storage.getOptions()).toBuilder().build();
+    String bucketName = bucket.getName();
+    try (TransferManager transferManager = config.getService();
+        TmpFile tmpFile = DataGenerator.base64Characters().tempFile(baseDir, objectContentSize)) {
+      ParallelUploadConfig parallelUploadConfig =
+          ParallelUploadConfig.newBuilder().setBucketName(bucketName).setSkipIfExists(true).build();
+      UploadJob jobInitUpload =
+          transferManager.uploadFiles(ImmutableList.of(tmpFile.getPath()), parallelUploadConfig);
+      List<UploadResult> uploadResults = jobInitUpload.getUploadResults();
+      assertThat(uploadResults.get(0).getStatus()).isEqualTo(TransferStatus.SUCCESS);
+      UploadJob failedSecondUpload =
+          transferManager.uploadFiles(ImmutableList.of(tmpFile.getPath()), parallelUploadConfig);
+      List<UploadResult> failedResult = failedSecondUpload.getUploadResults();
     }
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
@@ -188,7 +188,7 @@ public class ITTransferManagerTest {
       assertThat(uploadResults).hasSize(4);
       assertThat(
               uploadResults.stream()
-                  .filter(x -> x.getStatus() == TransferStatus.FAILED_TO_START)
+                  .filter(x -> x.getStatus() == TransferStatus.FAILED_TO_FINISH)
                   .collect(Collectors.toList()))
           .hasSize(1);
       assertThat(
@@ -211,7 +211,7 @@ public class ITTransferManagerTest {
           ParallelUploadConfig.newBuilder().setBucketName(bucketName).build();
       UploadJob job = transferManager.uploadFiles(files, parallelUploadConfig);
       List<UploadResult> uploadResults = job.getUploadResults();
-      assertThat(uploadResults.get(0).getStatus()).isEqualTo(TransferStatus.FAILED_TO_START);
+      assertThat(uploadResults.get(0).getStatus()).isEqualTo(TransferStatus.FAILED_TO_FINISH);
       assertThat(uploadResults.get(0).getException()).isInstanceOf(StorageException.class);
     }
   }
@@ -227,7 +227,7 @@ public class ITTransferManagerTest {
           ParallelUploadConfig.newBuilder().setBucketName(bucketName).build();
       UploadJob job = transferManager.uploadFiles(files, parallelUploadConfig);
       List<UploadResult> uploadResults = job.getUploadResults();
-      assertThat(uploadResults.get(0).getStatus()).isEqualTo(TransferStatus.FAILED_TO_START);
+      assertThat(uploadResults.get(0).getStatus()).isEqualTo(TransferStatus.FAILED_TO_FINISH);
       assertThat(uploadResults.get(0).getException()).isInstanceOf(NoSuchFileException.class);
     }
   }
@@ -248,9 +248,7 @@ public class ITTransferManagerTest {
       UploadJob failedSecondUpload =
           transferManager.uploadFiles(ImmutableList.of(tmpFile.getPath()), parallelUploadConfig);
       List<UploadResult> failedResult = failedSecondUpload.getUploadResults();
-      assertThat(failedResult.get(0).getStatus()).isEqualTo(TransferStatus.FAILED_TO_FINISH);
-      assertThat(failedResult.get(0).getException()).isInstanceOf(StorageException.class);
-      assertThat(failedResult.get(0).getException().getMessage()).contains("Precondition Failed");
+      assertThat(failedResult.get(0).getStatus()).isEqualTo(TransferStatus.SKIPPED);
     }
   }
 
@@ -275,9 +273,7 @@ public class ITTransferManagerTest {
       UploadJob failedSecondUpload =
           transferManager.uploadFiles(ImmutableList.of(tmpFile.getPath()), parallelUploadConfig);
       List<UploadResult> failedResult = failedSecondUpload.getUploadResults();
-      assertThat(failedResult.get(0).getStatus()).isEqualTo(TransferStatus.FAILED_TO_FINISH);
-      assertThat(failedResult.get(0).getException()).isInstanceOf(StorageException.class);
-      assertThat(failedResult.get(0).getException().getMessage()).contains("Precondition Failed");
+      assertThat(failedResult.get(0).getStatus()).isEqualTo(TransferStatus.SKIPPED);
     }
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
@@ -248,6 +248,9 @@ public class ITTransferManagerTest {
       UploadJob failedSecondUpload =
           transferManager.uploadFiles(ImmutableList.of(tmpFile.getPath()), parallelUploadConfig);
       List<UploadResult> failedResult = failedSecondUpload.getUploadResults();
+      assertThat(failedResult.get(0).getStatus()).isEqualTo(TransferStatus.FAILED_TO_FINISH);
+      assertThat(failedResult.get(0).getException()).isInstanceOf(StorageException.class);
+      assertThat(failedResult.get(0).getException().getMessage()).contains("Precondition Failed");
     }
   }
 


### PR DESCRIPTION
This PR has a few parts to it, all small enough to where I did not feel the need to separate.

### Major Addition
There was a bug where the storageObject was being accessed before the WriteChannel closes, when the upload is not finished WriteChannel returns a null storageObject resulting in an NPE when we go to decode the storageObject. see [BlobWriteChannel#storageObject](https://github.com/googleapis/java-storage/blob/976b9ba367d5eb5bcd4a2b50ef6f530b3a6dff94/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobWriteChannel.java#L44) for where this is documented.

First Pass (up to commit [76462df](https://github.com/googleapis/java-storage/pull/2086/commits/76462df4649db6764043f1ca011e5d2d62a68ddd)): addressed this by trying to process the storageObject outside of the scope of the try block, which would ensure the write has completed. All we have to do is manually ensure that the channel is closed.

Refactor (commit [976b9ba](https://github.com/googleapis/java-storage/pull/2086/commits/976b9ba367d5eb5bcd4a2b50ef6f530b3a6dff94)): utilizes createFrom, this addition is to both relieve the upload call of handling the Write/FileChannels directly and also allows us to take advantage of any performance improvements being made. The drawback of this is we will regress on our TransferStatus reporting as we no longer have direct byte access to track upload progress. The plan is to short term handle this via Status code checks and long term add in progress monitoring.

### Minor Additions
- Add additional assertions to tests to prevent a bug like this from lurking about.
- Add the skipIfExists functionality 