### PR TITLE
fix: update GrpcStorageImpl.createFrom(BlobInfo, Path) to use RewindableContent

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedWritableByteChannel.java
@@ -31,7 +31,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @ParametersAreNonnullByDefault
 final class ApiaryUnbufferedWritableByteChannel implements UnbufferedWritableByteChannel {
 
-  private final ResumableSession<StorageObject> session;
+  private final JsonResumableSession session;
 
   private final SettableApiFuture<StorageObject> result;
   private final LongConsumer committedBytesCallback;
@@ -57,7 +57,7 @@ final class ApiaryUnbufferedWritableByteChannel implements UnbufferedWritableByt
     if (!open) {
       throw new ClosedChannelException();
     }
-    RewindableHttpContent content = RewindableHttpContent.of(Utils.subArray(srcs, offset, length));
+    RewindableContent content = RewindableContent.of(Utils.subArray(srcs, offset, length));
     long available = content.getLength();
     long newFinalByteOffset = cumulativeByteCount + available;
     final HttpContentRange header;
@@ -96,7 +96,7 @@ final class ApiaryUnbufferedWritableByteChannel implements UnbufferedWritableByt
     if (!finished) {
       try {
         ResumableOperationResult<@Nullable StorageObject> operationResult =
-            session.put(RewindableHttpContent.empty(), HttpContentRange.of(cumulativeByteCount));
+            session.put(RewindableContent.empty(), HttpContentRange.of(cumulativeByteCount));
         long persistedSize = operationResult.getPersistedSize();
         committedBytesCallback.accept(persistedSize);
         result.set(operationResult.getObject());

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ByteSizeConstants.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ByteSizeConstants.java
@@ -28,6 +28,9 @@ final class ByteSizeConstants {
   static final int _2MiB = 2 * _1MiB;
   static final int _16MiB = 16 * _1MiB;
   static final int _32MiB = 32 * _1MiB;
+  static final long _1GiB = 1024 * _1MiB;
+  static final long _1TiB = 1024 * _1GiB;
+  static final long _5TiB = 5 * _1TiB;
 
   static final long _128KiBL = 131072L;
   static final long _256KiBL = 262144L;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcResumableSession.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcResumableSession.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.grpc.GrpcCallContext;
+import com.google.api.gax.retrying.ResultRetryAlgorithm;
+import com.google.api.gax.rpc.ClientStreamingCallable;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.cloud.storage.BufferedWritableByteChannelSession.BufferedWritableByteChannel;
+import com.google.cloud.storage.Conversions.Decoder;
+import com.google.cloud.storage.Retrying.RetryingDependencies;
+import com.google.storage.v2.Object;
+import com.google.storage.v2.QueryWriteStatusRequest;
+import com.google.storage.v2.QueryWriteStatusResponse;
+import com.google.storage.v2.WriteObjectRequest;
+import com.google.storage.v2.WriteObjectResponse;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+final class GrpcResumableSession {
+
+  private final RetryingDependencies deps;
+  private final ResultRetryAlgorithm<?> alg;
+  private final ClientStreamingCallable<WriteObjectRequest, WriteObjectResponse> writeCallable;
+  private final UnaryCallable<QueryWriteStatusRequest, QueryWriteStatusResponse>
+      queryWriteStatusCallable;
+  private final ResumableWrite resumableWrite;
+  private final Hasher hasher;
+
+  GrpcResumableSession(
+      RetryingDependencies deps,
+      ResultRetryAlgorithm<?> alg,
+      ClientStreamingCallable<WriteObjectRequest, WriteObjectResponse> writeCallable,
+      UnaryCallable<QueryWriteStatusRequest, QueryWriteStatusResponse> queryWriteStatusCallable,
+      ResumableWrite resumableWrite,
+      Hasher hasher) {
+    this.deps = deps;
+    this.alg = alg;
+    this.writeCallable = writeCallable;
+    this.queryWriteStatusCallable = queryWriteStatusCallable;
+    this.resumableWrite = resumableWrite;
+    this.hasher = hasher;
+  }
+
+  ResumableOperationResult<@Nullable Object> query() {
+    QueryWriteStatusRequest.Builder b =
+        QueryWriteStatusRequest.newBuilder().setUploadId(resumableWrite.getRes().getUploadId());
+    if (resumableWrite.getReq().hasCommonObjectRequestParams()) {
+      b.setCommonObjectRequestParams(resumableWrite.getReq().getCommonObjectRequestParams());
+    }
+    QueryWriteStatusRequest req = b.build();
+    try {
+      QueryWriteStatusResponse response = queryWriteStatusCallable.call(req);
+      if (response.hasResource()) {
+        return ResumableOperationResult.complete(
+            response.getResource(), response.getResource().getSize());
+      } else {
+        return ResumableOperationResult.incremental(response.getPersistedSize());
+      }
+    } catch (Exception e) {
+      throw StorageException.coalesce(e);
+    }
+  }
+
+  ResumableOperationResult<@Nullable Object> put(RewindableContent content) {
+    AtomicBoolean dirty = new AtomicBoolean(false);
+    GrpcCallContext retryingCallContext = Retrying.newCallContext();
+    BufferHandle handle = BufferHandle.allocate(ByteSizeConstants._2MiB);
+
+    return Retrying.run(
+        deps,
+        alg,
+        () -> {
+          if (dirty.getAndSet(true)) {
+            ResumableOperationResult<@Nullable Object> query = query();
+            if (query.getObject() != null) {
+              return query;
+            } else {
+              content.rewindTo(query.getPersistedSize());
+            }
+          }
+          WritableByteChannelSession<BufferedWritableByteChannel, WriteObjectResponse> session =
+              ResumableMedia.gapic()
+                  .write()
+                  .byteChannel(writeCallable.withDefaultCallContext(retryingCallContext))
+                  .setByteStringStrategy(ByteStringStrategy.copy())
+                  .setHasher(hasher)
+                  .resumable()
+                  .setFsyncEvery(false)
+                  .buffered(handle)
+                  .setStartAsync(ApiFutures.immediateFuture(resumableWrite))
+                  .build();
+
+          try (BufferedWritableByteChannel channel = session.open()) {
+            content.writeTo(channel);
+          }
+
+          WriteObjectResponse response = session.getResult().get();
+          if (response.hasResource()) {
+            return ResumableOperationResult.complete(
+                response.getResource(), response.getResource().getSize());
+          } else {
+            return ResumableOperationResult.incremental(response.getPersistedSize());
+          }
+        },
+        Decoder.identity());
+  }
+}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSession.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSession.java
@@ -26,7 +26,7 @@ import io.opencensus.trace.EndSpanOptions;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-final class JsonResumableSession extends ResumableSession<StorageObject> {
+final class JsonResumableSession {
 
   static final String SPAN_NAME_WRITE =
       String.format("Sent.%s.write", HttpStorageRpc.class.getName());
@@ -53,14 +53,12 @@ final class JsonResumableSession extends ResumableSession<StorageObject> {
    * Not automatically retried. Usually called from within another retrying context. We don't yet
    * have the concept of nested retry handling.
    */
-  @Override
   ResumableOperationResult<@Nullable StorageObject> query() {
     return new JsonResumableSessionQueryTask(context, resumableWrite.getUploadId()).call();
   }
 
-  @Override
   ResumableOperationResult<@Nullable StorageObject> put(
-      RewindableHttpContent content, HttpContentRange contentRange) {
+      RewindableContent content, HttpContentRange contentRange) {
     JsonResumableSessionPutTask task =
         new JsonResumableSessionPutTask(
             context, resumableWrite.getUploadId(), content, contentRange);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionPutTask.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionPutTask.java
@@ -39,7 +39,7 @@ final class JsonResumableSessionPutTask
 
   private final HttpClientContext context;
   private final String uploadId;
-  private final RewindableHttpContent content;
+  private final RewindableContent content;
   private final HttpContentRange originalContentRange;
 
   private HttpContentRange contentRange;
@@ -48,7 +48,7 @@ final class JsonResumableSessionPutTask
   JsonResumableSessionPutTask(
       HttpClientContext httpClientContext,
       String uploadId,
-      RewindableHttpContent content,
+      RewindableContent content,
       HttpContentRange originalContentRange) {
     this.context = httpClientContext;
     this.uploadId = uploadId;
@@ -64,9 +64,9 @@ final class JsonResumableSessionPutTask
       long originalBegin = range.beginOffset();
       long contentOffset = offset - originalBegin;
       Preconditions.checkArgument(
-          0 <= contentOffset && contentOffset < content.getLength(),
+          0 <= contentOffset && contentOffset < range.length(),
           "Rewind offset is out of bounds. (%s <= %s < %s)",
-          range.beginOffset(),
+          originalBegin,
           offset,
           range.endOffset());
       content.rewindTo(contentOffset);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableSession.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableSession.java
@@ -17,17 +17,17 @@
 package com.google.cloud.storage;
 
 import com.google.api.gax.retrying.ResultRetryAlgorithm;
+import com.google.api.gax.rpc.ClientStreamingCallable;
+import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.storage.Retrying.RetryingDependencies;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import com.google.storage.v2.QueryWriteStatusRequest;
+import com.google.storage.v2.QueryWriteStatusResponse;
+import com.google.storage.v2.WriteObjectRequest;
+import com.google.storage.v2.WriteObjectResponse;
 
-abstract class ResumableSession<T> {
+final class ResumableSession {
 
-  ResumableSession() {}
-
-  abstract ResumableOperationResult<@Nullable T> put(
-      RewindableHttpContent content, HttpContentRange contentRange);
-
-  abstract ResumableOperationResult<@Nullable T> query();
+  private ResumableSession() {}
 
   static JsonResumableSession json(
       HttpClientContext context,
@@ -35,5 +35,16 @@ abstract class ResumableSession<T> {
       ResultRetryAlgorithm<?> alg,
       JsonResumableWrite resumableWrite) {
     return new JsonResumableSession(context, deps, alg, resumableWrite);
+  }
+
+  static GrpcResumableSession grpc(
+      RetryingDependencies deps,
+      ResultRetryAlgorithm<?> alg,
+      ClientStreamingCallable<WriteObjectRequest, WriteObjectResponse> writeCallable,
+      UnaryCallable<QueryWriteStatusRequest, QueryWriteStatusResponse> queryWriteStatusCallable,
+      ResumableWrite resumableWrite,
+      Hasher hasher) {
+    return new GrpcResumableSession(
+        deps, alg, writeCallable, queryWriteStatusCallable, resumableWrite, hasher);
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
@@ -255,7 +255,7 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
     HttpContentRange contentRange =
         HttpContentRange.of(ByteRangeSpec.relativeLength(0L, size), size);
     ResumableOperationResult<StorageObject> put =
-        session.put(RewindableHttpContent.of(path), contentRange);
+        session.put(RewindableContent.of(path), contentRange);
     // all exception translation is taken care of down in the JsonResumableSession
     StorageObject object = put.getObject();
     if (object == null) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITJsonResumableSessionPutTaskTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITJsonResumableSessionPutTaskTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.storage;
 
 import static com.google.cloud.storage.ByteSizeConstants._128KiBL;
+import static com.google.cloud.storage.ByteSizeConstants._256KiB;
 import static com.google.cloud.storage.ByteSizeConstants._256KiBL;
 import static com.google.cloud.storage.ByteSizeConstants._512KiBL;
 import static com.google.cloud.storage.ByteSizeConstants._768KiBL;
@@ -45,6 +46,7 @@ import io.grpc.netty.shaded.io.netty.handler.codec.http.HttpHeaderNames;
 import io.grpc.netty.shaded.io.netty.handler.codec.http.HttpResponseStatus;
 import java.math.BigInteger;
 import java.net.URI;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
@@ -98,7 +100,7 @@ public final class ITJsonResumableSessionPutTaskTest {
           new JsonResumableSessionPutTask(
               httpClientContext,
               uploadUrl,
-              RewindableHttpContent.empty(),
+              RewindableContent.empty(),
               HttpContentRange.of(ByteRangeSpec.explicitClosed(0L, 0L), 0));
 
       ResumableOperationResult<@Nullable StorageObject> operationResult = task.call();
@@ -144,7 +146,7 @@ public final class ITJsonResumableSessionPutTaskTest {
           new JsonResumableSessionPutTask(
               httpClientContext,
               uploadUrl,
-              RewindableHttpContent.empty(),
+              RewindableContent.empty(),
               HttpContentRange.of(ByteRangeSpec.explicitClosed(0L, 10L)));
 
       StorageException se = assertThrows(StorageException.class, task::call);
@@ -191,7 +193,7 @@ public final class ITJsonResumableSessionPutTaskTest {
           new JsonResumableSessionPutTask(
               httpClientContext,
               uploadUrl,
-              RewindableHttpContent.empty(),
+              RewindableContent.empty(),
               HttpContentRange.of(ByteRangeSpec.explicitClosed(0L, 10L)));
 
       StorageException se = assertThrows(StorageException.class, task::call);
@@ -272,7 +274,7 @@ public final class ITJsonResumableSessionPutTaskTest {
           new JsonResumableSessionPutTask(
               httpClientContext,
               uploadUrl,
-              RewindableHttpContent.of(tmpFile.getPath()),
+              RewindableContent.of(tmpFile.getPath()),
               HttpContentRange.of(ByteRangeSpec.explicit(0L, _256KiBL)));
 
       StorageException se = assertThrows(StorageException.class, task::call);
@@ -341,7 +343,7 @@ public final class ITJsonResumableSessionPutTaskTest {
           new JsonResumableSessionPutTask(
               httpClientContext,
               uploadUrl,
-              RewindableHttpContent.empty(),
+              RewindableContent.empty(),
               HttpContentRange.of(_256KiBL));
 
       StorageException se = assertThrows(StorageException.class, task::call);
@@ -410,7 +412,7 @@ public final class ITJsonResumableSessionPutTaskTest {
           new JsonResumableSessionPutTask(
               httpClientContext,
               uploadUrl,
-              RewindableHttpContent.empty(),
+              RewindableContent.empty(),
               HttpContentRange.of(_512KiBL));
 
       StorageException se = assertThrows(StorageException.class, task::call);
@@ -488,7 +490,7 @@ public final class ITJsonResumableSessionPutTaskTest {
           new JsonResumableSessionPutTask(
               httpClientContext,
               uploadUrl,
-              RewindableHttpContent.empty(),
+              RewindableContent.empty(),
               HttpContentRange.of(_256KiBL));
 
       ResumableOperationResult<@Nullable StorageObject> operationResult = task.call();
@@ -570,7 +572,7 @@ public final class ITJsonResumableSessionPutTaskTest {
           new JsonResumableSessionPutTask(
               httpClientContext,
               uploadUrl,
-              RewindableHttpContent.empty(),
+              RewindableContent.empty(),
               HttpContentRange.of(_512KiBL));
 
       StorageException se = assertThrows(StorageException.class, task::call);
@@ -650,7 +652,7 @@ public final class ITJsonResumableSessionPutTaskTest {
           new JsonResumableSessionPutTask(
               httpClientContext,
               uploadUrl,
-              RewindableHttpContent.empty(),
+              RewindableContent.empty(),
               HttpContentRange.of(_128KiBL));
 
       StorageException se = assertThrows(StorageException.class, task::call);
@@ -728,7 +730,7 @@ public final class ITJsonResumableSessionPutTaskTest {
           new JsonResumableSessionPutTask(
               httpClientContext,
               uploadUrl,
-              RewindableHttpContent.of(tmpFile.getPath()),
+              RewindableContent.of(tmpFile.getPath()),
               HttpContentRange.of(ByteRangeSpec.explicit(_512KiBL, _768KiBL)));
 
       StorageException se = assertThrows(StorageException.class, task::call);
@@ -768,7 +770,7 @@ public final class ITJsonResumableSessionPutTaskTest {
 
       JsonResumableSessionPutTask task =
           new JsonResumableSessionPutTask(
-              httpClientContext, uploadUrl, RewindableHttpContent.empty(), HttpContentRange.of(0));
+              httpClientContext, uploadUrl, RewindableContent.empty(), HttpContentRange.of(0));
 
       StorageException se = assertThrows(StorageException.class, task::call);
       // the parse error happens while trying to read the success object, make sure we raise it as
@@ -803,7 +805,7 @@ public final class ITJsonResumableSessionPutTaskTest {
 
       JsonResumableSessionPutTask task =
           new JsonResumableSessionPutTask(
-              httpClientContext, uploadUrl, RewindableHttpContent.empty(), HttpContentRange.of(0));
+              httpClientContext, uploadUrl, RewindableContent.empty(), HttpContentRange.of(0));
 
       ResumableOperationResult<@Nullable StorageObject> operationResult = task.call();
       StorageObject call = operationResult.getObject();
@@ -814,7 +816,7 @@ public final class ITJsonResumableSessionPutTaskTest {
 
   @Test
   public void attemptToRewindOutOfBoundsThrows_lower() {
-    RewindableHttpContent content = RewindableHttpContent.of();
+    RewindableContent content = RewindableContent.of();
     JsonResumableSessionPutTask task =
         new JsonResumableSessionPutTask(
             null, null, content, HttpContentRange.of(ByteRangeSpec.relativeLength(10L, 10L)));
@@ -826,7 +828,7 @@ public final class ITJsonResumableSessionPutTaskTest {
 
   @Test
   public void attemptToRewindOutOfBoundsThrows_upper() {
-    RewindableHttpContent content = RewindableHttpContent.of();
+    RewindableContent content = RewindableContent.of();
     JsonResumableSessionPutTask task =
         new JsonResumableSessionPutTask(
             null, null, content, HttpContentRange.of(ByteRangeSpec.relativeLength(10L, 10L)));
@@ -834,5 +836,39 @@ public final class ITJsonResumableSessionPutTaskTest {
     IllegalArgumentException iae =
         assertThrows(IllegalArgumentException.class, () -> task.rewindTo(20));
     assertThat(iae).hasMessageThat().isEqualTo("Rewind offset is out of bounds. (10 <= 20 < 20)");
+  }
+
+  @Test
+  public void repeatedRewindsToTheSameLocationWork() {
+    ByteBuffer buf1 = DataGenerator.base64Characters().genByteBuffer(_256KiB);
+    ByteBuffer buf2 = DataGenerator.base64Characters().genByteBuffer(_256KiB);
+    RewindableContent content = RewindableContent.of(buf1, buf2);
+    JsonResumableSessionPutTask task =
+        new JsonResumableSessionPutTask(
+            null, null, content, HttpContentRange.of(ByteRangeSpec.relativeLength(0L, _512KiBL)));
+
+    task.rewindTo(0);
+    assertThat(buf1.position()).isEqualTo(0);
+    assertThat(buf2.position()).isEqualTo(0);
+
+    int last = buf1.capacity();
+    buf1.position(last);
+    buf2.position(last);
+
+    task.rewindTo(_256KiBL);
+    assertThat(buf1.remaining()).isEqualTo(0);
+    assertThat(buf2.position()).isEqualTo(0);
+
+    task.rewindTo(_256KiBL);
+    assertThat(buf1.remaining()).isEqualTo(0);
+    assertThat(buf2.position()).isEqualTo(0);
+
+    task.rewindTo(_256KiBL + 13);
+    assertThat(buf1.remaining()).isEqualTo(0);
+    assertThat(buf2.position()).isEqualTo(13);
+
+    task.rewindTo(_256KiBL + 13);
+    assertThat(buf1.remaining()).isEqualTo(0);
+    assertThat(buf2.position()).isEqualTo(13);
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITJsonResumableSessionTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITJsonResumableSessionTest.java
@@ -119,7 +119,7 @@ public final class ITJsonResumableSessionTest {
               httpClientContext, RETRYING_DEPENDENCIES, RETRY_ALGORITHM, resumableWrite);
 
       ResumableOperationResult<@Nullable StorageObject> operationResult =
-          session.put(RewindableHttpContent.of(tmpFile.getPath()), range1);
+          session.put(RewindableContent.of(tmpFile.getPath()), range1);
       StorageObject call = operationResult.getObject();
       assertThat(call).isNull();
       assertThat(operationResult.getPersistedSize()).isEqualTo(_512KiBL);
@@ -173,13 +173,13 @@ public final class ITJsonResumableSessionTest {
               httpClientContext, RETRYING_DEPENDENCIES, RETRY_ALGORITHM, resumableWrite);
 
       ResumableOperationResult<@Nullable StorageObject> operationResult1 =
-          session.put(RewindableHttpContent.of(buf1), range1);
+          session.put(RewindableContent.of(buf1), range1);
       StorageObject call1 = operationResult1.getObject();
       assertThat(call1).isNull();
       assertThat(operationResult1.getPersistedSize()).isEqualTo(_512KiBL);
 
       ResumableOperationResult<@Nullable StorageObject> operationResult2 =
-          session.put(RewindableHttpContent.of(buf2), range3);
+          session.put(RewindableContent.of(buf2), range3);
       StorageObject call2 = operationResult2.getObject();
       assertThat(call2).isNull();
       assertThat(operationResult2.getPersistedSize()).isEqualTo(_768KiBL);
@@ -240,13 +240,13 @@ public final class ITJsonResumableSessionTest {
               httpClientContext, RETRYING_DEPENDENCIES, RETRY_ALGORITHM, resumableWrite);
 
       ResumableOperationResult<@Nullable StorageObject> operationResult1 =
-          session.put(RewindableHttpContent.of(buf1), range1);
+          session.put(RewindableContent.of(buf1), range1);
       StorageObject call1 = operationResult1.getObject();
       assertThat(call1).isNull();
       assertThat(operationResult1.getPersistedSize()).isEqualTo(_512KiBL);
 
       ResumableOperationResult<@Nullable StorageObject> operationResult2 =
-          session.put(RewindableHttpContent.of(buf2), range2);
+          session.put(RewindableContent.of(buf2), range2);
       StorageObject call2 = operationResult2.getObject();
       assertThat(call2).isNull();
       assertThat(operationResult2.getPersistedSize()).isEqualTo(_768KiBL);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/RewindableByteBufferContentTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/RewindableByteBufferContentTest.java
@@ -21,7 +21,7 @@ import static com.google.cloud.storage.TestUtils.xxd;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
-import com.google.cloud.storage.RewindableHttpContentPropertyTest.ErroringOutputStream;
+import com.google.cloud.storage.RewindableContentPropertyTest.ErroringOutputStream;
 import com.google.protobuf.ByteString;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -61,7 +61,7 @@ public final class RewindableByteBufferContentTest {
 
   @Test
   public void getLength() {
-    RewindableHttpContent content = RewindableHttpContent.of(buffers);
+    RewindableContent content = RewindableContent.of(buffers);
 
     assertThat(content.getLength()).isEqualTo(total);
   }
@@ -69,7 +69,7 @@ public final class RewindableByteBufferContentTest {
   @Test
   public void writeTo() throws IOException {
 
-    RewindableHttpContent content = RewindableHttpContent.of(buffers);
+    RewindableContent content = RewindableContent.of(buffers);
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     content.writeTo(baos);
@@ -81,7 +81,7 @@ public final class RewindableByteBufferContentTest {
   @Test
   public void rewind() throws IOException {
 
-    RewindableHttpContent content = RewindableHttpContent.of(buffers);
+    RewindableContent content = RewindableContent.of(buffers);
 
     assertThrows(
         IOException.class,
@@ -100,7 +100,7 @@ public final class RewindableByteBufferContentTest {
 
   @Test
   public void rewindTo() throws Exception {
-    RewindableHttpContent content = RewindableHttpContent.of(buffers);
+    RewindableContent content = RewindableContent.of(buffers);
 
     ByteString reduce =
         Arrays.stream(buffers)
@@ -135,7 +135,7 @@ public final class RewindableByteBufferContentTest {
     int position = buf.position();
     int limit = buf.limit();
 
-    RewindableHttpContent content = RewindableHttpContent.of(buf);
+    RewindableContent content = RewindableContent.of(buf);
     int hackPosition = 2;
     // after content has initialized, mutate the position underneath it. We're doing this to detect
     // if rewind is actually modifying things. It shouldn't until the content is dirtied by calling

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/RewindableContentPropertyTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/RewindableContentPropertyTest.java
@@ -41,12 +41,12 @@ import net.jqwik.api.Provide;
 import net.jqwik.api.RandomDistribution;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-final class RewindableHttpContentPropertyTest {
+final class RewindableContentPropertyTest {
 
   @Property
   void path(@ForAll("PathScenario") PathScenario pathScenario) throws Exception {
     try (PathScenario s = pathScenario) {
-      RewindableHttpContent content = RewindableHttpContent.of(s.getPath());
+      RewindableContent content = RewindableContent.of(s.getPath());
       assertThrows(
           IOException.class,
           () -> {
@@ -68,7 +68,7 @@ final class RewindableHttpContentPropertyTest {
 
   @Property
   void byteBuffers(@ForAll("ByteBuffersScenario") ByteBuffersScenario s) throws IOException {
-    RewindableHttpContent content = RewindableHttpContent.of(s.getBuffers());
+    RewindableContent content = RewindableContent.of(s.getBuffers());
     assertThat(content.getLength()).isEqualTo(s.getFullLength());
     assertThrows(
         IOException.class,

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectChecksumSupportTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectChecksumSupportTest.java
@@ -54,7 +54,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(StorageITRunner.class)
 @CrossRun(
-    transports = {Transport.HTTP /*, Transport.GRPC*/},
+    transports = {Transport.HTTP, Transport.GRPC},
     backends = Backend.PROD)
 @Parameterized(ChecksummedTestContentProvider.class)
 public final class ITObjectChecksumSupportTest {


### PR DESCRIPTION
With the introduction of RewindableContent, we can now upload an entire file in a single WriteObjectRequest stream.

* chore: rename RewindableHttpContent -> RewindableContent

