### PR TITLE
fix: optimize resumable uploads to allow sending bytes during finalization

### DIFF
--- a/google-cloud-storage/clirr-ignored-differences.xml
+++ b/google-cloud-storage/clirr-ignored-differences.xml
@@ -8,4 +8,11 @@
     <method>com.google.cloud.storage.BlobWriteSession blobWriteSession(com.google.cloud.storage.BlobInfo, com.google.cloud.storage.Storage$BlobWriteOption[])</method>
   </difference>
 
+  <!-- Not breaking, new method has a default implementation -->
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/storage/UnbufferedWritableByteChannelSession$UnbufferedWritableByteChannel</className>
+    <method>* writeAndClose(*)</method>
+  </difference>
+
 </differences>

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultBufferedWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultBufferedWritableByteChannel.java
@@ -160,8 +160,17 @@ final class DefaultBufferedWritableByteChannel implements BufferedWritableByteCh
 
   @Override
   public void close() throws IOException {
-    try (UnbufferedWritableByteChannel ignored = channel) {
-      flush();
+    if (enqueuedBytes()) {
+      ByteBuffer buffer = handle.get();
+      Buffers.flip(buffer);
+      channel.writeAndClose(buffer);
+      if (buffer.hasRemaining()) {
+        buffer.compact();
+      } else {
+        Buffers.clear(buffer);
+      }
+    } else {
+      channel.close();
     }
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultStorageRetryStrategy.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultStorageRetryStrategy.java
@@ -145,7 +145,7 @@ final class DefaultStorageRetryStrategy implements StorageRetryStrategy {
     public RetryResult beforeEval(Exception exception) {
       if (exception instanceof IllegalArgumentException) {
         IllegalArgumentException illegalArgumentException = (IllegalArgumentException) exception;
-        if (illegalArgumentException.getMessage().equals("no JSON input found")) {
+        if ("no JSON input found".equals(illegalArgumentException.getMessage())) {
           return RetryResult.RETRY;
         }
       }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcResumableSession.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcResumableSession.java
@@ -91,6 +91,7 @@ final class GrpcResumableSession {
             if (query.getObject() != null) {
               return query;
             } else {
+              handle.get().clear();
               content.rewindTo(query.getPersistedSize());
             }
           }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageByteChannels.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageByteChannels.java
@@ -185,6 +185,22 @@ final class StorageByteChannels {
     }
 
     @Override
+    public synchronized int writeAndClose(ByteBuffer src) throws IOException {
+      return delegate.writeAndClose(src);
+    }
+
+    @Override
+    public synchronized long writeAndClose(ByteBuffer[] srcs) throws IOException {
+      return delegate.writeAndClose(srcs);
+    }
+
+    @Override
+    public synchronized long writeAndClose(ByteBuffer[] srcs, int offset, int length)
+        throws IOException {
+      return delegate.writeAndClose(srcs, offset, length);
+    }
+
+    @Override
     public boolean isOpen() {
       return delegate.isOpen();
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/UnbufferedWritableByteChannelSession.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/UnbufferedWritableByteChannelSession.java
@@ -28,12 +28,26 @@ interface UnbufferedWritableByteChannelSession<ResultT>
   interface UnbufferedWritableByteChannel extends WritableByteChannel, GatheringByteChannel {
     @Override
     default int write(ByteBuffer src) throws IOException {
-      return Math.toIntExact(write(new ByteBuffer[] {src}));
+      return Math.toIntExact(write(new ByteBuffer[] {src}, 0, 1));
     }
 
     @Override
     default long write(ByteBuffer[] srcs) throws IOException {
       return write(srcs, 0, srcs.length);
+    }
+
+    default int writeAndClose(ByteBuffer src) throws IOException {
+      return Math.toIntExact(writeAndClose(new ByteBuffer[] {src}, 0, 1));
+    }
+
+    default long writeAndClose(ByteBuffer[] srcs) throws IOException {
+      return writeAndClose(srcs, 0, srcs.length);
+    }
+
+    default long writeAndClose(ByteBuffer[] srcs, int offset, int length) throws IOException {
+      long write = write(srcs, offset, length);
+      close();
+      return write;
     }
   }
 }


### PR DESCRIPTION

Add new methods to UnbufferedWritableByteChannel to allow writing and closing in a single call
* writeAndClose(ByteBuffer)
* writeAndClose(ByteBuffer[])
* writeAndClose(ByteBuffer[], int, int)

Update grpc and json implementation to leverage new methods and to write and finalize in the same call.

DefaultBufferedWritableByteChannel will use the new methods as appropriate.

