### PR TITLE
chore: update BlobWriteSessionConfig to implement Serializable

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobWriteSessionConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobWriteSessionConfig.java
@@ -23,6 +23,7 @@ import com.google.cloud.storage.UnifiedOpts.ObjectTargetOpt;
 import com.google.cloud.storage.UnifiedOpts.Opts;
 import com.google.storage.v2.WriteObjectResponse;
 import java.io.IOException;
+import java.io.Serializable;
 import java.time.Clock;
 
 /**
@@ -39,7 +40,7 @@ import java.time.Clock;
  */
 // When we have java modules, actually seal this to internal extension only
 @InternalApi
-public abstract class BlobWriteSessionConfig {
+public abstract class BlobWriteSessionConfig implements Serializable {
 
   @InternalApi
   BlobWriteSessionConfig() {}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultBlobWriteSessionConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultBlobWriteSessionConfig.java
@@ -53,6 +53,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 @BetaApi
 public final class DefaultBlobWriteSessionConfig extends BlobWriteSessionConfig {
+  private static final long serialVersionUID = -6873740918589930633L;
 
   private final int chunkSize;
 


### PR DESCRIPTION
BlobWriteSessionConfig needs to implement Serializable because it plugs into StorageOptions which is Serializable.

Not sure, how the SerializationTest was passing when the PR was posted and now fails on main.

