### PR TITLE
chore: remove manual grpc version management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,13 +60,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-bom</artifactId>
-        <version>1.56.1</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
         <version>${google.cloud.shared-dependencies.version}</version>


### PR DESCRIPTION
Now that shared-dependencies is tracking grpc 1.56.1 we no longer need to override it ourselves.

