### PR TITLE
fix: make use of ImmutableMap.Builder#buildOrThrow graceful

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
@@ -2086,6 +2086,21 @@ final class UnifiedOpts {
    */
   @SuppressWarnings("unchecked")
   static final class Opts<T extends Opt> {
+    private static final Function<ImmutableMap.Builder<?, ?>, ImmutableMap<?, ?>> mapBuild;
+
+    static {
+      Function<ImmutableMap.Builder<?, ?>, ImmutableMap<?, ?>> tmp;
+      // buildOrThrow was added in guava 31.0
+      // if it fails, fallback to the older build() method instead.
+      // The behavior was the same, but the new name makes the behavior clear
+      try {
+        ImmutableMap.builder().buildOrThrow();
+        tmp = ImmutableMap.Builder::buildOrThrow;
+      } catch (NoSuchMethodError e) {
+        tmp = ImmutableMap.Builder::build;
+      }
+      mapBuild = tmp;
+    }
 
     private final ImmutableList<T> opts;
 
@@ -2172,7 +2187,7 @@ final class UnifiedOpts {
     ImmutableMap<StorageRpc.Option, ?> getRpcOptions() {
       ImmutableMap.Builder<StorageRpc.Option, Object> builder =
           rpcOptionMapper().apply(ImmutableMap.builder());
-      return builder.buildOrThrow();
+      return (ImmutableMap<StorageRpc.Option, ?>) mapBuild.apply(builder);
     }
 
     Mapper<GrpcCallContext> grpcMetadataMapper() {


### PR DESCRIPTION
`buildOrThrow` was added in guava 31.0, and while we specify a min version >= 31.0, sometimes our library is used in environments that set different guava version (usually due to platform pinned versions).

We do not strictly need this method, as it has the same behavior of `ImmutableMap.Builder#build()` but with a more clear name (`ImmutableMap.Builder` never allowed duplicate keys).

Manually tested, but creating a separate project that did the following in its maven config:
```
  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>com.google.guava</groupId>
        <artifactId>guava</artifactId>
        <version>24.0-jre</version>
      </dependency>
      <dependency>
        <groupId>com.google.cloud</groupId>
        <artifactId>google-cloud-storage-bom</artifactId>
        <version>2.26.1-SNAPSHOT</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
    </dependencies>
  </dependencyManagement>
  <dependencies>
    <dependency>
      <groupId>com.google.guava</groupId>
      <artifactId>guava</artifactId>
    </dependency>
    <dependency>
      <groupId>com.google.cloud</groupId>
      <artifactId>google-cloud-storage</artifactId>
      <exclusions>
        <exclusion>
          <groupId>com.google.guava</groupId>
          <artifactId>guava</artifactId>
        </exclusion>
      </exclusions>
    </dependency>
  </dependencies>
```

Then issuing any RPC.

