### PR TITLE
fix: update version resolution logic to be more resilient

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
@@ -23,7 +23,6 @@ import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.FixedCredentialsProvider;
-import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.GrpcInterceptorProvider;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
@@ -210,9 +209,7 @@ public final class GrpcStorageOptions extends StorageOptions
 
     HeaderProvider internalHeaderProvider =
         StorageSettings.defaultApiClientHeaderProviderBuilder()
-            .setClientLibToken(
-                ServiceOptions.getGoogApiClientLibName(),
-                GaxProperties.getLibraryVersion(this.getClass()))
+            .setClientLibToken(ServiceOptions.getGoogApiClientLibName(), getLibraryVersion())
             .build();
 
     StorageSettings.Builder builder =

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerImpl.java
@@ -20,7 +20,6 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.BetaApi;
 import com.google.api.core.ListenableFutureToApiFuture;
-import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -45,8 +44,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 final class TransferManagerImpl implements TransferManager {
 
   private static final String USER_AGENT_ENTRY = "gcloud-tm/";
-  private static final String LIBRARY_VERSION =
-      GaxProperties.getLibraryVersion(TransferManagerConfig.class);
+  private static final String LIBRARY_VERSION = StorageOptions.version();
   private final TransferManagerConfig transferManagerConfig;
   private final ListeningExecutorService executor;
   private final Qos qos;


### PR DESCRIPTION
Update StorageOptions to resolve its version from maven metadata rather than manifest version. A jar can only have one MANIFEST.mf thereby leading to storage thinking it is a version it is not.

In particular, if a program is shaded, this change will now allow for the actual version of storage to be carried through.

Related https://github.com/googleapis/google-api-java-client/pull/1419
