### PR TITLE
test: update bucket name for gRPC quickstart

### DIFF
--- a/samples/snippets/src/test/java/com/example/storage/QuickstartSampleIT.java
+++ b/samples/snippets/src/test/java/com/example/storage/QuickstartSampleIT.java
@@ -45,7 +45,7 @@ public class QuickstartSampleIT {
 
   @Before
   public void setUp() {
-    bucketName = "my-new-bucket-" + UUID.randomUUID();
+    bucketName = "java-storage-grpc-" + UUID.randomUUID();
   }
 
   @After


### PR DESCRIPTION
The current bucket name doesn't have an allowlisted prefix so the test is failing. Use the allowlisted prefix for now.

Fixes #2174
Fixes #2175

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-storage/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)


