### PR TITLE
feat: Follow-up CLI Improvements

### DIFF
--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/StorageSharedBenchmarkingCli.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/StorageSharedBenchmarkingCli.java
@@ -113,7 +113,7 @@ public final class StorageSharedBenchmarkingCli implements Runnable {
     Range objectSizeRange = Range.of(objectSize);
     for (int i = 0; i < samples; i++) {
       int objectSize = getRandomInt(objectSizeRange.min, objectSizeRange.max);
-      PrintWriter pw = new PrintWriter(System.out);
+      PrintWriter pw = new PrintWriter(System.out, true);
       workloadRuns.add(
           convert(
               executorService.submit(

--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/W1R3.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/W1R3.java
@@ -74,7 +74,6 @@ final class W1R3 implements Callable<String> {
                     created.getSize().longValue(), elapsedTimeUpload),
                 created)
             .toString());
-    printWriter.flush();
     for (int i = 0; i <= StorageSharedBenchmarkingUtils.DEFAULT_NUMBER_OF_READS; i++) {
       TmpFile dest = TmpFile.of(tempDirectory, "prefix", "bin");
       startTime = clock.instant();
@@ -88,7 +87,6 @@ final class W1R3 implements Callable<String> {
                       created.getSize().longValue(), elapsedTimeDownload),
                   created)
               .toString());
-      printWriter.flush();
     }
     StorageSharedBenchmarkingUtils.cleanupObject(storage, created);
     return "OK";


### PR DESCRIPTION
1. Rename Workload1.java to W1R3 to prevent future confusion when it is used for other workloads
2. Take in temporary directory as a CLI argument
3. Utilize PrintWrite instead of System.out directly
