### PR TITLE
feat: add new JournalingBlobWriteSessionConfig usable with gRPC transport

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobWriteSessionConfigs.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobWriteSessionConfigs.java
@@ -21,12 +21,114 @@ import com.google.cloud.storage.GrpcStorageOptions.GrpcStorageDefaults;
 import com.google.cloud.storage.Storage.BlobWriteOption;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.nio.channels.WritableByteChannel;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 
 /**
  * Factory class to select and construct {@link BlobWriteSessionConfig}s.
+ *
+ * <p>There are several strategies which can be used to upload a {@link Blob} to Google Cloud
+ * Storage. This class provides factories which allow you to select the appropriate strategy for
+ * your workload.
+ *
+ * <table>
+ *   <caption>Comparison of Strategies</caption>
+ *   <tr>
+ *     <th>Strategy</th>
+ *     <th>Factory Method(s)</th>
+ *     <th>Description</th>
+ *     <th>Retry Support</th>
+ *     <th>Transports Supported</th>
+ *     <th>Cloud Storage API used</th>
+ *     <th>Considerations</th>
+ *   </tr>
+ *   <tr>
+ *     <td>Default (Chunk based upload)</td>
+ *     <td>{@link #getDefault()}</td>
+ *     <td>
+ *       Buffer up to a configurable amount of bytes in memory, write to Cloud Storage when
+ *       full or close. Buffer size is configurable via
+ *       {@link DefaultBlobWriteSessionConfig#withChunkSize(int)}
+ *     </td>
+ *     <td>
+ *       Each chunk is retried up to the limitations specified in
+ *       {@link StorageOptions#getRetrySettings()}
+ *     </td>
+ *     <td>gRPC</td>
+ *     <td><a href="https://cloud.google.com/storage/docs/resumable-uploads">Resumable Upload</a></td>
+ *     <td>The network will only be used for the following operations:
+ *     <ol>
+ *       <li>Creating the Resumable Upload Session</li>
+ *       <li>Transmitting zero or more incremental chunks</li>
+ *       <li>Transmitting the final chunk and finalizing the Resumable Upload Session</li>
+ *       <li>
+ *         If any of the above are interrupted with a retryable error, the Resumable Upload Session
+ *         will be queried to reconcile client side state with Cloud Storage
+ *       </li>
+ *     </ol>
+ *     </td>
+ *   </tr>
+ *   <tr>
+ *     <td>Buffer to disk then upload</td>
+ *     <td>
+ *       <ul>
+ *         <li>{@link #bufferToDiskThenUpload(Path)}</li>
+ *         <li>{@link #bufferToDiskThenUpload(Collection) bufferToDiskThenUpload(Collection&lt;Path>)}</li>
+ *         <li>{@link #bufferToTempDirThenUpload()}</li>
+ *       </ul>
+ *     </td>
+ *     <td>
+ *       Buffer bytes to a temporary file on disk. On {@link WritableByteChannel#close() close()}
+ *       upload the entire files contents to Cloud Storage. Delete the temporary file.
+ *     </td>
+ *     <td>
+ *       Upload the file in the fewest number of RPC possible retrying within the limitations
+ *       specified in {@link StorageOptions#getRetrySettings()}
+ *     </td>
+ *     <td>gRPC</td>
+ *     <td><a href="https://cloud.google.com/storage/docs/resumable-uploads">Resumable Upload</a></td>
+ *     <td>
+ *       <ol>
+ *         <li>A Resumable Upload Session will be used to upload the file on disk.</li>
+ *         <li>
+ *           If the upload is interrupted with a retryable error, the Resumable Upload Session will
+ *           be queried to restart the upload from Cloud Storage's last received byte
+ *         </li>
+ *       </ol>
+ *     </td>
+ *   </tr>
+ *   <tr>
+ *     <td>Journal to disk while uploading</td>
+ *     <td>{@link #journaling(Collection) journaling(Collection&lt;Path>)}</td>
+ *     <td>
+ *       Create a Resumable Upload Session, before transmitting bytes to Cloud Storage write
+ *       to a recovery file on disk. If the stream to Cloud Storage is interrupted with a
+ *       retryable error query the offset of the Resumable Upload Session, then open the recovery
+ *       file from the offset and transmit the bytes to Cloud Storage.
+ *     </td>
+ *     <td>gRPC</td>
+ *     <td><a href="https://cloud.google.com/storage/docs/resumable-uploads">Resumable Upload</a></td>
+ *     <td>
+ *       <ol>
+ *         <li>
+ *           The stream to Cloud Storage will be held open until a) the write is complete
+ *           b) the stream is interrupted
+ *         </li>
+ *         <li>
+ *           Because the bytes are journaled to disk, the upload to Cloud Storage can only
+ *           be as fast as the disk.
+ *         </li>
+ *         <li>
+ *           The use of <a href="https://cloud.google.com/compute/docs/disks/local-ssd#nvme">Compute
+ *           Engine Local NVMe SSD</a> is strongly encouraged compared to Compute Engine Persistent
+ *           Disk.
+ *         </li>
+ *       </ol>
+ *     </td>
+ *   </tr>
+ * </table>
  *
  * @see BlobWriteSessionConfig
  * @see GrpcStorageOptions.Builder#setBlobWriteSessionConfig(BlobWriteSessionConfig)
@@ -56,11 +158,11 @@ public final class BlobWriteSessionConfigs {
    * Create a new {@link BlobWriteSessionConfig} which will first buffer the content of the object
    * to a temporary file under {@code java.io.tmpdir}.
    *
-   * <p>Once the file on disk is closed, the entire file will then be uploaded to Google Cloud
-   * Storage.
+   * <p>Once the file on disk is closed, the entire file will then be uploaded to Cloud Storage.
    *
    * @see Storage#blobWriteSession(BlobInfo, BlobWriteOption...)
    * @see GrpcStorageOptions.Builder#setBlobWriteSessionConfig(BlobWriteSessionConfig)
+   * @since 2.26.0 This new api is in preview and is subject to breaking changes.
    */
   @BetaApi
   public static BlobWriteSessionConfig bufferToTempDirThenUpload() throws IOException {
@@ -72,11 +174,11 @@ public final class BlobWriteSessionConfigs {
    * Create a new {@link BlobWriteSessionConfig} which will first buffer the content of the object
    * to a temporary file under the specified {@code path}.
    *
-   * <p>Once the file on disk is closed, the entire file will then be uploaded to Google Cloud
-   * Storage.
+   * <p>Once the file on disk is closed, the entire file will then be uploaded to Cloud Storage.
    *
    * @see Storage#blobWriteSession(BlobInfo, BlobWriteOption...)
    * @see GrpcStorageOptions.Builder#setBlobWriteSessionConfig(BlobWriteSessionConfig)
+   * @since 2.26.0 This new api is in preview and is subject to breaking changes.
    */
   @BetaApi
   public static BufferToDiskThenUpload bufferToDiskThenUpload(Path path) throws IOException {
@@ -87,18 +189,34 @@ public final class BlobWriteSessionConfigs {
    * Create a new {@link BlobWriteSessionConfig} which will first buffer the content of the object
    * to a temporary file under one of the specified {@code paths}.
    *
-   * <p>Once the file on disk is closed, the entire file will then be uploaded to Google Cloud
-   * Storage.
+   * <p>Once the file on disk is closed, the entire file will then be uploaded to Cloud Storage.
    *
    * <p>The specifics of how the work is spread across multiple paths is undefined and subject to
    * change.
    *
    * @see Storage#blobWriteSession(BlobInfo, BlobWriteOption...)
    * @see GrpcStorageOptions.Builder#setBlobWriteSessionConfig(BlobWriteSessionConfig)
+   * @since 2.26.0 This new api is in preview and is subject to breaking changes.
    */
   @BetaApi
   public static BufferToDiskThenUpload bufferToDiskThenUpload(Collection<Path> paths)
       throws IOException {
     return new BufferToDiskThenUpload(ImmutableList.copyOf(paths), false);
+  }
+
+  /**
+   * Create a new {@link BlobWriteSessionConfig} which will journal writes to a temporary file under
+   * one of the specified {@code paths} before transmitting the bytes to Cloud Storage.
+   *
+   * <p>The specifics of how the work is spread across multiple paths is undefined and subject to
+   * change.
+   *
+   * @see Storage#blobWriteSession(BlobInfo, BlobWriteOption...)
+   * @see GrpcStorageOptions.Builder#setBlobWriteSessionConfig(BlobWriteSessionConfig)
+   * @since 2.27.0 This new api is in preview and is subject to breaking changes.
+   */
+  @BetaApi
+  public static JournalingBlobWriteSessionConfig journaling(Collection<Path> paths) {
+    return new JournalingBlobWriteSessionConfig(ImmutableList.copyOf(paths), false);
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Buffers.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Buffers.java
@@ -16,8 +16,10 @@
 
 package com.google.cloud.storage;
 
+import java.io.IOException;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
 import java.util.function.Consumer;
 
 /**
@@ -136,5 +138,20 @@ final class Buffers {
       alignedSize = (size + alignmentMultiple - 1) / alignmentMultiple * alignmentMultiple;
     } // else size is already aligned
     return alignedSize;
+  }
+
+  static int fillFrom(ByteBuffer buf, ReadableByteChannel c) throws IOException {
+    int total = 0;
+    while (buf.hasRemaining()) {
+      int read = c.read(buf);
+      if (read != -1) {
+        total += read;
+      } else if (total == 0) {
+        return -1;
+      } else {
+        break;
+      }
+    }
+    return total;
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ChunkSegmenter.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ChunkSegmenter.java
@@ -50,6 +50,10 @@ final class ChunkSegmenter {
     return hasher;
   }
 
+  ChunkSegment[] segmentBuffer(ByteBuffer bb) {
+    return segmentBuffers(new ByteBuffer[] {bb}, 0, 1);
+  }
+
   /**
    * Given {@code bbs}, yield N segments, where each segment is at most {@code maxSegmentSize}
    * bytes.

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultBlobWriteSessionConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultBlobWriteSessionConfig.java
@@ -79,7 +79,8 @@ public final class DefaultBlobWriteSessionConfig extends BlobWriteSessionConfig 
    *
    * <p><i>Default:</i> {@code 16777216 (16 MiB)}
    *
-   * @param chunkSize The number of bytes each chunk should be. Must be >= {@code 262144 (256 KiB)}
+   * @param chunkSize The number of bytes each chunk should be. Must be &gt;= {@code 262144 (256
+   *     KiB)}
    * @return The new instance
    * @see #getChunkSize()
    * @since 2.26.0 This new api is in preview and is subject to breaking changes.

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultBufferedWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultBufferedWritableByteChannel.java
@@ -145,7 +145,8 @@ final class DefaultBufferedWritableByteChannel implements BufferedWritableByteCh
           ByteBuffer slice = src.slice();
           Buffers.limit(slice, bufferRemaining);
           int write = channel.write(slice);
-          Buffers.position(src, srcPosition + write);
+          int newPosition = srcPosition + write;
+          Buffers.position(src, newPosition);
           bytesConsumed += write;
         }
       }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -1768,7 +1768,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
     return opts.readObjectRequest().apply(builder).build();
   }
 
-  private WriteObjectRequest getWriteObjectRequest(BlobInfo info, Opts<ObjectTargetOpt> opts) {
+  WriteObjectRequest getWriteObjectRequest(BlobInfo info, Opts<ObjectTargetOpt> opts) {
     Object object = codecs.blobInfo().encode(info);
     Object.Builder objectBuilder =
         object

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/RecoveryFileManager.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/RecoveryFileManager.java
@@ -66,7 +66,7 @@ final class RecoveryFileManager {
     return of(volumes, p -> ThroughputSink.nullSink());
   }
 
-  static RecoveryFileManager of(List<Path> volumes, RecoverVolumeSinkFactory factory)
+  static RecoveryFileManager of(List<Path> volumes, RecoveryVolumeSinkFactory factory)
       throws IOException {
     checkArgument(!volumes.isEmpty(), "At least one volume must be specified");
     checkArgument(
@@ -86,7 +86,7 @@ final class RecoveryFileManager {
   }
 
   @FunctionalInterface
-  interface RecoverVolumeSinkFactory {
+  interface RecoveryVolumeSinkFactory {
     ThroughputSink apply(Path p);
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/SyncAndUploadUnbufferedWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/SyncAndUploadUnbufferedWritableByteChannel.java
@@ -1,0 +1,468 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.cloud.storage.WriteFlushStrategy.contextWithBucketName;
+
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.grpc.GrpcCallContext;
+import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.retrying.ResultRetryAlgorithm;
+import com.google.api.gax.retrying.TimedAttemptSettings;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.ApiExceptionFactory;
+import com.google.api.gax.rpc.ApiExceptions;
+import com.google.api.gax.rpc.ApiStreamObserver;
+import com.google.api.gax.rpc.ClientStreamingCallable;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.cloud.storage.ChunkSegmenter.ChunkSegment;
+import com.google.cloud.storage.Conversions.Decoder;
+import com.google.cloud.storage.Crc32cValue.Crc32cLengthKnown;
+import com.google.cloud.storage.Retrying.RetryingDependencies;
+import com.google.cloud.storage.UnbufferedWritableByteChannelSession.UnbufferedWritableByteChannel;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.protobuf.ByteString;
+import com.google.storage.v2.ChecksummedData;
+import com.google.storage.v2.Object;
+import com.google.storage.v2.ObjectChecksums;
+import com.google.storage.v2.QueryWriteStatusRequest;
+import com.google.storage.v2.QueryWriteStatusResponse;
+import com.google.storage.v2.WriteObjectRequest;
+import com.google.storage.v2.WriteObjectResponse;
+import io.grpc.Status.Code;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.util.Arrays;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+final class SyncAndUploadUnbufferedWritableByteChannel implements UnbufferedWritableByteChannel {
+
+  private final ClientStreamingCallable<WriteObjectRequest, WriteObjectResponse> write;
+  private final UnaryCallable<QueryWriteStatusRequest, QueryWriteStatusResponse> query;
+  private final SettableApiFuture<WriteObjectResponse> resultFuture;
+  private final ChunkSegmenter chunkSegmenter;
+  private final WriteCtx<ResumableWrite> writeCtx;
+  private final RetryingDependencies deps;
+  private final ResultRetryAlgorithm<?> alg;
+  private final RecoveryFile rf;
+
+  private final String uploadId;
+  private final BufferHandle copyBuffer;
+
+  /* --- running state --- */
+  private final RequestStream stream;
+
+  private boolean open;
+  private @Nullable GatheringByteChannel sync;
+  private boolean first;
+  private boolean finished;
+
+  SyncAndUploadUnbufferedWritableByteChannel(
+      ClientStreamingCallable<WriteObjectRequest, WriteObjectResponse> write,
+      UnaryCallable<QueryWriteStatusRequest, QueryWriteStatusResponse> query,
+      SettableApiFuture<WriteObjectResponse> resultFuture,
+      ChunkSegmenter chunkSegmenter,
+      RetryingDependencies deps,
+      ResultRetryAlgorithm<?> alg,
+      WriteCtx<ResumableWrite> writeCtx,
+      RecoveryFile rf,
+      BufferHandle copyBuffer) {
+    this.write =
+        write.withDefaultCallContext(
+            contextWithBucketName(
+                writeCtx.getRequestFactory().bucketName(), GrpcCallContext.createDefault()));
+    this.query = query;
+    this.resultFuture = resultFuture;
+    this.chunkSegmenter = chunkSegmenter;
+    this.writeCtx = writeCtx;
+    this.deps = deps;
+    this.alg = new Alg(alg, resultFuture);
+    this.rf = rf;
+    this.uploadId = writeCtx.newRequestBuilder().getUploadId();
+    this.copyBuffer = copyBuffer;
+    this.stream = new RequestStream(this.write, resultFuture);
+    this.open = true;
+    this.first = true;
+    this.finished = false;
+  }
+
+  @SuppressWarnings("resource")
+  @Override
+  public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+    if (!open) {
+      throw new ClosedChannelException();
+    }
+    ByteBuffer[] duplicates =
+        Arrays.stream(srcs, offset, offset + length)
+            .map(ByteBuffer::duplicate)
+            .toArray(ByteBuffer[]::new);
+    long prevWritten = writeCtx.getTotalSentBytes().get();
+    long syncWritten = openSync().write(duplicates);
+    long goalSize = Math.addExact(prevWritten, syncWritten);
+    ChunkSegment[] segments = chunkSegmenter.segmentBuffers(srcs, offset, length);
+    doUpload(false, segments, goalSize);
+    return syncWritten;
+  }
+
+  @Override
+  public boolean isOpen() {
+    return open;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (!open) {
+      return;
+    }
+    try {
+      doUpload(true, new ChunkSegment[0], writeCtx.getTotalSentBytes().get());
+      rf.close();
+    } finally {
+      open = false;
+    }
+  }
+
+  private GatheringByteChannel openSync() throws IOException {
+    if (sync == null) {
+      sync = rf.syncingChannel();
+    }
+    return sync;
+  }
+
+  private WriteObjectRequest processSegment(ChunkSegment segment) {
+    WriteObjectRequest.Builder builder = writeCtx.newRequestBuilder();
+    if (!first) {
+      builder.clearUploadId().clearWriteObjectSpec().clearObjectChecksums();
+    } else {
+      first = false;
+    }
+
+    Crc32cLengthKnown crc32c = segment.getCrc32c();
+    ByteString b = segment.getB();
+    int contentSize = b.size();
+
+    // update ctx state that tracks overall progress
+    writeCtx
+        .getCumulativeCrc32c()
+        .accumulateAndGet(crc32c, chunkSegmenter.getHasher()::nullSafeConcat);
+    // resolve current offset and set next
+    long offset = writeCtx.getTotalSentBytes().getAndAdd(contentSize);
+
+    ChecksummedData.Builder checksummedData = ChecksummedData.newBuilder().setContent(b);
+    if (crc32c != null) {
+      checksummedData.setCrc32C(crc32c.getValue());
+    }
+    builder.setWriteOffset(offset).setChecksummedData(checksummedData.build());
+
+    if (!segment.isOnlyFullBlocks()) {
+      finishMessage(builder);
+      finished = true;
+    }
+
+    WriteObjectRequest build = builder.build();
+    return build;
+  }
+
+  @NonNull
+  private WriteObjectRequest finishMessage() {
+    long offset = writeCtx.getTotalSentBytes().get();
+
+    WriteObjectRequest.Builder b = writeCtx.newRequestBuilder().setWriteOffset(offset);
+
+    WriteObjectRequest message = finishMessage(b).build();
+    return message;
+  }
+
+  private WriteObjectRequest.Builder finishMessage(WriteObjectRequest.Builder b) {
+    Crc32cLengthKnown crc32cValue = writeCtx.getCumulativeCrc32c().get();
+    b.setFinishWrite(true);
+    if (crc32cValue != null) {
+      b.setObjectChecksums(ObjectChecksums.newBuilder().setCrc32C(crc32cValue.getValue()).build());
+    }
+    return b;
+  }
+
+  private void doUpload(boolean closing, ChunkSegment[] segments, long goalSize) {
+    AtomicBoolean recover = new AtomicBoolean(false);
+    Retrying.run(
+        deps,
+        alg,
+        () -> {
+          if (closing && sync != null) {
+            sync.close();
+          }
+          boolean shouldRecover = recover.getAndSet(true);
+          if (!shouldRecover) {
+            for (ChunkSegment segment : segments) {
+              WriteObjectRequest writeObjectRequest = processSegment(segment);
+              stream.onNext(writeObjectRequest);
+            }
+
+            if (closing && !finished) {
+              WriteObjectRequest message = finishMessage();
+              stream.onNext(message);
+              finished = true;
+            }
+
+            if (closing) {
+              stream.onCompleted();
+            }
+          } else {
+            if (sync != null) {
+              sync.close();
+              sync = null;
+            }
+            stream.reset();
+
+            QueryWriteStatusRequest req =
+                QueryWriteStatusRequest.newBuilder().setUploadId(uploadId).build();
+            QueryWriteStatusResponse resp = query.call(req);
+            // if the response has a resource the session completed, no need to re-upload
+            if (!resp.hasResource()) {
+              long persistedSize = resp.getPersistedSize();
+
+              if (persistedSize != goalSize) {
+
+                // rewind our context
+                finished = false;
+                first = true;
+                writeCtx.getTotalSentBytes().set(persistedSize);
+                writeCtx.getConfirmedBytes().set(persistedSize);
+                writeCtx.getCumulativeCrc32c().set(null); // todo: can we rewind checksum?
+
+                try (SeekableByteChannel reader = rf.reader()) {
+                  reader.position(persistedSize);
+                  ByteBuffer buf = copyBuffer.get();
+                  while (Buffers.fillFrom(buf, reader) != -1) {
+                    buf.flip();
+                    while (buf.hasRemaining()) {
+                      ChunkSegment[] recoverySegments = chunkSegmenter.segmentBuffer(buf);
+                      for (ChunkSegment segment : recoverySegments) {
+                        WriteObjectRequest writeObjectRequest = processSegment(segment);
+                        stream.onNext(writeObjectRequest);
+                      }
+                    }
+                    buf.clear();
+                  }
+                }
+                if (closing && !finished) {
+                  WriteObjectRequest message = finishMessage();
+                  stream.onNext(message);
+                  finished = true;
+                }
+                recover.compareAndSet(true, false);
+                if (closing || finished) {
+                  stream.onCompleted();
+                }
+              }
+            } else {
+              Object resource = resp.getResource();
+              resultFuture.set(WriteObjectResponse.newBuilder().setResource(resource).build());
+            }
+          }
+          long newWritten = writeCtx.getTotalSentBytes().get();
+          Preconditions.checkState(newWritten == goalSize, "%s == %s", newWritten, goalSize);
+          return null;
+        },
+        Decoder.identity());
+  }
+
+  @VisibleForTesting
+  static final class RequestStream implements ApiStreamObserver<WriteObjectRequest> {
+    private static final ApiException CLIENT_RESET_ERROR =
+        ApiExceptionFactory.createException(null, GrpcStatusCode.of(Code.ABORTED), false);
+
+    private final ClientStreamingCallable<WriteObjectRequest, WriteObjectResponse> write;
+    private final SettableApiFuture<WriteObjectResponse> resultFuture;
+
+    private volatile StreamPair streamPair;
+
+    private RequestStream(
+        ClientStreamingCallable<WriteObjectRequest, WriteObjectResponse> write,
+        SettableApiFuture<WriteObjectResponse> resultFuture) {
+      this.write = write;
+      this.resultFuture = resultFuture;
+    }
+
+    @Override
+    public void onNext(WriteObjectRequest value) {
+      StreamPair pair = ensureOpen();
+      Throwable err = pair.getResponseStream().error;
+      if (err != null) {
+        reset();
+        throw StorageException.coalesce(err);
+      }
+
+      halfClosedToUnavailable(() -> pair.getRequestStream().onNext(value));
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      try {
+        halfClosedToUnavailable(() -> ensureOpen().getRequestStream().onError(t));
+      } finally {
+        streamPair = null;
+      }
+    }
+
+    @Override
+    public void onCompleted() {
+      StreamPair pair = ensureOpen();
+      Throwable err = pair.getResponseStream().error;
+      if (err != null) {
+        reset();
+        throw StorageException.coalesce(err);
+      }
+
+      halfClosedToUnavailable(pair.getRequestStream()::onCompleted);
+      pair.getResponseStream().await();
+    }
+
+    private StreamPair ensureOpen() {
+      if (streamPair == null) {
+        ResponseStream responseStream = new ResponseStream(resultFuture);
+        ApiStreamObserver<WriteObjectRequest> requestStream =
+            write.clientStreamingCall(responseStream);
+        streamPair = new StreamPair(requestStream, responseStream);
+      }
+      return streamPair;
+    }
+
+    private void reset() {
+      if (streamPair != null && streamPair.getRequestStream() != null) {
+        streamPair.getRequestStream().onError(CLIENT_RESET_ERROR);
+      }
+      streamPair = null;
+    }
+
+    /**
+     * If the stream is in the process of closing (usually due to error) and we call a method on it
+     * we will receive an IllegalStateException. A stream being half closed is not a terminal state
+     * for our upload operation. Attempt to detect and translate it into an UNAVAILABLE error we can
+     * retry.
+     */
+    static void halfClosedToUnavailable(Runnable r) {
+      try {
+        r.run();
+      } catch (IllegalStateException ise) {
+        String message = ise.getMessage();
+        if (message != null && message.contains("half-closed")) {
+          throw ApiExceptionFactory.createException(ise, GrpcStatusCode.of(Code.UNAVAILABLE), true);
+        } else {
+          throw ise;
+        }
+      }
+    }
+  }
+
+  @VisibleForTesting
+  static final class ResponseStream implements ApiStreamObserver<WriteObjectResponse> {
+    private final SettableApiFuture<Void> invocationHandle;
+    private final SettableApiFuture<WriteObjectResponse> resultFuture;
+
+    private volatile WriteObjectResponse last;
+    private volatile Throwable error;
+
+    @VisibleForTesting
+    ResponseStream(SettableApiFuture<WriteObjectResponse> resultFuture) {
+      this.resultFuture = resultFuture;
+      this.invocationHandle = SettableApiFuture.create();
+    }
+
+    @Override
+    public void onNext(WriteObjectResponse value) {
+      last = value;
+      error = null;
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      error = t;
+      invocationHandle.setException(t);
+    }
+
+    @Override
+    public void onCompleted() {
+      if (last != null && last.hasResource()) {
+        resultFuture.set(last);
+      }
+      invocationHandle.set(null);
+    }
+
+    void await() {
+      ApiExceptions.callAndTranslateApiException(invocationHandle);
+    }
+  }
+
+  @VisibleForTesting
+  static final class Alg implements ResultRetryAlgorithm<WriteObjectResponse> {
+
+    private final ResultRetryAlgorithm<WriteObjectResponse> delegate;
+    private final SettableApiFuture<WriteObjectResponse> resultFuture;
+
+    @VisibleForTesting
+    @SuppressWarnings("unchecked")
+    Alg(ResultRetryAlgorithm<?> delegate, SettableApiFuture<WriteObjectResponse> resultFuture) {
+      this.delegate = (ResultRetryAlgorithm<WriteObjectResponse>) delegate;
+      this.resultFuture = resultFuture;
+    }
+
+    @Override
+    public TimedAttemptSettings createNextAttempt(
+        Throwable prevThrowable,
+        WriteObjectResponse prevResponse,
+        TimedAttemptSettings prevSettings) {
+      return delegate.createNextAttempt(prevThrowable, prevResponse, prevSettings);
+    }
+
+    @Override
+    public boolean shouldRetry(Throwable prevThrowable, WriteObjectResponse prevResponse)
+        throws CancellationException {
+      boolean shouldRetry = delegate.shouldRetry(prevThrowable, prevResponse);
+      if (!shouldRetry && prevThrowable != null) {
+        resultFuture.setException(prevThrowable);
+      }
+      return shouldRetry;
+    }
+  }
+
+  private static final class StreamPair {
+    private final ApiStreamObserver<WriteObjectRequest> requestStream;
+    private final ResponseStream responseStream;
+
+    private StreamPair(
+        ApiStreamObserver<WriteObjectRequest> requestStream, ResponseStream responseStream) {
+      this.requestStream = requestStream;
+      this.responseStream = responseStream;
+    }
+
+    public ApiStreamObserver<WriteObjectRequest> getRequestStream() {
+      return requestStream;
+    }
+
+    public ResponseStream getResponseStream() {
+      return responseStream;
+    }
+  }
+}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/SyncingFileChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/SyncingFileChannel.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import com.google.cloud.storage.UnbufferedWritableByteChannelSession.UnbufferedWritableByteChannel;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+/** A FileChannel decorator that will fsync after every {@link #write(ByteBuffer)} */
+final class SyncingFileChannel implements UnbufferedWritableByteChannel {
+
+  private final FileChannel fc;
+
+  SyncingFileChannel(FileChannel fc) {
+    this.fc = fc;
+  }
+
+  @Override
+  public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+    long written = fc.write(srcs, offset, length);
+    // metadata in this case are things like mtime, atime etc. Those are not important to our needs
+    // simply force the file contents to by synced.
+    fc.force(/*includeMetaData = */ false);
+    return written;
+  }
+
+  @Override
+  public boolean isOpen() {
+    return fc.isOpen();
+  }
+
+  @Override
+  public void close() throws IOException {
+    fc.close();
+  }
+}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/WriteCtx.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/WriteCtx.java
@@ -40,6 +40,10 @@ final class WriteCtx<RequestFactoryT extends WriteObjectRequestBuilderFactory> {
     this.cumulativeCrc32c = new AtomicReference<>();
   }
 
+  public RequestFactoryT getRequestFactory() {
+    return requestFactory;
+  }
+
   public WriteObjectRequest.Builder newRequestBuilder() {
     return requestFactory.newBuilder();
   }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/WriteFlushStrategy.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/WriteFlushStrategy.java
@@ -86,8 +86,7 @@ final class WriteFlushStrategy {
         new FsyncOnClose(write, bucketName, committedTotalBytesCallback, onSuccessCallback);
   }
 
-  private static GrpcCallContext contextWithBucketName(
-      String bucketName, GrpcCallContext baseContext) {
+  static GrpcCallContext contextWithBucketName(String bucketName, GrpcCallContext baseContext) {
     if (bucketName != null && !bucketName.isEmpty()) {
       return baseContext.withExtraHeaders(
           ImmutableMap.of(
@@ -257,7 +256,7 @@ final class WriteFlushStrategy {
     }
   }
 
-  private static class Observer implements ApiStreamObserver<WriteObjectResponse> {
+  static class Observer implements ApiStreamObserver<WriteObjectResponse> {
 
     private final LongConsumer sizeCallback;
     private final Consumer<WriteObjectResponse> completeCallback;
@@ -265,7 +264,7 @@ final class WriteFlushStrategy {
     private final SettableApiFuture<Void> invocationHandle;
     private volatile WriteObjectResponse last;
 
-    private Observer(LongConsumer sizeCallback, Consumer<WriteObjectResponse> completeCallback) {
+    Observer(LongConsumer sizeCallback, Consumer<WriteObjectResponse> completeCallback) {
       this.sizeCallback = sizeCallback;
       this.completeCallback = completeCallback;
       this.invocationHandle = SettableApiFuture.create();
@@ -304,7 +303,7 @@ final class WriteFlushStrategy {
       invocationHandle.set(null);
     }
 
-    private void await() {
+    void await() {
       try {
         invocationHandle.get();
       } catch (InterruptedException | ExecutionException e) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITSyncingFileChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITSyncingFileChannelTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.cloud.storage.RewindableContentPropertyTest.byteBuffers;
+import static com.google.cloud.storage.TestUtils.xxd;
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.file.Files.readAllBytes;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+
+public final class ITSyncingFileChannelTest {
+
+  /**
+   * Run a series of generated scenarios where each write is performed against a {@link
+   * SyncingFileChannel} after {@link SyncingFileChannel#write(ByteBuffer)} returns verify the full
+   * contents of the file match the expected cumulative value.
+   */
+  @Property
+  void shouldHandleAnySizeWriteGt0(@ForAll("WriteScenario") WriteScenario writeScenario)
+      throws IOException {
+    // use try-with-resource to approximate @TearDown and cleanup the file
+    try (WriteScenario ws = writeScenario) {
+      Path path = ws.getPath();
+      try (FileChannel fc = FileChannel.open(path, ws.getOpenOptions());
+          SyncingFileChannel syncing = new SyncingFileChannel(fc)) {
+        assertThat(syncing.isOpen()).isTrue();
+        ByteBuffer[] writes = ws.writes();
+        for (int i = 0; i < writes.length; i++) {
+          ByteBuffer buf = writes[i];
+          syncing.write(buf);
+          assertThat(xxd(readAllBytes(path))).isEqualTo(ws.expected(i));
+        }
+      }
+      assertThat(xxd(readAllBytes(path))).isEqualTo(ws.all());
+    }
+  }
+
+  @Provide("WriteScenario")
+  static Arbitrary<WriteScenario> writeScenario() {
+    return Arbitraries.lazyOf(
+            () ->
+                Arbitraries.oneOf(
+                    byteBuffers(1, 10),
+                    byteBuffers(10, 100),
+                    byteBuffers(100, 1_000),
+                    byteBuffers(1_000, 10_000),
+                    byteBuffers(10_000, 100_000),
+                    byteBuffers(100_000, 1_000_000)))
+        .map(
+            buffers ->
+                Arrays.stream(buffers).filter(Buffer::hasRemaining).toArray(ByteBuffer[]::new))
+        .filter(
+            buffers -> {
+              long totalAvailable = Arrays.stream(buffers).mapToLong(ByteBuffer::remaining).sum();
+              return totalAvailable > 0;
+            })
+        .map(WriteScenario::of);
+  }
+
+  static final class WriteScenario implements AutoCloseable {
+    private static final Path TMP_DIR = Paths.get(System.getProperty("java.io.tmpdir"));
+    private static final Collector<CharSequence, ?, String> DEBUG_JOINER =
+        Collectors.joining(",\n\t", "[\n\t", "\n]");
+
+    private final Path path;
+    private final ByteBuffer[] writes;
+    private final ByteString[] expectedCumulativeContents;
+    private final EnumSet<StandardOpenOption> openOptions;
+
+    private WriteScenario(Path path, ByteBuffer[] writes, ByteString[] expectedCumulativeContents) {
+      this.path = path;
+      this.writes = writes;
+      this.expectedCumulativeContents = expectedCumulativeContents;
+      this.openOptions = EnumSet.of(StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+    }
+
+    public Path getPath() {
+      return path;
+    }
+
+    public EnumSet<StandardOpenOption> getOpenOptions() {
+      return openOptions;
+    }
+
+    ByteBuffer[] writes() {
+      return Arrays.stream(writes).map(ByteBuffer::duplicate).toArray(ByteBuffer[]::new);
+    }
+
+    String expected(int idx) {
+      Preconditions.checkArgument(
+          0 <= idx && idx < expectedCumulativeContents.length,
+          "index out of bounds: (0 <= %s && %s < %s)",
+          idx,
+          idx,
+          expectedCumulativeContents.length);
+      return xxd(false, expectedCumulativeContents[idx].asReadOnlyByteBuffer());
+    }
+
+    String all() {
+      return xxd(
+          false,
+          expectedCumulativeContents[expectedCumulativeContents.length - 1].asReadOnlyByteBuffer());
+    }
+
+    @Override
+    public void close() throws IOException {
+      Files.deleteIfExists(path);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("\npath", path)
+          .add(
+              "\nwrites",
+              Arrays.stream(writes)
+                  .map(b -> String.format("%s \n %s", b.toString(), xxd(false, b.duplicate())))
+                  .collect(DEBUG_JOINER))
+          .add(
+              "\nexpectedCumulativeContents",
+              Arrays.stream(expectedCumulativeContents)
+                  .map(ByteString::toString)
+                  .collect(DEBUG_JOINER))
+          .toString();
+    }
+
+    public static WriteScenario of(ByteBuffer[] byteBuffers) {
+      try {
+        Path path = Files.createTempFile(TMP_DIR, WriteScenario.class.getName() + "-", ".bin");
+
+        List<ByteString> byteStrings = new ArrayList<>();
+        for (int i = 0; i < byteBuffers.length; i++) {
+          ByteString bs = ByteString.empty();
+          for (int j = 0; j <= i; j++) {
+            ByteBuffer byteBuffer = byteBuffers[j].duplicate();
+            bs = bs.concat(ByteStringStrategy.noCopy().apply(byteBuffer));
+          }
+          byteStrings.add(bs);
+        }
+
+        return new WriteScenario(path, byteBuffers, byteStrings.toArray(new ByteString[0]));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/RewindableContentPropertyTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/RewindableContentPropertyTest.java
@@ -143,7 +143,7 @@ final class RewindableContentPropertyTest {
   }
 
   @NonNull
-  private static Arbitrary<ByteBuffer[]> byteBuffers(int perBufferMinSize, int perBufferMaxSize) {
+  static Arbitrary<ByteBuffer[]> byteBuffers(int perBufferMinSize, int perBufferMaxSize) {
     return byteBuffer(perBufferMinSize, perBufferMaxSize)
         .array(ByteBuffer[].class)
         .ofMinSize(1)
@@ -155,7 +155,7 @@ final class RewindableContentPropertyTest {
    * limit
    */
   @NonNull
-  private static Arbitrary<ByteBuffer> byteBuffer(int minSize, int maxSize) {
+  static Arbitrary<ByteBuffer> byteBuffer(int minSize, int maxSize) {
     return Arbitraries.integers()
         .between(minSize, maxSize)
         .withDistribution(RandomDistribution.uniform())

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/TestUtils.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/TestUtils.java
@@ -229,6 +229,10 @@ public final class TestUtils {
     return xxd(true, bytes);
   }
 
+  public static String xxd(ByteString bytes) {
+    return xxd(false, bytes.asReadOnlyByteBuffer());
+  }
+
   public static String xxd(boolean flip, ByteBuffer bytes) {
     ByteBuffer dup = bytes.duplicate();
     if (flip) dup.flip();

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ThroughputSinkTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ThroughputSinkTest.java
@@ -22,6 +22,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.cloud.storage.ThroughputSink.Record;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.time.Duration;
 import java.time.Instant;
@@ -256,6 +257,11 @@ public final class ThroughputSinkTest {
 
     @Override
     public WritableByteChannel decorate(WritableByteChannel wbc) {
+      return null;
+    }
+
+    @Override
+    public GatheringByteChannel decorate(GatheringByteChannel wbc) {
       return null;
     }
   }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcInterceptorTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcInterceptorTest.java
@@ -83,8 +83,6 @@ public class ITGrpcInterceptorTest {
             .map(m -> m.get(X_GOOG_REQUEST_PARAMS))
             .collect(Collectors.toList());
 
-    System.out.println("requestParams = " + requestParams);
-
     String expected = String.format("project=projects/%s", options.getProjectId());
     String expectedEncoded = String.format("project=projects%%2F%s", options.getProjectId());
     assertThat(requestParams).containsAnyOf(expected, expectedEncoded);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITJournalingBlobWriteSessionConfigTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITJournalingBlobWriteSessionConfigTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.it;
+
+import static com.google.cloud.storage.TestUtils.assertAll;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BlobWriteSession;
+import com.google.cloud.storage.BlobWriteSessionConfigs;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.DataGenerator;
+import com.google.cloud.storage.GrpcStorageOptions;
+import com.google.cloud.storage.JournalingBlobWriteSessionConfig;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobWriteOption;
+import com.google.cloud.storage.TransportCompatibility.Transport;
+import com.google.cloud.storage.it.runner.StorageITRunner;
+import com.google.cloud.storage.it.runner.annotations.Backend;
+import com.google.cloud.storage.it.runner.annotations.Inject;
+import com.google.cloud.storage.it.runner.annotations.SingleBackend;
+import com.google.cloud.storage.it.runner.annotations.StorageFixture;
+import com.google.cloud.storage.it.runner.registry.Generator;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+@RunWith(StorageITRunner.class)
+@SingleBackend(Backend.PROD)
+public final class ITJournalingBlobWriteSessionConfigTest {
+  private static final int _1MiB = 1024 * 1024;
+  private static final int _256MiB = 256 * _1MiB;
+
+  @Inject
+  @StorageFixture(Transport.GRPC)
+  public Storage storage;
+
+  @Inject public BucketInfo bucket;
+  @Inject public Generator generator;
+
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private Storage journalingStorage;
+  private Path tempDir;
+
+  @Before
+  public void setUp() throws Exception {
+    tempDir = temporaryFolder.newFolder(generator.randomObjectName()).toPath();
+    JournalingBlobWriteSessionConfig journaling =
+        BlobWriteSessionConfigs.journaling(ImmutableList.of(tempDir));
+    journalingStorage =
+        ((GrpcStorageOptions.Builder) this.storage.getOptions().toBuilder())
+            .setBlobWriteSessionConfig(journaling)
+            .build()
+            .getService();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (journalingStorage != null) {
+      journalingStorage.close();
+    }
+  }
+
+  @Test
+  public void allBytesProperlyTransmitted() throws Exception {
+
+    Random rand = new Random(bucket.getName().hashCode());
+    int objectSize = _256MiB;
+    byte[] bytes = DataGenerator.rand(rand).genBytes(objectSize);
+
+    BlobInfo info = BlobInfo.newBuilder(bucket, generator.randomObjectName()).build();
+
+    BlobWriteSession blobWriteSession =
+        journalingStorage.blobWriteSession(info, BlobWriteOption.doesNotExist());
+    try (WritableByteChannel w = blobWriteSession.open()) {
+      w.write(ByteBuffer.wrap(bytes));
+    }
+
+    BlobInfo resource = blobWriteSession.getResult().get(1, TimeUnit.SECONDS);
+
+    byte[] actual = storage.readAllBytes(info.getBlobId());
+    assertAll(
+        () -> assertThat(resource.getSize()).isEqualTo(objectSize),
+        () -> assertThat(actual).isEqualTo(bytes));
+  }
+
+  @Test
+  public void journalFileMustNotBeLeftOnDiskAfterSuccess() throws IOException {
+    BlobInfo info = BlobInfo.newBuilder(bucket, generator.randomObjectName()).build();
+    byte[] bytes = DataGenerator.base64Characters().genBytes(17);
+    BlobWriteSession blobWriteSession =
+        journalingStorage.blobWriteSession(info, BlobWriteOption.doesNotExist());
+    try (WritableByteChannel w = blobWriteSession.open()) {
+      w.write(ByteBuffer.wrap(bytes));
+    }
+
+    try (Stream<Path> stream = Files.list(tempDir)) {
+      ImmutableList<Path> leftOverFiles = stream.collect(ImmutableList.toImmutableList());
+      assertThat(leftOverFiles).isEmpty();
+    }
+  }
+}


### PR DESCRIPTION
### Overview

New BlobWriteSessionConfig that will use disk to "Journal" data before transmitting to GCS.

By journaling the data to disk we can rewind to an arbitrary offset in the case of failure, while being optimistic and keeping the stream open to gcs.

General flow of data into this new WritableByteChannel:
1. #write(ByteBuffer)
2. Write contents of ByteBuffer to recovery file on disk
3. force a flush to disk
4. transmit contents of ByteBuffer to GCS leaving stream open
5. return

If the stream to gcs is interrupted with a retriable error
1. query the offset that was successfully committed to GCS
2. rewind our transmit context to the offset
3. Open the recovery file at offset from query
4. stream contents from recovery file to GCS leaving stream open
5. Once recovery file contents are transmitted to GCS return

### Benchmark results

#### Setup
1. c2d-standard-32 in us-east1 
   * with 4 local nvme sdd used for the recovery files 
   * default NIC, premium network tier 
   * debian 11 image
3. regional bucket in us-east1

#### Workload
generate a random file with size `1GiB..2GiB` upload random file to GCS using each of the following configurations:
1. DefaultBlobWriteSessionConfig with 16MiB chunk size
2. DefaultBlobWriteSessionConfig with 64MiB chunk size
4. BufferToDiskThenUpload with the following directories as buffer locations: /mnt/ssd1:/mnt/ssd2:/mnt/ssd3:/mnt/ssd4
5. JournalingBlobWriteSessionConfig with the following directories as journal locations: /mnt/ssd1:/mnt/ssd2:/mnt/ssd3:/mnt/ssd4

Run across `{1,2,4,8,16,32}` concurrent threads to evaluate contention and horizontal scaling.

#### Collected metrics
1. Generate random file
2. record begin instant
3. create new BlobWriteSession
4. BlobWriteSession#open()
6. Copy all bytes from random file to WritableByteChannel from 4
7. close the WritableByteChannel from 4
8. record end instant
9. report `objectSize,UploadStrategy,elapsedTimeUs,Status,ThreadCount`

#### Results summary

Throuhgput in MiB/s, grouped by ThreadCount and UploadStrategy
```
                             count     mean     std     min      50%      75%      90%      99%      max
ThreadCount UploadStrategy
1           PUT 16MiB       4341.0   79.941   8.752  21.599   80.218   85.628   90.710   99.635  106.627
            PUT 64MiB       4341.0  100.410  11.555  20.490  100.022  108.208  115.214  128.251  139.710
            journaling      4341.0  125.820  31.332  45.502  133.590  149.027  161.899  188.716  201.938
2           PUT 16MiB       4237.0   80.000   8.525  15.814   80.693   85.651   90.241   97.958  106.677
            PUT 64MiB       4237.0  101.062  11.030  55.813  101.049  108.007  115.114  127.299  135.149
            journaling      4237.0  125.010  29.761  43.207  131.827  147.362  159.425  182.441  209.000
4           PUT 16MiB       4411.0   79.708   8.357  40.691   80.600   85.567   89.586   95.533  103.506
            PUT 64MiB       4411.0  100.536   9.947  58.084  100.846  107.209  113.144  122.172  131.974
            journaling      4411.0  123.705  30.707  40.082  130.553  147.581  159.995  186.684  222.646
8           PUT 16MiB       4260.0   79.314   8.393   7.148   80.153   85.175   89.319   95.475  100.757
            PUT 64MiB       4260.0   99.913  10.438  60.685  100.450  107.144  112.551  122.409  132.130
            journaling      4260.0  122.931  30.261  42.747  130.306  146.098  158.005  184.798  203.696
16          PUT 16MiB       4473.0   77.735   8.091  24.149   78.483   83.123   87.092   95.740  106.176
            PUT 64MiB       4473.0   97.690   9.987  45.342   97.768  103.996  109.807  122.202  140.906
            journaling      4473.0  118.956  30.486  44.253  122.585  143.344  156.484  182.211  200.777
32          PUT 16MiB       4024.0   72.923   8.045  20.205   73.601   78.575   82.341   88.970  100.665
            PUT 64MiB       4024.0   93.151  10.030  20.913   93.506   99.748  105.297  116.163  128.284
            journaling      4024.0  104.557  30.965  11.785   98.794  129.923  146.747  174.618  200.303
```


