### PR TITLE
chore(benchmarking): Fix throughput conversion issue and report metrics in seconds

### DIFF
--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/StorageSharedBenchmarkingUtils.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/StorageSharedBenchmarkingUtils.java
@@ -28,9 +28,12 @@ class StorageSharedBenchmarkingUtils {
         created.getBlobId(), Storage.BlobSourceOption.generationMatch(created.getGeneration()));
   }
 
-  public static double calculateThroughput(long size, Duration elapsedTime) {
-    return size >= StorageSharedBenchmarkingUtils.SSB_SIZE_THRESHOLD_BYTES
-        ? size / 1024 / 1024 / (elapsedTime.toNanos())
-        : size / 1024 / (elapsedTime.toNanos());
+  public static double calculateThroughput(double size, Duration elapsedTime) {
+    double adjustedSize =
+        size >= StorageSharedBenchmarkingUtils.SSB_SIZE_THRESHOLD_BYTES
+            ? (size / 1024D) / 1024D
+            : size / 1024D;
+    double throughput = adjustedSize / (elapsedTime.toMillis() / 1000D);
+    return throughput;
   }
 }

--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/W1R3.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/W1R3.java
@@ -58,9 +58,9 @@ final class W1R3 implements Callable<String> {
   @Override
   public String call() throws Exception {
     // Create the file to be uploaded and fill it with data
+
     try (TmpFile file = DataGenerator.base64Characters().tempFile(tempDirectory, objectSize)) {
       BlobInfo blob = BlobInfo.newBuilder(bucketName, file.toString()).build();
-
       // Get the start time
       Clock clock = Clock.systemDefaultZone();
       Instant startTime = clock.instant();
@@ -69,10 +69,10 @@ final class W1R3 implements Callable<String> {
       Duration elapsedTimeUpload = Duration.between(startTime, endTime);
       printWriter.println(
           generateCloudMonitoringResult(
-                  "WRITE",
-                  StorageSharedBenchmarkingUtils.calculateThroughput(
-                      created.getSize().longValue(), elapsedTimeUpload),
-                  created)
+              "WRITE",
+              StorageSharedBenchmarkingUtils.calculateThroughput(
+                  created.getSize().doubleValue(), elapsedTimeUpload),
+              created)
               .formatAsCustomMetric());
       for (int i = 0; i <= StorageSharedBenchmarkingUtils.DEFAULT_NUMBER_OF_READS; i++) {
         try (TmpFile dest = TmpFile.of(tempDirectory, "prefix", "bin")) {
@@ -82,10 +82,10 @@ final class W1R3 implements Callable<String> {
           Duration elapsedTimeDownload = Duration.between(startTime, endTime);
           printWriter.println(
               generateCloudMonitoringResult(
-                      "READ[" + i + "]",
-                      StorageSharedBenchmarkingUtils.calculateThroughput(
-                          created.getSize().longValue(), elapsedTimeDownload),
-                      created)
+                  "READ[" + i + "]",
+                  StorageSharedBenchmarkingUtils.calculateThroughput(
+                      created.getSize().doubleValue(), elapsedTimeDownload),
+                  created)
                   .formatAsCustomMetric());
         }
       }

--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/W1R3.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/W1R3.java
@@ -69,10 +69,10 @@ final class W1R3 implements Callable<String> {
       Duration elapsedTimeUpload = Duration.between(startTime, endTime);
       printWriter.println(
           generateCloudMonitoringResult(
-              "WRITE",
-              StorageSharedBenchmarkingUtils.calculateThroughput(
-                  created.getSize().doubleValue(), elapsedTimeUpload),
-              created)
+                  "WRITE",
+                  StorageSharedBenchmarkingUtils.calculateThroughput(
+                      created.getSize().doubleValue(), elapsedTimeUpload),
+                  created)
               .formatAsCustomMetric());
       for (int i = 0; i <= StorageSharedBenchmarkingUtils.DEFAULT_NUMBER_OF_READS; i++) {
         try (TmpFile dest = TmpFile.of(tempDirectory, "prefix", "bin")) {
@@ -82,10 +82,10 @@ final class W1R3 implements Callable<String> {
           Duration elapsedTimeDownload = Duration.between(startTime, endTime);
           printWriter.println(
               generateCloudMonitoringResult(
-                  "READ[" + i + "]",
-                  StorageSharedBenchmarkingUtils.calculateThroughput(
-                      created.getSize().doubleValue(), elapsedTimeDownload),
-                  created)
+                      "READ[" + i + "]",
+                      StorageSharedBenchmarkingUtils.calculateThroughput(
+                          created.getSize().doubleValue(), elapsedTimeDownload),
+                      created)
                   .formatAsCustomMetric());
         }
       }


### PR DESCRIPTION
The cli previously was reporting 0 for throughput. There was some loss between moving from longs and doubles. Also looking at other languages, it appears throughput is being recorded in seconds. We will follow suit.