### PR TITLE
chore: add MetadataField

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiFutureUtils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiFutureUtils.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A set of utility methods for working with {@link com.google.api.core.ApiFuture ApiFutures} that
+ * aren't already provided by {@link com.google.api.core.ApiFutures}
+ */
+final class ApiFutureUtils {
+
+  private ApiFutureUtils() {}
+
+  /**
+   * Similar to {@link com.google.api.gax.rpc.ApiExceptions#callAndTranslateApiException(ApiFuture)}
+   * except that it doesn't add a suppressed exception.
+   *
+   * <p>This should only be used in a context in which awaiting the future is on a thread that
+   * already contains the stack frames which originated the work.
+   */
+  static <T> T await(ApiFuture<T> future) {
+    try {
+      return Futures.getUnchecked(future);
+    } catch (UncheckedExecutionException exception) {
+      if (exception.getCause() instanceof RuntimeException) {
+        throw (RuntimeException) exception.getCause();
+      }
+      throw exception;
+    }
+  }
+
+  static <T> ApiFuture<T> just(T value) {
+    return ApiFutures.immediateFuture(value);
+  }
+
+  /** @see SmugglingException */
+  static <T> ApiFuture<List<T>> quietAllAsList(List<ApiFuture<T>> futures) {
+    List<ApiFuture<T>> pending =
+        futures.stream().map(ApiFutureUtils::smuggleThrowable).collect(Collectors.toList());
+    ApiFuture<List<T>> futureValues = ApiFutures.allAsList(pending);
+    return unwrapSmuggling(futureValues);
+  }
+
+  @FunctionalInterface
+  interface OnSuccessApiFutureCallback<T> extends ApiFutureCallback<T> {
+    @Override
+    default void onFailure(Throwable t) {
+      // noop
+    }
+  }
+
+  @FunctionalInterface
+  interface OnFailureApiFutureCallback<T> extends ApiFutureCallback<T> {
+    @Override
+    default void onSuccess(T result) {
+      // noop
+    }
+  }
+
+  private static <T> ApiFuture<T> smuggleThrowable(ApiFuture<T> future) {
+    return ApiFutures.catchingAsync(
+        future,
+        Throwable.class,
+        throwable -> ApiFutures.immediateFailedFuture(new SmugglingException(throwable)),
+        MoreExecutors.directExecutor());
+  }
+
+  private static <T> ApiFuture<T> unwrapSmuggling(ApiFuture<T> future) {
+    return ApiFutures.catchingAsync(
+        future,
+        SmugglingException.class,
+        smuggled -> ApiFutures.immediateFailedFuture(smuggled.smuggledCause),
+        MoreExecutors.directExecutor());
+  }
+
+  /**
+   * Guava's AggregateFuture attempts to help let you know when multiple futures fail while
+   * resolving via {@link com.google.common.util.concurrent.Futures#allAsList(Iterable)}.
+   *
+   * <p>This is detrimental to our use case, because we don't want to be spamming our customers with
+   * error message they can do nothing about. In an effort to prevent this spam we define a custom
+   * exception wrapper class that is able to smuggle the context we care about past the detection
+   * mechanism (instances are added to a ConcurrentHashSet).
+   *
+   * <p>To accomplish this smuggling, we abuse the following:
+   *
+   * <ol>
+   *   <li>hashCode is hardcoded to a constant value
+   *   <li>equals(Object) returns true if the classes are equal
+   *   <li>we define our own field to carry the cause (guava looks at the cause too)
+   * </ol>
+   *
+   * For our purposes we don't need to distinguish between different instances of our exception, as
+   * we track error at a different level.
+   */
+  private static final class SmugglingException extends RuntimeException {
+    private final Throwable smuggledCause;
+
+    private SmugglingException(Throwable smuggledCause) {
+      super("");
+      this.smuggledCause = smuggledCause;
+    }
+
+    public int hashCode() {
+      return 1;
+    }
+
+    public boolean equals(Object other) {
+      return other.getClass().equals(this.getClass());
+    }
+  }
+}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/AsyncAppendingQueue.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/AsyncAppendingQueue.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.rpc.ApiExceptions;
+import com.google.cloud.storage.ApiFutureUtils.OnFailureApiFutureCallback;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.PriorityQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * Define a queue where enqueued items are async tasks. When a limit is reached, compact all values
+ * into a new value.
+ */
+final class AsyncAppendingQueue<@NonNull T> implements AutoCloseable {
+
+  private enum State {
+    OPEN,
+    CLOSING,
+    CLOSED;
+
+    boolean isOpen() {
+      return this == OPEN;
+    }
+  }
+
+  private final Executor exec;
+  private final int maxElementsPerCompact;
+  private final ApiFunction<ImmutableList<T>, T> compactFunction;
+  private final AtomicInteger orderSequence;
+  private final SettableApiFuture<T> finalResult;
+  private final PriorityQueue<Element<T>> queue;
+  private final AtomicReference<Throwable> shortCircuitFailure;
+  private final ApiFutureCallback<T> shortCircuitRegistrationCallback;
+
+  private volatile State state;
+
+  private AsyncAppendingQueue(
+      Executor exec, int maxElementsPerCompact, ApiFunction<ImmutableList<T>, T> compactFunction) {
+    this.exec = exec;
+    this.maxElementsPerCompact = maxElementsPerCompact;
+    this.compactFunction = compactFunction;
+    this.orderSequence = new AtomicInteger(0);
+    this.finalResult = SettableApiFuture.create();
+    this.queue = new PriorityQueue<>(maxElementsPerCompact, Element.COMP);
+    this.state = State.OPEN;
+    this.shortCircuitFailure = new AtomicReference<>(null);
+    this.shortCircuitRegistrationCallback =
+        (OnFailureApiFutureCallback<T>)
+            throwable -> {
+              if (state.isOpen()) {
+                shortCircuitFailure.compareAndSet(null, throwable);
+              }
+            };
+  }
+
+  synchronized AsyncAppendingQueue<T> append(ApiFuture<T> value) throws ShortCircuitException {
+    checkState(state.isOpen(), "already closed");
+    Throwable throwable = shortCircuitFailure.get();
+    if (throwable != null) {
+      ShortCircuitException shortCircuitException = new ShortCircuitException(throwable);
+      finalResult.cancel(true);
+      throw shortCircuitException;
+    }
+    checkNotNull(value, "value must not be null");
+
+    Element<T> newElement = newElement(value);
+    queue.offer(newElement);
+    boolean isFull = queue.size() == maxElementsPerCompact;
+    if (isFull) {
+      Element<T> compact = compact(exec);
+      queue.offer(compact);
+    }
+    return this;
+  }
+
+  ApiFuture<T> getResult() {
+    return finalResult;
+  }
+
+  T await() {
+    return ApiExceptions.callAndTranslateApiException(finalResult);
+  }
+
+  @Override
+  public synchronized void close() {
+    if (!state.isOpen()) {
+      return;
+    }
+    state = State.CLOSING;
+
+    if (queue.isEmpty()) {
+      NoSuchElementException neverAppendedTo = new NoSuchElementException("Never appended to");
+      finalResult.setException(neverAppendedTo);
+      throw neverAppendedTo;
+    } else {
+      Element<T> transform = compact(exec);
+
+      ApiFutures.addCallback(
+          transform.getValue(),
+          new ApiFutureCallback<T>() {
+            @Override
+            public void onFailure(Throwable err) {
+              finalResult.setException(err);
+            }
+
+            @Override
+            public void onSuccess(T t) {
+              finalResult.set(t);
+            }
+          },
+          exec);
+    }
+    state = State.CLOSED;
+  }
+
+  @NonNull
+  private Element<T> newElement(ApiFuture<T> value) {
+    ApiFutures.addCallback(value, shortCircuitRegistrationCallback, MoreExecutors.directExecutor());
+    return new Element<>(orderSequence.getAndIncrement(), value);
+  }
+
+  @NonNull
+  private Element<T> compact(Executor executor) {
+    ArrayList<Element<T>> elements = new ArrayList<>();
+    Element<T> peek = queue.peek();
+    checkState(peek != null, "attempt to compact empty queue");
+    int order = peek.getOrder();
+
+    Element<T> curr;
+    while ((curr = queue.poll()) != null) {
+      elements.add(curr);
+    }
+
+    List<ApiFuture<T>> pending =
+        elements.stream().map(Element::getValue).collect(Collectors.toList());
+    ApiFuture<List<T>> futureTs = ApiFutureUtils.quietAllAsList(pending);
+    ApiFuture<T> transform =
+        ApiFutures.transform(
+            futureTs, ts -> compactFunction.apply(ImmutableList.copyOf(ts)), executor);
+    return new Element<>(order, transform);
+  }
+
+  public static <T> AsyncAppendingQueue<T> of(
+      Executor exec, int maxElementsPerCompact, ApiFunction<ImmutableList<T>, T> compactFunction) {
+    checkNotNull(exec, "exec must be non-null");
+    checkArgument(maxElementsPerCompact > 1, "maxElementsPerCompact must be > 1");
+    checkNotNull(compactFunction, "compactFunction must be non-null");
+    return new AsyncAppendingQueue<>(exec, maxElementsPerCompact, compactFunction);
+  }
+
+  static final class ShortCircuitException extends RuntimeException {
+    private ShortCircuitException(Throwable instigator) {
+      super("Short Circuiting due to previously failed future", instigator);
+    }
+  }
+
+  /**
+   * The order in which elements are compacted is important. Define a class that allows defining an
+   * order property for use by the {@link PriorityQueue}
+   */
+  private static final class Element<T> {
+    private static final Comparator<Element<?>> COMP = Comparator.comparing(Element::getOrder);
+    private final int order;
+    private final ApiFuture<T> value;
+
+    public Element(int order, ApiFuture<T> value) {
+      this.order = order;
+      this.value = value;
+    }
+
+    public int getOrder() {
+      return order;
+    }
+
+    public ApiFuture<T> getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this).add("order", order).add("value", value).toString();
+    }
+  }
+}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/MetadataField.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/MetadataField.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import com.google.cloud.storage.Conversions.Codec;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Utility construct which allows defining a field name along with a codec for use in creating
+ * typeful files in {@link BlobInfo#getMetadata()} or {@link BucketInfo#getLabels()}
+ *
+ * @param <T> The type of the value
+ */
+@SuppressWarnings("SameParameterValue")
+final class MetadataField<T> {
+
+  @SuppressWarnings("RedundantTypeArguments")
+  private static final Codec<Long, String> CODEC_LONG =
+      Codec.<Long, String>of(String::valueOf, Long::parseLong).nullable();
+
+  private static final Codec<String, String> CODEC_STRING =
+      Codec.<String, String>of(s -> s, s -> s).nullable();
+  private final String key;
+  private final Codec<T, String> codec;
+
+  private MetadataField(String key, Codec<T, String> codec) {
+    this.key = key;
+    this.codec = codec;
+  }
+
+  void appendTo(@NonNull T t, ImmutableMap.Builder<String, String> b) {
+    b.put(key, codec.encode(t));
+  }
+
+  @Nullable
+  T readFrom(BlobInfo info) {
+    Map<String, String> map = info.getMetadata();
+    if (map != null) {
+      return readFrom(map);
+    }
+    return null;
+  }
+
+  @VisibleForTesting
+  @Nullable
+  T readFrom(Map<String, String> m) {
+    return codec.decode(m.get(key));
+  }
+
+  static MetadataField<Long> forLong(String key) {
+    return of(key, CODEC_LONG);
+  }
+
+  static MetadataField<String> forString(String key) {
+    return of(key, CODEC_STRING);
+  }
+
+  static MetadataField<PartRange> forPartRange(String key) {
+    return of(key, PartRange.CODEC);
+  }
+
+  static final class PartRange {
+    private static final Codec<PartRange, String> CODEC =
+        Codec.of(PartRange::encode, PartRange::decode).nullable();
+    static final Comparator<PartRange> COMP =
+        Comparator.comparingLong(PartRange::getBegin).thenComparingLong(PartRange::getEnd);
+    private final long begin;
+    private final long end;
+
+    private PartRange(long begin, long end) {
+      this.begin = begin;
+      this.end = end;
+    }
+
+    public long getBegin() {
+      return begin;
+    }
+
+    public long getEnd() {
+      return end;
+    }
+
+    String encode() {
+      return String.format("%04d-%04d", begin, end);
+    }
+
+    static PartRange decode(String s) {
+      int splitPoint = s.indexOf("-");
+      long being = Long.parseLong(s.substring(0, splitPoint));
+      long end = Long.parseLong(s.substring(splitPoint + 1));
+      return of(being, end);
+    }
+
+    static PartRange of(long begin) {
+      return of(begin, begin);
+    }
+
+    static PartRange of(long begin, long end) {
+      return new PartRange(begin, end);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof PartRange)) {
+        return false;
+      }
+      PartRange partRange = (PartRange) o;
+      return begin == partRange.begin && end == partRange.end;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(begin, end);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this).add("begin", begin).add("end", end).toString();
+    }
+  }
+
+  private static <T> MetadataField<T> of(String key, Codec<T, String> codec) {
+    return new MetadataField<>(key, codec);
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ApiFutureUtilsTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ApiFutureUtilsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.cloud.storage.ApiFutureUtils.await;
+import static com.google.cloud.storage.ApiFutureUtils.just;
+import static com.google.cloud.storage.TestUtils.assertAll;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.assertThrows;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.SettableApiFuture;
+import com.google.cloud.testing.junit4.StdErrCaptureRule;
+import com.google.cloud.testing.junit4.StdOutCaptureRule;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class ApiFutureUtilsTest {
+
+  @Rule public final StdOutCaptureRule stdOut = new StdOutCaptureRule();
+  @Rule public final StdErrCaptureRule stdErr = new StdErrCaptureRule();
+
+  @Test
+  public void quietAllAsList_returnsFirstFailureAndDoesNotLogLaterExceptions() throws Exception {
+
+    // define a couple futures that will fail later
+    SettableApiFuture<String> b = SettableApiFuture.create();
+    SettableApiFuture<String> c = SettableApiFuture.create();
+
+    ImmutableList<ApiFuture<String>> futures = ImmutableList.of(just("a"), b, c, just("d"));
+
+    ApiFuture<List<String>> all = ApiFutureUtils.quietAllAsList(futures);
+
+    b.setException(new Kaboom());
+    c.setException(new RuntimeException());
+
+    assertAll(
+        () -> assertThrows(Kaboom.class, () -> await(all)),
+        () -> assertWithMessage("stdout").that(stdOut.getCapturedOutputAsUtf8String()).isEmpty(),
+        () -> assertWithMessage("stderr").that(stdErr.getCapturedOutputAsUtf8String()).isEmpty());
+  }
+
+  private static final class Kaboom extends RuntimeException {
+    private Kaboom() {
+      super("Kaboom!!!");
+    }
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/AsyncAppendingQueueTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/AsyncAppendingQueueTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.rpc.ApiExceptions;
+import com.google.cloud.storage.AsyncAppendingQueue.ShortCircuitException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public final class AsyncAppendingQueueTest {
+
+  private static ExecutorService exec;
+
+  @BeforeClass
+  public static void beforeClass() {
+    ThreadFactory threadFactory =
+        new ThreadFactoryBuilder().setDaemon(true).setNameFormat("test-aaqt-%d").build();
+    exec = Executors.newCachedThreadPool(threadFactory);
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    if (exec != null) {
+      exec.shutdownNow();
+    }
+  }
+
+  @Test
+  public void attemptingToAppendAfterClose_errors() {
+    Executor exec = MoreExecutors.newDirectExecutorService();
+    AsyncAppendingQueue<String> q = AsyncAppendingQueue.of(exec, 3, AsyncAppendingQueueTest::agg);
+
+    q.append(ApiFutures.immediateFuture("a"));
+    q.close();
+
+    IllegalStateException iae =
+        assertThrows(IllegalStateException.class, () -> q.append(ApiFutures.immediateFuture("b")));
+
+    assertThat(iae).hasMessageThat().contains("closed");
+  }
+
+  @Test
+  public void getResultPendingUntilClose()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    Executor exec = MoreExecutors.newDirectExecutorService();
+    AsyncAppendingQueue<String> q = AsyncAppendingQueue.of(exec, 3, AsyncAppendingQueueTest::agg);
+
+    q.append(ApiFutures.immediateFuture("a"));
+    ApiFuture<String> result = q.getResult();
+    assertThrows(TimeoutException.class, () -> result.get(3, TimeUnit.MILLISECONDS));
+    q.close();
+    String s = result.get(10, TimeUnit.MILLISECONDS);
+
+    assertThat(s).isEqualTo("a");
+  }
+
+  @Test
+  public void getResultAlwaysReturnsTheSameFuture() {
+    Executor exec = MoreExecutors.newDirectExecutorService();
+    try (AsyncAppendingQueue<String> q =
+        AsyncAppendingQueue.of(exec, 3, AsyncAppendingQueueTest::agg)) {
+
+      q.append(ApiFutures.immediateFuture("a"));
+      ApiFuture<String> result1 = q.getResult();
+      ApiFuture<String> result2 = q.getResult();
+
+      assertThat(result1).isSameInstanceAs(result2);
+    }
+  }
+
+  @Test
+  public void closingWithoutAppending_throwNoSuchElementException() {
+    Executor exec = MoreExecutors.newDirectExecutorService();
+    //noinspection resource
+    AsyncAppendingQueue<String> q = AsyncAppendingQueue.of(exec, 3, AsyncAppendingQueueTest::agg);
+
+    ApiFuture<String> result = q.getResult();
+    NoSuchElementException nse1 = assertThrows(NoSuchElementException.class, q::close);
+    NoSuchElementException nse2 =
+        assertThrows(
+            NoSuchElementException.class, () -> ApiExceptions.callAndTranslateApiException(result));
+
+    assertThat(nse1).hasMessageThat().contains("Never appended to");
+    assertThat(nse2).hasMessageThat().contains("Never appended to");
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  public void factoryMethodMustNotAccept_nullExecutor() {
+    assertThrows(NullPointerException.class, () -> AsyncAppendingQueue.of(null, 5, null));
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  public void factoryMethodMustNotAccept_maxElementsPerCompact_lte_1() {
+    Executor exec = MoreExecutors.newDirectExecutorService();
+    assertThrows(IllegalArgumentException.class, () -> AsyncAppendingQueue.of(exec, 1, null));
+    assertThrows(IllegalArgumentException.class, () -> AsyncAppendingQueue.of(exec, 0, null));
+    assertThrows(IllegalArgumentException.class, () -> AsyncAppendingQueue.of(exec, -10, null));
+  }
+
+  @Test
+  public void happyPath() throws Exception {
+    int arity = 2;
+    ApiFuture<String> result;
+
+    try (AsyncAppendingQueue<String> q =
+        AsyncAppendingQueue.of(exec, arity, AsyncAppendingQueueTest::agg)) {
+
+      q.append(immediate("a"))
+          .append(immediate("b"))
+          .append(immediate("c"))
+          .append(immediate("d"))
+          .append(immediate("e"))
+          .append(immediate("f"))
+          .append(immediate("g"));
+
+      result = q.getResult();
+    }
+    assertThat(result).isNotNull();
+    String s = result.get();
+    assertThat(s).isEqualTo("abcdefg");
+  }
+
+  @Test
+  public void appendShouldShortCircuit() {
+    Executor exec = MoreExecutors.newDirectExecutorService();
+
+    AtomicInteger aggCounter = new AtomicInteger(0);
+    ApiFunction<ImmutableList<String>, String> agg =
+        ss -> {
+          aggCounter.getAndIncrement();
+          return agg(ss);
+        };
+
+    AsyncAppendingQueue<String> q = AsyncAppendingQueue.of(exec, 5, agg);
+    q.append(immediate("a")).append(immediate("b")).append(immediate("c"));
+
+    q.append(ApiFutures.immediateFailedFuture(new Kaboom()));
+
+    assertThrows(ShortCircuitException.class, () -> q.append(immediate("d")));
+    assertThrows(CancellationException.class, q::await);
+
+    q.close();
+
+    assertThat(aggCounter.get()).isEqualTo(0);
+  }
+
+  @Test
+  public void resultFailureIfLastAppendFutureFails() {
+
+    AsyncAppendingQueue<String> q = AsyncAppendingQueue.of(exec, 2, AsyncAppendingQueueTest::agg);
+    SettableApiFuture<String> d = SettableApiFuture.create();
+    q.append(immediate("a"))
+        .append(immediate("b"))
+        .append(immediate("b"))
+        .append(immediate("c"))
+        .append(d);
+
+    q.close();
+    d.setException(new Kaboom());
+    assertThrows(Kaboom.class, q::await);
+  }
+
+  @Test
+  public void resultFailureIfFinalCompactFails() {
+    ApiFunction<ImmutableList<String>, String> agg =
+        ss -> {
+          if (ss.equals(ImmutableList.of("abc", "d"))) {
+            throw new Kaboom();
+          } else {
+            return agg(ss);
+          }
+        };
+
+    AsyncAppendingQueue<String> q = AsyncAppendingQueue.of(exec, 2, agg);
+    q.append(immediate("a")).append(immediate("b")).append(immediate("c")).append(immediate("d"));
+
+    q.close();
+    assertThrows(Kaboom.class, q::await);
+  }
+
+  @Test
+  public void append_multipleFailingFuturesWillAlwaysReturnTheFirstFailure() {
+
+    // define a couple futures that will fail later
+    SettableApiFuture<String> b = SettableApiFuture.create();
+    SettableApiFuture<String> c = SettableApiFuture.create();
+
+    AsyncAppendingQueue<String> q = AsyncAppendingQueue.of(exec, 6, AsyncAppendingQueueTest::agg);
+    q.append(immediate("a")).append(b).append(c).append(immediate("d"));
+
+    b.setException(new Kaboom());
+    c.setException(new RuntimeException());
+    q.close();
+
+    assertThrows(Kaboom.class, q::await);
+  }
+
+  @Test
+  public void shortCircuitOnlyHappensBeforeClose_affirmative() {
+    Executor exec = MoreExecutors.newDirectExecutorService();
+
+    AsyncAppendingQueue<String> q = AsyncAppendingQueue.of(exec, 5, AsyncAppendingQueueTest::agg);
+    q.append(immediate("a"));
+    q.append(ApiFutures.immediateFailedFuture(new Kaboom()));
+
+    assertThrows(ShortCircuitException.class, () -> q.append(immediate("d")));
+    assertThrows(CancellationException.class, q::await);
+
+    q.close();
+  }
+
+  @Test
+  public void shortCircuitOnlyHappensBeforeClose_negative() {
+
+    AsyncAppendingQueue<String> q = AsyncAppendingQueue.of(exec, 5, AsyncAppendingQueueTest::agg);
+    q.append(immediate("a"));
+    SettableApiFuture<String> d = SettableApiFuture.create();
+    q.append(d);
+
+    q.close();
+    d.setException(new Kaboom());
+
+    assertThrows(Kaboom.class, q::await);
+  }
+
+  static String agg(ImmutableList<String> ss) {
+    return ss.stream().reduce("", String::concat);
+  }
+
+  static ApiFuture<String> immediate(String s) {
+    return ApiFutures.immediateFuture(s);
+  }
+
+  private static final class Kaboom extends RuntimeException {
+    private Kaboom() {
+      super("Kaboom!!!");
+    }
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/MetadataFieldTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/MetadataFieldTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.storage.MetadataField.PartRange;
+import com.google.common.collect.ImmutableMap;
+import java.util.function.Consumer;
+import org.junit.Test;
+
+public final class MetadataFieldTest {
+
+  @Test
+  public void appendTo_long_encode_works() {
+    MetadataField<Long> l = MetadataField.forLong("long");
+    ImmutableMap<String, String> map = mapFrom(b -> l.appendTo(37L, b));
+    assertThat(map).containsEntry("long", "37");
+  }
+
+  @Test
+  public void readFrom_long_decode_null() {
+    ImmutableMap<String, String> map = ImmutableMap.of();
+    MetadataField<Long> l = MetadataField.forLong("long");
+    Long read = l.readFrom(map);
+    assertThat(read).isNull();
+  }
+
+  @Test
+  public void readFrom_long_decode_nonNull() {
+    ImmutableMap<String, String> map = ImmutableMap.of("long", "37");
+    MetadataField<Long> l = MetadataField.forLong("long");
+    Long read = l.readFrom(map);
+    assertThat(read).isNotNull();
+    assertThat(read).isEqualTo(37L);
+  }
+
+  @Test
+  public void readFrom_long_decode_blobInfo_null() {
+    BlobInfo info = BlobInfo.newBuilder("b", "o").build();
+    MetadataField<Long> l = MetadataField.forLong("long");
+    Long read = l.readFrom(info);
+    assertThat(read).isNull();
+  }
+
+  @Test
+  public void readFrom_long_decode_blobInfo_nonNull() {
+    ImmutableMap<String, String> map = ImmutableMap.of("long", "37");
+    BlobInfo info = BlobInfo.newBuilder("b", "o").setMetadata(map).build();
+    MetadataField<Long> l = MetadataField.forLong("long");
+    Long read = l.readFrom(info);
+    assertThat(read).isNotNull();
+    assertThat(read).isEqualTo(37L);
+  }
+
+  @Test
+  public void appendTo_string_encode_works() {
+    MetadataField<String> l = MetadataField.forString("string");
+    ImmutableMap<String, String> map = mapFrom(b -> l.appendTo("blah", b));
+    assertThat(map).containsEntry("string", "blah");
+  }
+
+  @Test
+  public void readFrom_string_decode_null() {
+    ImmutableMap<String, String> map = ImmutableMap.of();
+    MetadataField<String> l = MetadataField.forString("string");
+    String read = l.readFrom(map);
+    assertThat(read).isNull();
+  }
+
+  @Test
+  public void readFrom_string_decode_nonNull() {
+    ImmutableMap<String, String> map = ImmutableMap.of("string", "blah");
+    MetadataField<String> l = MetadataField.forString("string");
+    String read = l.readFrom(map);
+    assertThat(read).isNotNull();
+    assertThat(read).isEqualTo("blah");
+  }
+
+  @Test
+  public void appendTo_partRange_encode_works() {
+    MetadataField<PartRange> l = MetadataField.forPartRange("partRange");
+    ImmutableMap<String, String> map = mapFrom(b -> l.appendTo(PartRange.of(37L), b));
+    assertThat(map).containsEntry("partRange", "0037-0037");
+  }
+
+  @Test
+  public void readFrom_partRange_decode_null() {
+    ImmutableMap<String, String> map = ImmutableMap.of();
+    MetadataField<PartRange> l = MetadataField.forPartRange("partRange");
+    PartRange read = l.readFrom(map);
+    assertThat(read).isNull();
+  }
+
+  @Test
+  public void readFrom_partRange_decode_nonNull() {
+    ImmutableMap<String, String> map = ImmutableMap.of("partRange", "0037-0037");
+    MetadataField<PartRange> l = MetadataField.forPartRange("partRange");
+    PartRange read = l.readFrom(map);
+    assertThat(read).isNotNull();
+    assertThat(read).isEqualTo(PartRange.of(37L));
+  }
+
+  @Test
+  public void partRange_handlesNumbersWithMoreThanFourDigits_encode() {
+
+    PartRange r = PartRange.of(0, 123456);
+
+    String encode = r.encode();
+    assertThat(encode).isEqualTo("0000-123456");
+  }
+
+  @Test
+  public void partRange_handlesNumbersWithMoreThanFourDigits_decode() {
+
+    PartRange expected = PartRange.of(0, 123456);
+
+    PartRange decode = PartRange.decode("0000-123456");
+    assertThat(decode).isEqualTo(expected);
+  }
+
+  private static ImmutableMap<String, String> mapFrom(
+      Consumer<ImmutableMap.Builder<String, String>> f) {
+    ImmutableMap.Builder<String, String> builder = new ImmutableMap.Builder<>();
+    f.accept(builder);
+    return builder.build();
+  }
+}


### PR DESCRIPTION
_Pre-Work_

When performing a parallel composite upload the various parts will have metadata added to them related to where they exist in the overall object.

This class encapsulates the logic necessary to allow defining a field by its name and a codec for encoding/decoding its values.

