### PR TITLE
fix: consider Storage#delete(BlobId) idempotent when id has generation

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcRetryAlgorithmManager.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcRetryAlgorithmManager.java
@@ -96,6 +96,9 @@ final class GrpcRetryAlgorithmManager implements Serializable {
   }
 
   public ResultRetryAlgorithm<?> getFor(DeleteObjectRequest req) {
+    if (req.getGeneration() > 0 || req.hasIfGenerationMatch()) {
+      return retryStrategy.getIdempotentHandler();
+    }
     return retryStrategy.getNonidempotentHandler();
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpRetryAlgorithmManager.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpRetryAlgorithmManager.java
@@ -203,6 +203,7 @@ final class HttpRetryAlgorithmManager implements Serializable {
   public ResultRetryAlgorithm<?> getForObjectsDelete(
       StorageObject pb, Map<StorageRpc.Option, ?> optionsMap) {
     return optionsMap.containsKey(StorageRpc.Option.IF_GENERATION_MATCH)
+            || (pb.getGeneration() != null && pb.getGeneration() > 0)
         ? retryStrategy.getIdempotentHandler()
         : retryStrategy.getNonidempotentHandler();
   }


### PR DESCRIPTION
Update logic to consider an object delete request to be idempotent if the objects generation is specified in the BlobId.

