### PR TITLE
chore: implement automatic cleanup on failure in ParallelCompositeUploadWritableByteChannel

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -540,6 +540,11 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
       return true;
     } catch (NotFoundException e) {
       return false;
+    } catch (StorageException e) {
+      if (e.getCode() == 404) {
+        return false;
+      }
+      throw e;
     }
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageInternal.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageInternal.java
@@ -39,7 +39,9 @@ interface StorageInternal {
     throw new UnsupportedOperationException("not implemented");
   }
 
-  default boolean delete(BlobId id) {
+  // Void to allow easier mapping/use within streams and other mapping contexts
+  @SuppressWarnings("UnusedReturnValue")
+  default Void internalObjectDelete(BlobId id, Opts<ObjectSourceOpt> opts) {
     throw new UnsupportedOperationException("not implemented");
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ParallelCompositeUploadWritableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ParallelCompositeUploadWritableByteChannelTest.java
@@ -460,7 +460,7 @@ public final class ParallelCompositeUploadWritableByteChannelTest {
             bufferHandlePool,
             MoreExecutors.directExecutor(),
             partNamingStrategy,
-            PartCleanupStrategy.never(),
+            PartCleanupStrategy.always(),
             3,
             finalObject,
             new FakeStorageInternal() {
@@ -839,9 +839,13 @@ public final class ParallelCompositeUploadWritableByteChannelTest {
     }
 
     @Override
-    public boolean delete(BlobId id) {
+    public Void internalObjectDelete(BlobId id, Opts<ObjectSourceOpt> opts) {
       deleteRequests.add(id);
-      return addedObjects.containsKey(id);
+      boolean containsKey = addedObjects.containsKey(id);
+      if (!containsKey) {
+        throw ApiExceptionFactory.createException(null, GrpcStatusCode.of(Code.NOT_FOUND), false);
+      }
+      return null;
     }
 
     @Override


### PR DESCRIPTION
I'm not 100% happy with how invasive this change was, I think we can refactor things after this initial implementation to make it easier to tests and understand.