### PR TITLE
chore: rename BufferStrategy to BufferAllocationStrategy

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/SerializationTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/SerializationTest.java
@@ -33,7 +33,7 @@ import com.google.cloud.storage.Acl.Project.ProjectRole;
 import com.google.cloud.storage.BlobReadChannelV2.BlobReadChannelContext;
 import com.google.cloud.storage.BlobReadChannelV2.BlobReadChannelV2State;
 import com.google.cloud.storage.BlobWriteChannelV2.BlobWriteChannelV2State;
-import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.BufferStrategy;
+import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.BufferAllocationStrategy;
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.ExecutorSupplier;
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.PartCleanupStrategy;
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.PartNamingStrategy;
@@ -385,7 +385,7 @@ public class SerializationTest extends BaseSerializationTest {
 
     ParallelCompositeUploadBlobWriteSessionConfig pcu2 =
         BlobWriteSessionConfigs.parallelCompositeUpload()
-            .withBufferStrategy(BufferStrategy.fixedPool(1, 3))
+            .withBufferAllocationStrategy(BufferAllocationStrategy.fixedPool(1, 3))
             .withPartCleanupStrategy(PartCleanupStrategy.never())
             .withPartNamingStrategy(PartNamingStrategy.prefix("prefix"))
             .withExecutorSupplier(ExecutorSupplier.fixedPool(5));

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITParallelCompositeUploadBlobWriteSessionConfigTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITParallelCompositeUploadBlobWriteSessionConfigTest.java
@@ -29,7 +29,7 @@ import com.google.cloud.storage.BlobWriteSessionConfigs;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.DataGenerator;
 import com.google.cloud.storage.GrpcStorageOptions;
-import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.BufferStrategy;
+import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.BufferAllocationStrategy;
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.ExecutorSupplier;
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.PartCleanupStrategy;
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.PartNamingStrategy;
@@ -105,8 +105,8 @@ public final class ITParallelCompositeUploadBlobWriteSessionConfigTest {
             .setBlobWriteSessionConfig(
                 BlobWriteSessionConfigs.parallelCompositeUpload()
                     .withExecutorSupplier(ExecutorSupplier.useExecutor(exec))
-                    // deinfe a max part size that is fairly small to aid in test speed
-                    .withBufferStrategy(BufferStrategy.simple(_1MiB))
+                    // define a max part size that is fairly small to aid in test speed
+                    .withBufferAllocationStrategy(BufferAllocationStrategy.simple(_1MiB))
                     .withPartNamingStrategy(PartNamingStrategy.prefix("prefix-a"))
                     // let our fixtures take care of cleaning things up
                     .withPartCleanupStrategy(PartCleanupStrategy.never()))


### PR DESCRIPTION
Use a more clear name to signal the configuration is for the allocation of buffers, not the buffering itself.
