### PR TITLE
chore: blob write session cleanup

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobWriteSessionConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobWriteSessionConfig.java
@@ -17,11 +17,9 @@
 package com.google.cloud.storage;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.storage.Conversions.Decoder;
 import com.google.cloud.storage.Storage.BlobWriteOption;
 import com.google.cloud.storage.UnifiedOpts.ObjectTargetOpt;
 import com.google.cloud.storage.UnifiedOpts.Opts;
-import com.google.storage.v2.WriteObjectResponse;
 import java.io.IOException;
 import java.io.Serializable;
 import java.time.Clock;
@@ -52,9 +50,15 @@ public abstract class BlobWriteSessionConfig implements Serializable {
   interface WriterFactory {
     @InternalApi
     WritableByteChannelSession<?, BlobInfo> writeSession(
-        StorageInternal s,
-        BlobInfo info,
-        Opts<ObjectTargetOpt> opts,
-        Decoder<WriteObjectResponse, BlobInfo> d);
+        StorageInternal s, BlobInfo info, Opts<ObjectTargetOpt> opts);
   }
+
+  /**
+   * Internal marker interface to signify an implementation of {@link BlobWriteSessionConfig} is
+   * compatible with {@link com.google.cloud.storage.TransportCompatibility.Transport#GRPC}
+   *
+   * <p>We could evaluate the annotations, but the code for that is more complicated and probably
+   * not worth the effort.
+   */
+  interface GrpcCompatible {}
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobWriteSessionConfigs.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobWriteSessionConfigs.java
@@ -21,6 +21,7 @@ import com.google.cloud.storage.GrpcStorageOptions.GrpcStorageDefaults;
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.PartCleanupStrategy;
 import com.google.cloud.storage.Storage.BlobTargetOption;
 import com.google.cloud.storage.Storage.BlobWriteOption;
+import com.google.cloud.storage.TransportCompatibility.Transport;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
@@ -240,6 +241,7 @@ public final class BlobWriteSessionConfigs {
    * @since 2.26.0 This new api is in preview and is subject to breaking changes.
    */
   @BetaApi
+  @TransportCompatibility({Transport.GRPC})
   public static DefaultBlobWriteSessionConfig getDefault() {
     return new DefaultBlobWriteSessionConfig(ByteSizeConstants._16MiB);
   }
@@ -255,6 +257,7 @@ public final class BlobWriteSessionConfigs {
    * @since 2.26.0 This new api is in preview and is subject to breaking changes.
    */
   @BetaApi
+  @TransportCompatibility({Transport.GRPC})
   public static BlobWriteSessionConfig bufferToTempDirThenUpload() throws IOException {
     return bufferToDiskThenUpload(
         Paths.get(System.getProperty("java.io.tmpdir"), "google-cloud-storage"));
@@ -271,6 +274,7 @@ public final class BlobWriteSessionConfigs {
    * @since 2.26.0 This new api is in preview and is subject to breaking changes.
    */
   @BetaApi
+  @TransportCompatibility({Transport.GRPC})
   public static BufferToDiskThenUpload bufferToDiskThenUpload(Path path) throws IOException {
     return bufferToDiskThenUpload(ImmutableList.of(path));
   }
@@ -289,6 +293,7 @@ public final class BlobWriteSessionConfigs {
    * @since 2.26.0 This new api is in preview and is subject to breaking changes.
    */
   @BetaApi
+  @TransportCompatibility({Transport.GRPC})
   public static BufferToDiskThenUpload bufferToDiskThenUpload(Collection<Path> paths)
       throws IOException {
     return new BufferToDiskThenUpload(ImmutableList.copyOf(paths), false);
@@ -306,6 +311,7 @@ public final class BlobWriteSessionConfigs {
    * @since 2.27.0 This new api is in preview and is subject to breaking changes.
    */
   @BetaApi
+  @TransportCompatibility(Transport.GRPC)
   public static JournalingBlobWriteSessionConfig journaling(Collection<Path> paths) {
     return new JournalingBlobWriteSessionConfig(ImmutableList.copyOf(paths), false);
   }
@@ -321,6 +327,7 @@ public final class BlobWriteSessionConfigs {
    * @since 2.28.0 This new api is in preview and is subject to breaking changes.
    */
   @BetaApi
+  @TransportCompatibility({Transport.GRPC})
   public static ParallelCompositeUploadBlobWriteSessionConfig parallelCompositeUpload() {
     return ParallelCompositeUploadBlobWriteSessionConfig.withDefaults();
   }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BufferToDiskThenUpload.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BufferToDiskThenUpload.java
@@ -21,15 +21,14 @@ import com.google.api.core.ApiFutures;
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.core.SettableApiFuture;
-import com.google.cloud.storage.Conversions.Decoder;
 import com.google.cloud.storage.RecoveryFileManager.RecoveryVolumeSinkFactory;
 import com.google.cloud.storage.Storage.BlobWriteOption;
+import com.google.cloud.storage.TransportCompatibility.Transport;
 import com.google.cloud.storage.UnifiedOpts.ObjectTargetOpt;
 import com.google.cloud.storage.UnifiedOpts.Opts;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.storage.v2.WriteObjectResponse;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -60,7 +59,9 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
  */
 @Immutable
 @BetaApi
-public final class BufferToDiskThenUpload extends BlobWriteSessionConfig {
+@TransportCompatibility({Transport.GRPC})
+public final class BufferToDiskThenUpload extends BlobWriteSessionConfig
+    implements BlobWriteSessionConfig.GrpcCompatible {
   private static final long serialVersionUID = 9059242302276891867L;
 
   /**
@@ -151,10 +152,7 @@ public final class BufferToDiskThenUpload extends BlobWriteSessionConfig {
     @InternalApi
     @Override
     public WritableByteChannelSession<?, BlobInfo> writeSession(
-        StorageInternal storage,
-        BlobInfo info,
-        Opts<ObjectTargetOpt> opts,
-        Decoder<WriteObjectResponse, BlobInfo> d) {
+        StorageInternal storage, BlobInfo info, Opts<ObjectTargetOpt> opts) {
       return new Factory.WriteToFileThenUpload(
           storage, info, opts, recoveryFileManager.newRecoveryFile(info));
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.storage;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import com.google.api.core.ApiClock;
@@ -522,6 +523,9 @@ public final class GrpcStorageOptions extends StorageOptions
     public GrpcStorageOptions.Builder setBlobWriteSessionConfig(
         @NonNull BlobWriteSessionConfig blobWriteSessionConfig) {
       requireNonNull(blobWriteSessionConfig, "blobWriteSessionConfig must be non null");
+      checkArgument(
+          blobWriteSessionConfig instanceof BlobWriteSessionConfig.GrpcCompatible,
+          "The provided instance of BlobWriteSessionConfig is not compatible with gRPC transport.");
       this.blobWriteSessionConfig = blobWriteSessionConfig;
       return this;
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfig.java
@@ -26,9 +26,9 @@ import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.core.SettableApiFuture;
 import com.google.cloud.storage.BufferedWritableByteChannelSession.BufferedWritableByteChannel;
-import com.google.cloud.storage.Conversions.Decoder;
 import com.google.cloud.storage.MetadataField.PartRange;
 import com.google.cloud.storage.Storage.BlobWriteOption;
+import com.google.cloud.storage.TransportCompatibility.Transport;
 import com.google.cloud.storage.UnifiedOpts.ObjectTargetOpt;
 import com.google.cloud.storage.UnifiedOpts.Opts;
 import com.google.common.annotations.VisibleForTesting;
@@ -36,7 +36,6 @@ import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.google.storage.v2.WriteObjectResponse;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
@@ -116,7 +115,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  */
 @Immutable
 @BetaApi
-public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWriteSessionConfig {
+@TransportCompatibility({Transport.GRPC})
+public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWriteSessionConfig
+    implements BlobWriteSessionConfig.GrpcCompatible {
 
   private static final int MAX_PARTS_PER_COMPOSE = 32;
   private final int maxPartsPerCompose;
@@ -669,10 +670,7 @@ public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWri
 
     @Override
     public WritableByteChannelSession<?, BlobInfo> writeSession(
-        StorageInternal s,
-        BlobInfo info,
-        Opts<ObjectTargetOpt> opts,
-        Decoder<WriteObjectResponse, BlobInfo> d) {
+        StorageInternal s, BlobInfo info, Opts<ObjectTargetOpt> opts) {
       return new PCUSession(s, info, opts);
     }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageInternal.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageInternal.java
@@ -31,10 +31,6 @@ interface StorageInternal {
     throw new UnsupportedOperationException("not implemented");
   }
 
-  default StorageWriteChannel internalWriter(BlobInfo info, Opts<ObjectTargetOpt> opts) {
-    throw new UnsupportedOperationException("not implemented");
-  }
-
   default BlobInfo internalDirectUpload(BlobInfo info, Opts<ObjectTargetOpt> opts, ByteBuffer buf) {
     throw new UnsupportedOperationException("not implemented");
   }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BufferToDiskThenUploadTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BufferToDiskThenUploadTest.java
@@ -20,10 +20,8 @@ import static com.google.cloud.storage.TestUtils.xxd;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.cloud.storage.BlobWriteSessionConfig.WriterFactory;
-import com.google.cloud.storage.Conversions.Decoder;
 import com.google.cloud.storage.UnifiedOpts.ObjectTargetOpt;
 import com.google.cloud.storage.UnifiedOpts.Opts;
-import com.google.storage.v2.WriteObjectResponse;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
@@ -39,9 +37,6 @@ import org.junit.rules.TestName;
 
 public final class BufferToDiskThenUploadTest {
 
-  private static final Decoder<WriteObjectResponse, BlobInfo>
-      WRITE_OBJECT_RESPONSE_BLOB_INFO_DECODER =
-          Conversions.grpc().blobInfo().compose(WriteObjectResponse::getResource);
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
   @Rule public final TestName testName = new TestName();
 
@@ -68,8 +63,7 @@ public final class BufferToDiskThenUploadTest {
               }
             },
             blobInfo,
-            Opts.empty(),
-            WRITE_OBJECT_RESPONSE_BLOB_INFO_DECODER);
+            Opts.empty());
 
     byte[] bytes = DataGenerator.base64Characters().genBytes(128);
     try (WritableByteChannel open = writeSession.open()) {


### PR DESCRIPTION
1. Add TransportCompatibility annotations to factory methods in BlobWriteSessionConfigs
2. Add BlobWriteSessionConfig.GrpcCompatible marker interface for validation in GrpcStorageOptions
3. Add BlobWriteSessionConfig.GrpcCompatible to all existing BlobWriteSessionConfigs
4. Cleanup todo in DefaultBlobWriteSessionConfig that was reaching down into the GrpcBlobWriteChannel. Now, the WritableByteChannelSession will be constructed directly.
5. Add @CrossRun annotations to BlobWriteSession integration tests
