### PR TITLE
test: add support to ITRetryConformanceTest suite to allow running gRPC transport tests

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
@@ -30,6 +30,7 @@ import com.google.cloud.conformance.storage.v1.RetryTest;
 import com.google.cloud.conformance.storage.v1.RetryTests;
 import com.google.cloud.storage.CIUtils;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.TransportCompatibility.Transport;
 import com.google.cloud.storage.conformance.retry.Functions.CtxFunction;
 import com.google.cloud.storage.conformance.retry.ITRetryConformanceTest.RetryConformanceParameterProvider;
 import com.google.cloud.storage.it.runner.StorageITRunner;
@@ -63,6 +64,7 @@ import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.After;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
@@ -93,7 +95,7 @@ public class ITRetryConformanceTest {
   private RpcMethodMapping mapping;
   private Storage nonTestStorage;
   private Storage testStorage;
-  private Ctx ctx;
+  @Nullable private Ctx ctx;
 
   @Before
   public void setUp() throws Throwable {
@@ -114,9 +116,11 @@ public class ITRetryConformanceTest {
   @After
   public void tearDown() throws Throwable {
     LOGGER.fine("Running teardown...");
-    getReplaceStorageInObjectsFromCtx()
-        .andThen(mapping.getTearDown())
-        .apply(ctx, testRetryConformance);
+    if (ctx != null) {
+      getReplaceStorageInObjectsFromCtx()
+          .andThen(mapping.getTearDown())
+          .apply(ctx, testRetryConformance);
+    }
     retryTestFixture.finished(null);
     LOGGER.fine("Running teardown complete");
   }
@@ -128,6 +132,7 @@ public class ITRetryConformanceTest {
   @Test
   public void test() throws Throwable {
     LOGGER.fine("Running test...");
+    assertThat(ctx).isNotNull();
     try {
       ctx =
           getReplaceStorageInObjectsFromCtx()
@@ -161,7 +166,9 @@ public class ITRetryConformanceTest {
               .setMappings(new RpcMethodMappings())
               .setProjectId("conformance-tests")
               .setHost(testBench.getBaseUri().replaceAll("https?://", ""))
-              .setTestAllowFilter(RetryTestCaseResolver.includeAll())
+              .setTestAllowFilter(
+                  RetryTestCaseResolver.includeAll()
+                      .and(RetryTestCaseResolver.lift(trc -> trc.getTransport() == Transport.HTTP)))
               .build();
 
       List<RetryTestCase> retryTestCases;
@@ -276,69 +283,76 @@ public class ITRetryConformanceTest {
         RpcMethodMappings rpcMethodMappings, List<RetryTest> retryTests) {
 
       List<RetryTestCase> testCases = new ArrayList<>();
-      for (RetryTest testCase : retryTests) {
-        for (InstructionList instructionList : testCase.getCasesList()) {
-          for (Method method : testCase.getMethodsList()) {
-            String methodName = method.getName();
-            RpcMethod key = RpcMethod.storage.lookup.get(methodName);
-            assertNotNull(
-                String.format("Unable to resolve RpcMethod for value '%s'", methodName), key);
-            // get all RpcMethodMappings which are defined for key
-            List<RpcMethodMapping> mappings =
-                rpcMethodMappings.get(key).stream()
-                    .sorted(Comparator.comparingInt(RpcMethodMapping::getMappingId))
-                    .collect(Collectors.toList());
-            // if we don't have any mappings defined for the provide key, generate a case that when
-            // run reports an ignored test. This is done for the sake of completeness and to be
-            // aware of a lack of mapping.
-            if (mappings.isEmpty() && CIUtils.verbose()) {
-              TestRetryConformance testRetryConformance =
-                  new TestRetryConformance(
-                      projectId,
-                      host,
-                      testCase.getId(),
-                      method,
-                      instructionList,
-                      testCase.getPreconditionProvided(),
-                      false);
-              if (testAllowFilter.test(key, testRetryConformance)) {
-                testCases.add(
-                    new RetryTestCase(testRetryConformance, RpcMethodMapping.notImplemented(key)));
-              }
-            } else {
-              for (RpcMethodMapping mapping : mappings) {
+      Transport[] values = Transport.values();
+      for (Transport transport : values) {
+        for (RetryTest testCase : retryTests) {
+          for (InstructionList instructionList : testCase.getCasesList()) {
+            for (Method method : testCase.getMethodsList()) {
+              String methodName = method.getName();
+              RpcMethod key = RpcMethod.storage.lookup.get(methodName);
+              assertNotNull(
+                  String.format("Unable to resolve RpcMethod for value '%s'", methodName), key);
+              // get all RpcMethodMappings which are defined for key
+              List<RpcMethodMapping> mappings =
+                  rpcMethodMappings.get(key).stream()
+                      .sorted(Comparator.comparingInt(RpcMethodMapping::getMappingId))
+                      .collect(Collectors.toList());
+              // if we don't have any mappings defined for the provide key, generate a case that
+              // when
+              // run reports an ignored test. This is done for the sake of completeness and to be
+              // aware of a lack of mapping.
+              if (mappings.isEmpty() && CIUtils.verbose()) {
                 TestRetryConformance testRetryConformance =
                     new TestRetryConformance(
+                        transport,
                         projectId,
                         host,
                         testCase.getId(),
                         method,
                         instructionList,
                         testCase.getPreconditionProvided(),
-                        testCase.getExpectSuccess(),
-                        mapping.getMappingId());
-                // check that this case is allowed based on the provided filter
+                        false);
                 if (testAllowFilter.test(key, testRetryConformance)) {
-                  // check that the defined mapping is applicable to the case we've resolved.
-                  // Many mappings are conditionally valid and depend on the defined case.
-                  if (mapping.getApplicable().test(testRetryConformance)) {
-                    testCases.add(new RetryTestCase(testRetryConformance, mapping));
-                  } else if (CIUtils.verbose()) {
-                    // when the mapping is determined to not be applicable to this case, generate
-                    // a synthetic mapping which  will report as an ignored test. This is done for
-                    // the sake of completeness.
-                    RpcMethodMapping build =
-                        mapping
-                            .toBuilder()
-                            .withSetup(CtxFunction.identity())
-                            .withTest(
-                                (s, c) -> {
-                                  throw new AssumptionViolatedException(
-                                      "applicability predicate evaluated to false");
-                                })
-                            .withTearDown(CtxFunction.identity())
-                            .build();
-                    testCases.add(new RetryTestCase(testRetryConformance, build));
+                  testCases.add(
+                      new RetryTestCase(
+                          testRetryConformance, RpcMethodMapping.notImplemented(key)));
+                }
+              } else {
+                for (RpcMethodMapping mapping : mappings) {
+                  TestRetryConformance testRetryConformance =
+                      new TestRetryConformance(
+                          transport,
+                          projectId,
+                          host,
+                          testCase.getId(),
+                          method,
+                          instructionList,
+                          testCase.getPreconditionProvided(),
+                          testCase.getExpectSuccess(),
+                          mapping.getMappingId());
+                  // check that this case is allowed based on the provided filter
+                  if (testAllowFilter.test(key, testRetryConformance)) {
+                    // check that the defined mapping is applicable to the case we've resolved.
+                    // Many mappings are conditionally valid and depend on the defined case.
+                    if (mapping.getApplicable().test(testRetryConformance)) {
+                      testCases.add(new RetryTestCase(testRetryConformance, mapping));
+                    } else if (CIUtils.verbose()) {
+                      // when the mapping is determined to not be applicable to this case, generate
+                      // a synthetic mapping which  will report as an ignored test. This is done for
+                      // the sake of completeness.
+                      RpcMethodMapping build =
+                          mapping
+                              .toBuilder()
+                              .withSetup(CtxFunction.identity())
+                              .withTest(
+                                  (s, c) -> {
+                                    throw new AssumptionViolatedException(
+                                        "applicability predicate evaluated to false");
+                                  })
+                              .withTearDown(CtxFunction.identity())
+                              .build();
+                      testCases.add(new RetryTestCase(testRetryConformance, build));
+                    }
                   }
                 }
               }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobWriteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobWriteChannelTest.java
@@ -200,7 +200,8 @@ public final class ITBlobWriteChannelTest {
             InstructionList.newBuilder()
                 .addInstructions(
                     String.format("return-broken-stream-final-chunk-after-%dB", cappedByteCount))
-                .build());
+                .build(),
+            Transport.HTTP.name());
     RetryTestResource retryTest = testBench.createRetryTest(retryTestResource);
 
     StorageOptions baseOptions =

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestBench.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestBench.java
@@ -35,6 +35,7 @@ import com.google.cloud.conformance.storage.v1.InstructionList;
 import com.google.cloud.conformance.storage.v1.Method;
 import com.google.cloud.storage.it.runner.SneakyException;
 import com.google.common.base.Charsets;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharStreams;
 import com.google.gson.Gson;
@@ -384,6 +385,7 @@ public final class TestBench implements ManagedLifecycle {
   public static final class RetryTestResource {
     public String id;
     public Boolean completed;
+    public String transport;
     public JsonObject instructions;
 
     public RetryTestResource() {}
@@ -392,7 +394,8 @@ public final class TestBench implements ManagedLifecycle {
       this.instructions = instructions;
     }
 
-    public static RetryTestResource newRetryTestResource(Method m, InstructionList l) {
+    public static RetryTestResource newRetryTestResource(
+        Method m, InstructionList l, String transport) {
       RetryTestResource resource = new RetryTestResource();
       resource.instructions = new JsonObject();
       JsonArray instructions = new JsonArray();
@@ -400,20 +403,18 @@ public final class TestBench implements ManagedLifecycle {
         instructions.add(s);
       }
       resource.instructions.add(m.getName(), instructions);
+      resource.transport = transport;
       return resource;
     }
 
     @Override
     public String toString() {
-      return "RetryTestResource{"
-          + "id='"
-          + id
-          + '\''
-          + ", completed="
-          + completed
-          + ", instructions="
-          + instructions
-          + '}';
+      return MoreObjects.toStringHelper(this)
+          .add("id", id)
+          .add("completed", completed)
+          .add("transport", transport)
+          .add("instructions", instructions)
+          .toString();
     }
   }
 


### PR DESCRIPTION

* Current test case resolver still only resolves HTTP cases
* RetryTestFixture is updated to turn a `501 Not Implemented` into an AssumptionViolationException signaling the test is skipped/ignored
* RetryTestFixture is updated to call close on Storage instances -- needed so we don't leak channel builders with grpc
* RetryTestFixture nonTestStorage will always be HTTP, only testStorage will be built with the selected transport
* TestRetryConformance generated names now include either `_h` or `_g` depending on transport -- this removes collisions of names between the two transports
* TestRetryConformance will now generate test names of the following format: `TestRetryConformance/{lower_transport}-{scenario_id}-[{instructions}]-{method_name}-{mapping_id}`
* TestBench.RetryTestResource has a new property `transport`

