### PR TITLE
fix: update implementation of readAllBytes and downloadTo to be more robust to retryable errors

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BaseStorageWriteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BaseStorageWriteChannel.java
@@ -101,12 +101,10 @@ abstract class BaseStorageWriteChannel<T> implements StorageWriteChannel {
       }
       int write = tmp.write(src);
       return write;
-    } catch (StorageException e) {
-      throw new IOException(e);
     } catch (IOException e) {
       throw e;
     } catch (Exception e) {
-      throw new IOException(StorageException.coalesce(e));
+      throw StorageException.coalesce(e);
     }
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
@@ -53,6 +53,7 @@ import com.google.cloud.storage.Storage.CopyRequest;
 import com.google.cloud.storage.Storage.SignUrlOption;
 import com.google.cloud.storage.Storage.UriScheme;
 import com.google.cloud.storage.StorageRoles;
+import com.google.cloud.storage.TransportCompatibility.Transport;
 import com.google.cloud.storage.conformance.retry.CtxFunctions.Local;
 import com.google.cloud.storage.conformance.retry.CtxFunctions.ResourceSetup;
 import com.google.cloud.storage.conformance.retry.CtxFunctions.Rpc;
@@ -1607,7 +1608,9 @@ final class RpcMethodMappings {
                 .build());
         a.add(
             RpcMethodMapping.newBuilder(54, objects.insert)
-                .withApplicable(not(TestRetryConformance::isPreconditionsProvided))
+                .withApplicable(
+                    not(TestRetryConformance::isPreconditionsProvided)
+                        .and(TestRetryConformance.transportIs(Transport.HTTP)))
                 .withSetup(defaultSetup.andThen(Local.blobInfoWithoutGeneration))
                 .withTest(
                     (ctx, c) ->

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestRetryConformance.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestRetryConformance.java
@@ -42,6 +42,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -237,6 +238,10 @@ final class TestRetryConformance {
   @Override
   public String toString() {
     return getTestName();
+  }
+
+  public static Predicate<TestRetryConformance> transportIs(Transport t) {
+    return trc -> trc.transport == t;
   }
 
   private static Supplier<Path> resolvePathForResource(String objectName, Method method) {


### PR DESCRIPTION
Additional small changes to bring http and grpc implementation into conformance with each other.

Much of this also serves as prework to the grpc retry conformance tests enablement after the next release of testbench.

