### PR TITLE
fix: Add an exception to zero byte uploads on CreateFrom

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
@@ -230,6 +230,10 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
     if (Files.isDirectory(path)) {
       throw new StorageException(0, path + " is a directory");
     }
+    long size = Files.size(path);
+    if (size == 0L) {
+      return create(blobInfo, null, options);
+    }
     Opts<ObjectTargetOpt> opts = Opts.unwrap(options).resolveFrom(blobInfo);
     final Map<StorageRpc.Option, ?> optionsMap = opts.getRpcOptions();
     BlobInfo.Builder builder = blobInfo.toBuilder().setMd5(null).setCrc32c(null);
@@ -251,7 +255,6 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
             getOptions().asRetryDependencies(),
             retryAlgorithmManager.idempotent(),
             jsonResumableWrite);
-    long size = Files.size(path);
     HttpContentRange contentRange =
         HttpContentRange.of(ByteRangeSpec.relativeLength(0L, size), size);
     ResumableOperationResult<StorageObject> put =

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectTest.java
@@ -54,7 +54,6 @@ import com.google.cloud.storage.Storage.CopyRequest;
 import com.google.cloud.storage.Storage.PredefinedAcl;
 import com.google.cloud.storage.StorageClass;
 import com.google.cloud.storage.StorageException;
-import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.TransportCompatibility.Transport;
 import com.google.cloud.storage.it.runner.StorageITRunner;
 import com.google.cloud.storage.it.runner.annotations.Backend;

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectTest.java
@@ -54,6 +54,7 @@ import com.google.cloud.storage.Storage.CopyRequest;
 import com.google.cloud.storage.Storage.PredefinedAcl;
 import com.google.cloud.storage.StorageClass;
 import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.TransportCompatibility.Transport;
 import com.google.cloud.storage.it.runner.StorageITRunner;
 import com.google.cloud.storage.it.runner.annotations.Backend;
@@ -74,10 +75,12 @@ import com.google.common.io.ByteStreams;
 import com.google.common.primitives.Ints;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
+import java.nio.file.Paths;
 import java.security.Key;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -193,6 +196,21 @@ public class ITObjectTest {
     assertNotNull(remoteBlob);
     assertEquals(blob.getBucket(), remoteBlob.getBucket());
     assertEquals(blob.getName(), remoteBlob.getName());
+    byte[] readBytes = storage.readAllBytes(bucket.getName(), blobName);
+    assertArrayEquals(new byte[0], readBytes);
+  }
+
+  @Test
+  public void testZeroByteFileUpload() throws Exception {
+    String blobName = generator.randomObjectName();
+    BlobId blobId = BlobId.of(bucket.getName(), blobName);
+    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+
+    File zeroByteFile = File.createTempFile("zerobyte", null);
+    zeroByteFile.deleteOnExit();
+
+    storage.createFrom(blobInfo, Paths.get(zeroByteFile.getAbsolutePath()));
+
     byte[] readBytes = storage.readAllBytes(bucket.getName(), blobName);
     assertArrayEquals(new byte[0], readBytes);
   }


### PR DESCRIPTION
[This PR](https://github.com/googleapis/java-storage/commit/4c2f44e28a1ff19ffb2a02e3cefc062a1dd98fdc) introduced a bug in using createFrom to upload a zero byte object. I can't figure out where exactly the bug is, but something is causing the content range to be 0-1 instead of 0-0 in this case. It ends up getting rejected because the range is bigger than the content size, which is still zero.

We can fix the bug later when we identify the root cause, but for now I'm just reverting to the old way of doing it when we detect that we're uploading a zero byte file.

I also added a test for this case