### PR TITLE
fix: missing serialVersionUID of serializable classes

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
@@ -767,6 +767,7 @@ public final class GrpcStorageOptions extends StorageOptions
 
   private static final class NoopGrpcInterceptorProvider
       implements GrpcInterceptorProvider, Serializable {
+    private static long serialVersionUID = -8523033236999805349L;
     private static final NoopGrpcInterceptorProvider INSTANCE = new NoopGrpcInterceptorProvider();
 
     @Override

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpStorageOptions.java
@@ -346,7 +346,7 @@ public class HttpStorageOptions extends StorageOptions {
    * we do need use it in a couple places, for those we create this adapter.
    */
   private final class RetryDependenciesAdapter implements RetryingDependencies, Serializable {
-
+    private static long serialVersionUID = -7446566394108158974L;
     private RetryDependenciesAdapter() {}
 
     @Override

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Notification.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Notification.java
@@ -26,6 +26,7 @@ import java.util.Objects;
  * details.
  */
 public class Notification extends NotificationInfo {
+  private static final long serialVersionUID = 3150928330690874200L;
 
   private final StorageOptions options;
   private transient Storage storage;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageOptions.java
@@ -63,6 +63,8 @@ public abstract class StorageOptions extends ServiceOptions<Storage, StorageOpti
   /** @deprecated Use {@link HttpStorageFactory} */
   @Deprecated
   public static class DefaultStorageFactory extends HttpStorageFactory {
+    private static final long serialVersionUID = -7856840922014956661L;
+    
     /** @deprecated Use {@link HttpStorageDefaults#getDefaultServiceFactory()} */
     @Deprecated
     public DefaultStorageFactory() {
@@ -73,6 +75,7 @@ public abstract class StorageOptions extends ServiceOptions<Storage, StorageOpti
   /** @deprecated Use {@link HttpStorageRpcFactory} */
   @Deprecated
   public static class DefaultStorageRpcFactory extends HttpStorageRpcFactory {
+    private static final long serialVersionUID = -7856840922014956661L;
 
     /** @deprecated Use {@link HttpStorageDefaults#getDefaultRpcFactory()} */
     @Deprecated

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageOptions.java
@@ -64,7 +64,7 @@ public abstract class StorageOptions extends ServiceOptions<Storage, StorageOpti
   @Deprecated
   public static class DefaultStorageFactory extends HttpStorageFactory {
     private static final long serialVersionUID = -7856840922014956661L;
-    
+
     /** @deprecated Use {@link HttpStorageDefaults#getDefaultServiceFactory()} */
     @Deprecated
     public DefaultStorageFactory() {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
@@ -2540,6 +2540,7 @@ final class UnifiedOpts {
   }
 
   private static final class PrefixedNamedField implements NamedField {
+    private static long serialVersionUID = -4899304145424680141L;
 
     private final String prefix;
     private final NamedField delegate;
@@ -2586,6 +2587,7 @@ final class UnifiedOpts {
   }
 
   private static final class LiteralNamedField implements NamedField {
+    private static long serialVersionUID = 1422947423774466409L;
 
     private final String name;
 
@@ -2627,6 +2629,7 @@ final class UnifiedOpts {
   }
 
   private static final class NestedNamedField implements NamedField {
+    private static long serialVersionUID = -7623005572810688221L;
     private final NamedField parent;
     private final NamedField child;
 


### PR DESCRIPTION
In files: HttpStorageOptions.java, GrpcStorageOptions.java, Notification.java, StorageOptions.java and UnifiedOpts.java there are some classes that are serializable but it does not contain any serialVersionUID field. The compiler generates one by default in such scenarios, but the generated id is dependent on compiler implementation and may cause unwanted problems during deserialization. 

##### The Role of serialVersionUID:

The primary role of serialVersionUID is to provide version control during deserialization. When deserialize an object, the JVM checks whether the serialVersionUID of the serialized data matches the serialVersionUID of the class in the current classpath. If they match, the deserialization proceeds without issues. However, if they do not match, programmers encounter InvalidClassException.

As, serialVersionUID servers the purpose of version control of class during serialization-deserialization, without a serialVersionUID, we risk breaking backward compatibility when making changes to classes, which can lead to unexpected issues and errors during deserialization.

##### Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
