### PR TITLE
feat: Add ability to create a PCU Prefix at the object level

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.29.0')
+implementation platform('com.google.cloud:libraries-bom:26.30.0')
 
 implementation 'com.google.cloud:google-cloud-storage'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-storage:2.30.1'
+implementation 'com.google.cloud:google-cloud-storage:2.31.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "2.30.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "2.31.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -428,7 +428,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-storage.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-storage/2.30.1
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-storage/2.31.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfig.java
@@ -521,6 +521,11 @@ public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWri
       return new WithPrefix(rand, prefixPattern);
     }
 
+    @BetaApi
+    public static PartNamingStrategy objectLevelPrefix() {
+      return objectLevelPrefix("");
+    }
+
     /**
      * Strategy in which an explicit stable prefix with object name included is present on each part
      * and intermediary compose object.
@@ -583,7 +588,9 @@ public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWri
 
       private WithObjectLevelPrefix(SecureRandom rand, String prefix) {
         super(rand);
-        this.prefix = prefix;
+        // If no prefix is specified we will create the part files under the same directory as the
+        // ultimate object.
+        this.prefix = prefix.isEmpty() ? prefix :  prefix + "/";
       }
 
       @Override
@@ -592,7 +599,6 @@ public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWri
             OBJECT_NAME_HASH_FUNCTION.hashString(ultimateObjectName, StandardCharsets.UTF_8);
         String nameDigest = B64.encodeToString(hashCode.asBytes());
         return prefix
-            + "/"
             + ultimateObjectName
             + "/"
             + randomKey

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfig.java
@@ -520,19 +520,14 @@ public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWri
       return new WithPrefix(rand, prefixPattern);
     }
 
-    @BetaApi
-    public static PartNamingStrategy objectLevelPrefix() {
-      return objectLevelPrefix("");
-    }
-
     /**
-     * Strategy in which an explicit stable prefix with object name included is present on each part
+     * Strategy in which the end object name is the prefix included and is present on each part
      * and intermediary compose object.
      *
      * <p>General format is
      *
      * <pre><code>
-     *   {prefixPattern}/{objectName}/{randomKeyDigest};{objectInfoDigest};{partIndex}.part
+     *   {objectName}/{randomKeyDigest};{objectInfoDigest};{partIndex}.part
      * </code></pre>
      *
      * <p>{@code {objectInfoDigest}} will be fixed for an individual {@link BlobWriteSession}.
@@ -540,16 +535,16 @@ public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWri
      * <p><b><i>NOTE:</i></b>The way in which both {@code randomKeyDigest} and {@code
      * objectInfoDigest} are generated is undefined and subject to change at any time.
      *
-     * <p>Care must be taken when choosing to specify a stable prefix as this can create hotspots in
-     * the keyspace for object names. See <a
-     * href="https://cloud.google.com/storage/docs/request-rate#naming-convention">Object Naming
-     * Convention Guidelines</a> for more details.
      *
      * @see #withPartNamingStrategy(PartNamingStrategy)
      * @since 2.30.2 This new api is in preview and is subject to breaking changes.
      */
     @BetaApi
-    public static PartNamingStrategy objectLevelPrefix(String prefixPattern) {
+    public static PartNamingStrategy objectNamePrefix() {
+      return objectNamePrefix("");
+    }
+    
+    private static PartNamingStrategy objectNamePrefix(String prefixPattern) {
       checkNotNull(prefixPattern, "prefixPattern must be non null");
       SecureRandom rand = new SecureRandom();
       return new WithObjectLevelPrefix(rand, prefixPattern);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfig.java
@@ -126,7 +126,6 @@ public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWri
   private final PartNamingStrategy partNamingStrategy;
   private final PartCleanupStrategy partCleanupStrategy;
 
-
   private ParallelCompositeUploadBlobWriteSessionConfig(
       int maxPartsPerCompose,
       ExecutorSupplier executorSupplier,
@@ -581,16 +580,17 @@ public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWri
             + ".part";
       }
     }
-     static final class WithObjectLevelPrefix extends PartNamingStrategy {
 
-       private static final long serialVersionUID = 5157942020618764450L;
+    static final class WithObjectLevelPrefix extends PartNamingStrategy {
+
+      private static final long serialVersionUID = 5157942020618764450L;
       private final String prefix;
 
       private WithObjectLevelPrefix(SecureRandom rand, String prefix) {
         super(rand);
         // If no prefix is specified we will create the part files under the same directory as the
         // ultimate object.
-        this.prefix = prefix.isEmpty() ? prefix :  prefix + "/";
+        this.prefix = prefix.isEmpty() ? prefix : prefix + "/";
       }
 
       @Override

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfig.java
@@ -527,7 +527,7 @@ public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWri
      * <p>General format is
      *
      * <pre><code>
-     *   {objectName}/{randomKeyDigest};{objectInfoDigest};{partIndex}.part
+     *   {objectName}-parts/{randomKeyDigest};{objectInfoDigest};{partIndex}.part
      * </code></pre>
      *
      * <p>{@code {objectInfoDigest}} will be fixed for an individual {@link BlobWriteSession}.
@@ -594,6 +594,7 @@ public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWri
         String nameDigest = B64.encodeToString(hashCode.asBytes());
         return prefix
             + ultimateObjectName
+            + "-parts"
             + "/"
             + randomKey
             + FIELD_SEPARATOR

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfig.java
@@ -521,8 +521,8 @@ public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWri
     }
 
     /**
-     * Strategy in which the end object name is the prefix included and is present on each part
-     * and intermediary compose object.
+     * Strategy in which the end object name is the prefix included and is present on each part and
+     * intermediary compose object.
      *
      * <p>General format is
      *
@@ -535,7 +535,6 @@ public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWri
      * <p><b><i>NOTE:</i></b>The way in which both {@code randomKeyDigest} and {@code
      * objectInfoDigest} are generated is undefined and subject to change at any time.
      *
-     *
      * @see #withPartNamingStrategy(PartNamingStrategy)
      * @since 2.30.2 This new api is in preview and is subject to breaking changes.
      */
@@ -543,7 +542,7 @@ public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWri
     public static PartNamingStrategy objectNamePrefix() {
       return objectNamePrefix("");
     }
-    
+
     private static PartNamingStrategy objectNamePrefix(String prefixPattern) {
       checkNotNull(prefixPattern, "prefixPattern must be non null");
       SecureRandom rand = new SecureRandom();

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfig.java
@@ -527,7 +527,7 @@ public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWri
      * <p>General format is
      *
      * <pre><code>
-     *   {objectName}-parts/{randomKeyDigest};{objectInfoDigest};{partIndex}.part
+     *   {objectName}-{randomKeyDigest};{objectInfoDigest};{partIndex}.part
      * </code></pre>
      *
      * <p>{@code {objectInfoDigest}} will be fixed for an individual {@link BlobWriteSession}.
@@ -539,11 +539,11 @@ public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWri
      * @since 2.30.2 This new api is in preview and is subject to breaking changes.
      */
     @BetaApi
-    public static PartNamingStrategy objectNamePrefix() {
-      return objectNamePrefix("");
+    public static PartNamingStrategy useObjectNameAsPrefix() {
+      return useObjectNameAsPrefix("");
     }
 
-    private static PartNamingStrategy objectNamePrefix(String prefixPattern) {
+    private static PartNamingStrategy useObjectNameAsPrefix(String prefixPattern) {
       checkNotNull(prefixPattern, "prefixPattern must be non null");
       SecureRandom rand = new SecureRandom();
       return new WithObjectLevelPrefix(rand, prefixPattern);
@@ -594,8 +594,7 @@ public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWri
         String nameDigest = B64.encodeToString(hashCode.asBytes());
         return prefix
             + ultimateObjectName
-            + "-parts"
-            + "/"
+            + "-"
             + randomKey
             + FIELD_SEPARATOR
             + nameDigest

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfigTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfigTest.java
@@ -70,6 +70,38 @@ public final class ParallelCompositeUploadBlobWriteSessionConfigTest {
         () -> assertThat(fmt).startsWith("[%s]/"));
   }
 
+  @Test
+  public void partNameStrategy_prefixObjectLevel() throws Exception {
+    PartNamingStrategy strategy = PartNamingStrategy.objectLevelPrefix("asdf");
+
+    String fmt = strategy.fmtName("a/b/obj", PartRange.of(1, 96));
+    assertAll(
+        // random digest with prefix to spread over keyspace
+        // digest is 22, prefix is 4, slash is 1 , objectName is 7, additional slash is 1
+        () -> assertField(fmt, 0).hasLength(22 + 5 + 8),
+        // name digest
+        () -> assertField(fmt, 1).hasLength(22),
+        () -> assertField(fmt, 2).isEqualTo("0001-0096.part"),
+        () -> assertThat(fmt).startsWith("asdf/a/b/obj/"));
+  }
+
+  @Test
+  public void partNameStrategy_noPrefixObjectLevel() throws Exception {
+    // Creating an object level prefix without specifying an additional prefix will append the
+    // object name to the beginning of the part name.
+    PartNamingStrategy strategy = PartNamingStrategy.objectLevelPrefix();
+
+    String fmt = strategy.fmtName("a/b/obj", PartRange.of(1, 96));
+    assertAll(
+        // random digest with prefix to spread over keyspace
+        // digest is 22, objectName is 7, slash is 1
+        () -> assertField(fmt, 0).hasLength(22 + 8),
+        // name digest
+        () -> assertField(fmt, 1).hasLength(22),
+        () -> assertField(fmt, 2).isEqualTo("0001-0096.part"),
+        () -> assertThat(fmt).startsWith("a/b/obj/"));
+  }
+
   private static StringSubject assertField(String fmt, int idx) {
     String[] split = fmt.split(";");
     String s = split[idx];

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfigTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfigTest.java
@@ -74,7 +74,7 @@ public final class ParallelCompositeUploadBlobWriteSessionConfigTest {
   public void partNameStrategy_objectNamePrefix() throws Exception {
     // Creating an object level prefix without specifying an additional prefix will append the
     // object name to the beginning of the part name.
-    PartNamingStrategy strategy = PartNamingStrategy.objectNamePrefix();
+    PartNamingStrategy strategy = PartNamingStrategy.useObjectNameAsPrefix();
 
     String fmt = strategy.fmtName("a/b/obj", PartRange.of(1, 96));
     assertAll(

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfigTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfigTest.java
@@ -71,25 +71,10 @@ public final class ParallelCompositeUploadBlobWriteSessionConfigTest {
   }
 
   @Test
-  public void partNameStrategy_prefixObjectLevel() throws Exception {
-    PartNamingStrategy strategy = PartNamingStrategy.objectLevelPrefix("asdf");
-
-    String fmt = strategy.fmtName("a/b/obj", PartRange.of(1, 96));
-    assertAll(
-        // random digest with prefix to spread over keyspace
-        // digest is 22, prefix is 4, slash is 1 , objectName is 7, additional slash is 1
-        () -> assertField(fmt, 0).hasLength(22 + 5 + 8),
-        // name digest
-        () -> assertField(fmt, 1).hasLength(22),
-        () -> assertField(fmt, 2).isEqualTo("0001-0096.part"),
-        () -> assertThat(fmt).startsWith("asdf/a/b/obj/"));
-  }
-
-  @Test
-  public void partNameStrategy_noPrefixObjectLevel() throws Exception {
+  public void partNameStrategy_objectNamePrefix() throws Exception {
     // Creating an object level prefix without specifying an additional prefix will append the
     // object name to the beginning of the part name.
-    PartNamingStrategy strategy = PartNamingStrategy.objectLevelPrefix();
+    PartNamingStrategy strategy = PartNamingStrategy.objectNamePrefix();
 
     String fmt = strategy.fmtName("a/b/obj", PartRange.of(1, 96));
     assertAll(


### PR DESCRIPTION
This feature enabled the user to create a prefix that will be unique per parallel composite upload. If the user specifies a prefix the prefix will be appended to the ultimate object name which will be appended to the part name to create a staging area for objects per PCU.

If the user does not specify a prefix then the parts will simply be created at the level of the ultimate object name.
