### PR TITLE
chore: deep-preserve for `ITFoldersTest`

### DIFF
--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -15,6 +15,9 @@
 docker:
   image: "gcr.io/cloud-devrel-public-resources/owlbot-java:latest"
 
+deep-preserve-regex:
+- "/google-.*/src/test/java/com/google/storage/control/v2/ITFoldersTest.java"
+
 deep-remove-regex:
 - "/grpc-google-.*/src"
 - "/proto-google-.*/src"


### PR DESCRIPTION
Owlbot PRs will be removing this IT. This PR prevents it. I found out about this by testing [new GAPIC generation in sdk-platform-java](https://github.com/googleapis/sdk-platform-java/tree/main/library_generation) (I generated a post-processed library and the diff between my generation and the `java-storage` repo was this one missing file)

OwlBot CLI's `copy-code` output (from a local generation):

```
...
rm  /repo/google-cloud-storage-control/src/main/java/com/google/storage/control/v2/StorageControlClient.java
rm  /repo/google-cloud-storage-control/src/main/java/com/google/storage/control/v2/StorageControlSettings.java
rm  /repo/google-cloud-storage-control/src/main/java/com/google/storage/control/v2/stub/GrpcStorageControlCallableFactory.java
rm  /repo/google-cloud-storage-control/src/main/java/com/google/storage/control/v2/stub/GrpcStorageControlStub.java
rm  /repo/google-cloud-storage-control/src/main/java/com/google/storage/control/v2/stub/StorageControlStub.java
rm  /repo/google-cloud-storage-control/src/main/java/com/google/storage/control/v2/stub/StorageControlStubSettings.java
rm  /repo/google-cloud-storage-control/src/main/resources/com/google/storage/control/v2/gapic_metadata.json
rm  /repo/google-cloud-storage-control/src/main/resources/META-INF/native-image/com.google.storage.control.v2/reflect-config.json

// problematic removal
rm  /repo/google-cloud-storage-
control/src/test/java/com/google/storage/control/v2/ITFoldersTest.java

rm  /repo/google-cloud-storage-control/src/test/java/com/google/storage/control/v2/MockStorageControl.java
rm  /repo/google-cloud-storage-control/src/test/java/com/google/storage/control/v2/MockStorageControlImpl.java
rm  /repo/google-cloud-storage-control/src/test/java/com/google/storage/control/v2/StorageControlClientTest.java
rmdir  /repo/google-cloud-storage-control/src/main/resources/META-INF/native-image/com.google.storage.control.v2
rmdir  /repo/gapic-google-cloud-storage-v2/src/main/resources/META-INF/native-image/com.google.storage.v2
rmdir  /repo/proto-google-cloud-storage-control-v2/src/main/java/com/google/storage/control/v2

...
```
@JoeWang1127 @suztomo @blakeli0 
I will disable `storage` tests in our hermetic build ITs while this is not merged