### PR TITLE
feat: Adds TPC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ implementation 'com.google.cloud:google-cloud-storage'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-storage:2.31.0'
+implementation 'com.google.cloud:google-cloud-storage:2.32.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "2.31.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "2.32.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -428,7 +428,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-storage.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-storage/2.31.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-storage/2.32.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.30.0')
+implementation platform('com.google.cloud:libraries-bom:26.31.0')
 
 implementation 'com.google.cloud:google-cloud-storage'
 ```

--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -173,13 +173,13 @@
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-kms-v1</artifactId>
-      <version>0.126.0</version>
+      <version>0.127.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-kms</artifactId>
-      <version>2.35.0</version>
+      <version>2.36.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpStorageOptions.java
@@ -323,6 +323,11 @@ public class HttpStorageOptions extends StorageOptions {
     public ServiceRpc create(StorageOptions options) {
       if (options instanceof HttpStorageOptions) {
         HttpStorageOptions httpStorageOptions = (HttpStorageOptions) options;
+        // todo: In the future, this step will be done automatically, and the getResolvedApiaryHost helper method will
+        // be removed. When that happens, delete the following block.
+        if (httpStorageOptions.getUniverseDomain() != null) {
+          httpStorageOptions = httpStorageOptions.toBuilder().setHost(httpStorageOptions.getResolvedApiaryHost("storage")).build();
+        }
         return new HttpStorageRpc(httpStorageOptions);
       } else {
         throw new IllegalArgumentException("Only HttpStorageOptions supported");

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpStorageOptions.java
@@ -325,6 +325,7 @@ public class HttpStorageOptions extends StorageOptions {
         HttpStorageOptions httpStorageOptions = (HttpStorageOptions) options;
         // todo: In the future, this step will be done automatically, and the getResolvedApiaryHost helper method will
         // be removed. When that happens, delete the following block.
+        // https://github.com/googleapis/google-api-java-client-services/issues/19286
         if (httpStorageOptions.getUniverseDomain() != null) {
           httpStorageOptions = httpStorageOptions.toBuilder().setHost(httpStorageOptions.getResolvedApiaryHost("storage")).build();
         }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
@@ -1587,7 +1587,7 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
      * TODO: In the future, this should happen automatically, and this block will be deleted
      * https://github.com/googleapis/google-api-java-client-services/issues/19286
      */
-    if(options.getUniverseDomain() != null) {
+    if (options.getUniverseDomain() != null) {
 
       return options.toBuilder().setHost(options.getResolvedApiaryHost("storage")).build();
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
@@ -101,7 +101,8 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
   /** Signed URLs are only supported through the GCS XML API endpoint. */
   private static final String STORAGE_XML_URI_SCHEME = "https";
 
-  private static final String STORAGE_XML_URI_HOST_NAME = "storage.googleapis.com";
+  // TODO: in the future, this can be replaced by getOptions().getHost()
+  private final String STORAGE_XML_URI_HOST_NAME = getOptions().getResolvedApiaryHost("storage").replaceFirst("http(s)?://", "").replace("/", "");
 
   private static final int DEFAULT_BUFFER_SIZE = 15 * 1024 * 1024;
   private static final int MIN_BUFFER_SIZE = 256 * 1024;
@@ -1048,7 +1049,8 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
             "host",
             slashlessBucketNameFromBlobInfo(blobInfo) + "." + getBaseStorageHostName(optionMap));
       } else if (optionMap.containsKey(SignUrlOption.Option.HOST_NAME)
-          || optionMap.containsKey(SignUrlOption.Option.BUCKET_BOUND_HOST_NAME)) {
+          || optionMap.containsKey(SignUrlOption.Option.BUCKET_BOUND_HOST_NAME)
+          || getOptions().getUniverseDomain() != null) {
         extHeadersBuilder.put("host", getBaseStorageHostName(optionMap));
       }
     }
@@ -1576,7 +1578,14 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
 
   @Override
   public HttpStorageOptions getOptions() {
-    return (HttpStorageOptions) super.getOptions();
+    HttpStorageOptions options = (HttpStorageOptions) super.getOptions();
+    /**
+     * TODO: In the future, this should happen automatically, and this block will be deleted
+     */
+    if(options.getUniverseDomain() != null) {
+      return options.toBuilder().setHost(options.getResolvedApiaryHost("storage")).build();
+    }
+    return options;
   }
 
   private Blob internalGetBlob(BlobId blob, Map<StorageRpc.Option, ?> optionsMap) {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
@@ -1581,6 +1581,7 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage {
     HttpStorageOptions options = (HttpStorageOptions) super.getOptions();
     /**
      * TODO: In the future, this should happen automatically, and this block will be deleted
+     * https://github.com/googleapis/google-api-java-client-services/issues/19286
      */
     if(options.getUniverseDomain() != null) {
       return options.toBuilder().setHost(options.getResolvedApiaryHost("storage")).build();


### PR DESCRIPTION
This PR adds an intercept when `UniverseDomain` is set in `StorageOptions`, which overrides the host in StorageOptions. It also changes signed URLs to respect custom hosts, including a specified universe domain. 

There are no tests for this because Kokoro is not able to access any TPC universes yet. I tested all these changes locally, and they're working against the staging universe. 