### PR TITLE
chore(benchmarks): Warmup v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.30.0')
+implementation platform('com.google.cloud:libraries-bom:26.31.0')
 
 implementation 'com.google.cloud:google-cloud-storage'
 ```

--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/StorageSharedBenchmarkingCli.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/StorageSharedBenchmarkingCli.java
@@ -142,8 +142,8 @@ public final class StorageSharedBenchmarkingCli implements Runnable {
   private void runW1R3(Storage storageClient) throws ExecutionException, InterruptedException {
     ListeningExecutorService executorService =
         MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(workers));
+    runWarmup(storageClient);
     for (int i = 0; i < samples; i++) {
-      runWarmup(storageClient);
       Range objectSizeRange = Range.of(objectSize);
       int objectSize = getRandomInt(objectSizeRange.min, objectSizeRange.max);
       convert(

--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/StorageSharedBenchmarkingCli.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/StorageSharedBenchmarkingCli.java
@@ -124,6 +124,7 @@ public final class StorageSharedBenchmarkingCli implements Runnable {
       runW1R3(storageClient);
     } catch (Exception e) {
       System.err.println("Failed to run workload 1: " + e.getMessage());
+      System.exit(1);
     }
   }
 
@@ -136,6 +137,7 @@ public final class StorageSharedBenchmarkingCli implements Runnable {
       runW1R3(storageClient);
     } catch (Exception e) {
       System.err.println("Failed to run workload 4: " + e.getMessage());
+      System.exit(1);
     }
   }
 

--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/W1R3.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/W1R3.java
@@ -98,7 +98,7 @@ final class W1R3 implements Callable<String> {
               .setTransferSize("")
               .setThroughput(0)
               .build();
-      printWriter.println(result);
+      printWriter.println(result.formatAsCustomMetric());
     }
     return "OK";
   }

--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/W1R3.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/W1R3.java
@@ -97,7 +97,7 @@ final class W1R3 implements Callable<String> {
               .setBucketName("")
               .setStatus("FAIL")
               .setTransferSize("")
-              .setThroughput(-1)
+              .setThroughput(0)
               .build();
       printWriter.println(result);
       return "FAIL";

--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/W1R3.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/W1R3.java
@@ -81,7 +81,6 @@ final class W1R3 implements Callable<String> {
         }
       }
       StorageSharedBenchmarkingUtils.cleanupObject(storage, created);
-      return "OK";
     } catch (Exception e) {
       CloudMonitoringResult result =
           CloudMonitoringResult.newBuilder()
@@ -100,8 +99,8 @@ final class W1R3 implements Callable<String> {
               .setThroughput(0)
               .build();
       printWriter.println(result);
-      return "FAIL";
     }
+    return "OK";
   }
 
   private void printResult(String op, Blob created, Duration duration) {


### PR DESCRIPTION
1. Addressed some late comments on the previous warmup PR. (ie moving warmup outside of samples loop)
2. Added in exits for when we encounter an exception that causes the workload to fail.
3. Fixed metric publishing for failures(-1 to 0), just publish the metric instead of completely failing out of the workload.

