### PR TITLE
chore: testing google-http-client 1.44.1 [no need to review]

### DIFF
--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -27,6 +27,8 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
+      <!-- This version stops declaring commons-logging -->
+      <version>1.44.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>


### PR DESCRIPTION
google-http-client 1.44.1 stopped declaring commons-logging. Would that work?

(But google-api-client still declares commons-logging via httpclient. So maybe this experiment does not show anything)