### PR TITLE
chore(benchmarking): Remove retries and switch to publishing api_latency instead of throughput

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.32.0')
+implementation platform('com.google.cloud:libraries-bom:26.33.0')
 
 implementation 'com.google.cloud:google-cloud-storage'
 ```

--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/Bidi.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/Bidi.java
@@ -76,12 +76,7 @@ class Bidi implements Callable<String> {
 
   private void printResult(String op, BlobInfo created, Duration duration) {
     pw.println(
-        generateCloudMonitoringResult(
-                op,
-                duration.toMillis(),
-                created,
-                api,
-                workers)
+        generateCloudMonitoringResult(op, duration.toMillis(), created, api, workers)
             .formatAsCustomMetric());
   }
 }

--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/Bidi.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/Bidi.java
@@ -78,8 +78,7 @@ class Bidi implements Callable<String> {
     pw.println(
         generateCloudMonitoringResult(
                 op,
-                StorageSharedBenchmarkingUtils.calculateThroughput(
-                    created.getSize().doubleValue(), duration),
+                duration.toMillis(),
                 created,
                 api,
                 workers)

--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/CloudMonitoringResult.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/CloudMonitoringResult.java
@@ -39,7 +39,7 @@ final class CloudMonitoringResult {
   @NonNull private final String transferSize;
   @NonNull private final String transferOffset;
   @NonNull private final String failureMsg;
-  private final double throughput;
+  private final double latency;
 
   CloudMonitoringResult(
       String library,
@@ -57,7 +57,7 @@ final class CloudMonitoringResult {
       String transferSize,
       String transferOffset,
       String failureMsg,
-      double throughput) {
+      double latency) {
     this.library = library;
     this.api = api;
     this.op = op;
@@ -73,7 +73,7 @@ final class CloudMonitoringResult {
     this.transferSize = transferSize;
     this.transferOffset = transferOffset;
     this.failureMsg = failureMsg;
-    this.throughput = throughput;
+    this.latency = latency;
   }
 
   public static Builder newBuilder() {
@@ -98,7 +98,7 @@ final class CloudMonitoringResult {
         .add("transferSize", transferSize)
         .add("transferOffset", transferOffset)
         .add("failureMsg", failureMsg)
-        .add("throughput", throughput)
+        .add("latency", latency)
         .toString();
   }
 
@@ -118,7 +118,7 @@ final class CloudMonitoringResult {
         && crc32CEnabled == result.crc32CEnabled
         && md5Enabled == result.md5Enabled
         && cpuTimeUs == result.cpuTimeUs
-        && Double.compare(result.throughput, throughput) == 0
+        && Double.compare(result.latency, latency) == 0
         && Objects.equals(library, result.library)
         && Objects.equals(api, result.api)
         && Objects.equals(op, result.op)
@@ -147,12 +147,12 @@ final class CloudMonitoringResult {
         transferSize,
         transferOffset,
         failureMsg,
-        throughput);
+        latency);
   }
 
   public String formatAsCustomMetric() {
     return String.format(
-        "throughput{library=%s,api=%s,op=%s,object_size=%d,chunksize=%d,workers=%d,crc32c_enabled=%b,md5_enabled=%b,bucket_name=%s,status=%s,app_buffer_size=%d}%.1f",
+        "latency{library=%s,api=%s,op=%s,object_size=%d,chunksize=%d,workers=%d,crc32c_enabled=%b,md5_enabled=%b,bucket_name=%s,status=%s,app_buffer_size=%d}%.1f",
         library,
         api,
         op,
@@ -164,7 +164,7 @@ final class CloudMonitoringResult {
         bucketName,
         status,
         appBufferSize,
-        throughput);
+        latency);
   }
 
   public static class Builder {
@@ -184,7 +184,7 @@ final class CloudMonitoringResult {
     @NonNull private String transferSize;
     @NonNull private String transferOffset;
     @NonNull private String failureMsg;
-    private double throughput;
+    private double latency;
 
     Builder() {
       library = "";
@@ -272,8 +272,8 @@ final class CloudMonitoringResult {
       return this;
     }
 
-    public Builder setThroughput(double throughput) {
-      this.throughput = throughput;
+    public Builder setLatency(double latency) {
+      this.latency = latency;
       return this;
     }
 
@@ -302,7 +302,7 @@ final class CloudMonitoringResult {
           transferSize,
           transferOffset,
           failureMsg,
-          throughput);
+          latency);
     }
   }
 }

--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/CloudMonitoringResult.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/CloudMonitoringResult.java
@@ -152,7 +152,7 @@ final class CloudMonitoringResult {
 
   public String formatAsCustomMetric() {
     return String.format(
-        "latency{library=%s,api=%s,op=%s,object_size=%d,chunksize=%d,workers=%d,crc32c_enabled=%b,md5_enabled=%b,bucket_name=%s,status=%s,app_buffer_size=%d}%.1f",
+        "api_latency{library=%s,api=%s,op=%s,object_size=%d,chunksize=%d,workers=%d,crc32c_enabled=%b,md5_enabled=%b,bucket_name=%s,status=%s,app_buffer_size=%d}%.1f",
         library,
         api,
         op,

--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/StorageSharedBenchmarkingCli.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/StorageSharedBenchmarkingCli.java
@@ -132,7 +132,7 @@ public final class StorageSharedBenchmarkingCli implements Runnable {
   }
 
   private void runWorkload1Json() {
-    RetrySettings retrySettings = StorageOptions.getDefaultRetrySettings().toBuilder().build();
+    RetrySettings retrySettings = StorageOptions.getNoRetrySettings().toBuilder().build();
 
     StorageOptions retryStorageOptions =
         StorageOptions.newBuilder().setProjectId(project).setRetrySettings(retrySettings).build();
@@ -146,7 +146,7 @@ public final class StorageSharedBenchmarkingCli implements Runnable {
   }
 
   private void runWorkload1DirectPath() {
-    RetrySettings retrySettings = StorageOptions.getDefaultRetrySettings().toBuilder().build();
+    RetrySettings retrySettings = StorageOptions.getNoRetrySettings().toBuilder().build();
     StorageOptions retryStorageOptions =
         StorageOptions.grpc().setRetrySettings(retrySettings).setAttemptDirectPath(true).build();
     Storage storageClient = retryStorageOptions.getService();

--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/StorageSharedBenchmarkingUtils.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/StorageSharedBenchmarkingUtils.java
@@ -17,7 +17,6 @@ package com.google.cloud.storage.benchmarking;
 
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
-import java.time.Duration;
 
 class StorageSharedBenchmarkingUtils {
   public static long SSB_SIZE_THRESHOLD_BYTES = 1048576;

--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/StorageSharedBenchmarkingUtils.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/StorageSharedBenchmarkingUtils.java
@@ -28,17 +28,8 @@ class StorageSharedBenchmarkingUtils {
         created.getBlobId(), Storage.BlobSourceOption.generationMatch(created.getGeneration()));
   }
 
-  public static double calculateThroughput(double size, Duration elapsedTime) {
-    double adjustedSize =
-        size >= StorageSharedBenchmarkingUtils.SSB_SIZE_THRESHOLD_BYTES
-            ? (size / 1024D) / 1024D
-            : size / 1024D;
-    double throughput = adjustedSize / (elapsedTime.toMillis() / 1000D);
-    return throughput;
-  }
-
   public static CloudMonitoringResult generateCloudMonitoringResult(
-      String op, double throughput, BlobInfo created, String api, int workers) {
+      String op, double latency, BlobInfo created, String api, int workers) {
     CloudMonitoringResult result =
         CloudMonitoringResult.newBuilder()
             .setLibrary("java")
@@ -53,7 +44,7 @@ class StorageSharedBenchmarkingUtils {
             .setBucketName(created.getBucket())
             .setStatus("OK")
             .setTransferSize(created.getSize().toString())
-            .setThroughput(throughput)
+            .setLatency(latency)
             .build();
     return result;
   }

--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/W1R3.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/W1R3.java
@@ -98,7 +98,7 @@ final class W1R3 implements Callable<String> {
               .setBucketName("")
               .setStatus("FAIL")
               .setTransferSize("")
-              .setThroughput(0)
+              .setLatency(0)
               .build();
       printWriter.println(result.formatAsCustomMetric());
     }
@@ -110,8 +110,7 @@ final class W1R3 implements Callable<String> {
       printWriter.println(
           generateCloudMonitoringResult(
                   op,
-                  StorageSharedBenchmarkingUtils.calculateThroughput(
-                      created.getSize().doubleValue(), duration),
+                  duration.toMillis(),
                   created.asBlobInfo(),
                   api,
                   workers)

--- a/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/W1R3.java
+++ b/storage-shared-benchmarking/src/main/java/com/google/cloud/storage/benchmarking/W1R3.java
@@ -108,12 +108,7 @@ final class W1R3 implements Callable<String> {
   private void printResult(String op, Blob created, Duration duration) {
     if (!isWarmup) {
       printWriter.println(
-          generateCloudMonitoringResult(
-                  op,
-                  duration.toMillis(),
-                  created.asBlobInfo(),
-                  api,
-                  workers)
+          generateCloudMonitoringResult(op, duration.toMillis(), created.asBlobInfo(), api, workers)
               .formatAsCustomMetric());
     }
   }


### PR DESCRIPTION
In order to better compare performance of gRPC and JSON I have removed retries to keep retried requests from impacting latency metrics. We can monitor failed metrics and perhaps in the future publish metrics around if a request would have been retried or not.

I also believe publishing latency is more useful than throughput. If we want throughput the math is simpler to conduct in the dashboards than the other way around.