### PR TITLE
chore: update package-info with gRPC GA Allowlist

### DIFF
--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -269,7 +269,7 @@
               <dependency>io.grpc:grpc-netty-shaded</dependency>
               <!--
               defining a runtime dependency on this so it is on the default classpath for customers wanting
-              to use direct path
+              to use Direct Google Access
               -->
               <dependency>io.grpc:grpc-googleapis</dependency>
               <dependency>io.grpc:grpc-xds</dependency>

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
@@ -386,11 +386,11 @@ public final class GrpcStorageOptions extends StorageOptions
     }
 
     /**
-     * Option which signifies the client should attempt to connect to gcs via Direct Path.
+     * Option which signifies the client should attempt to connect to gcs via Direct Google Access.
      *
      * <p><i>NOTE</i>There is no need to specify a new endpoint via {@link #setHost(String)} as the
      * underlying code will translate the normal {@code https://storage.googleapis.com:443} into the
-     * proper Direct Path URI for you.
+     * proper Direct Google Access URI for you.
      *
      * @since 2.14.0 This new api is in preview and is subject to breaking changes.
      */

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
@@ -158,8 +158,8 @@ public final class GrpcStorageOptions extends StorageOptions
     URI uri = URI.create(endpoint);
     String scheme = uri.getScheme();
     int port = uri.getPort();
-    // Gax routes the endpoint into a method which can't handle schemes, unless for direct path
-    // try and strip here if we can
+    // Gax routes the endpoint into a method which can't handle schemes,
+    // unless for Direct Google Access try and strip here if we can
     switch (scheme) {
       case "http":
         endpoint = String.format("%s:%s", uri.getHost(), port > 0 ? port : 80);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/package-info.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/package-info.java
@@ -66,7 +66,8 @@
  * features remain experimental and subject to change without notice. The methods to create, list,
  * query, and delete HMAC keys and notifications are unavailable in gRPC transport.
  *
- * <p>This example shows how to enable gRPC with Direct Google Access only supported on Google Compute Engine.
+ * <p>This example shows how to enable gRPC with Direct Google Access only supported on Google
+ * Compute Engine.
  *
  * <pre>{@code
  * StorageOptions options = StorageOptions.grpc().setAttemptDirectPath(true).build();

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/package-info.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/package-info.java
@@ -66,7 +66,7 @@
  * features remain experimental and subject to change without notice. The methods to create, list,
  * query, and delete HMAC keys and notifications are unavailable in gRPC transport.
  *
- * <p>This example shows how to enable gRPC with DirectPath only supported on Google Compute Engine.
+ * <p>This example shows how to enable gRPC with Direct Google Access only supported on Google Compute Engine.
  *
  * <pre>{@code
  * StorageOptions options = StorageOptions.grpc().setAttemptDirectPath(true).build();
@@ -83,7 +83,7 @@
  * }
  * }</pre>
  *
- * <p>This example shows how to enable gRPC without DirectPath.
+ * <p>This example shows how to enable gRPC.
  *
  * <pre>{@code
  * StorageOptions options = StorageOptions.grpc().build();

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/package-info.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/package-info.java
@@ -56,18 +56,15 @@
  * href="https://github.com/googleapis/java-storage/blob/main/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobWriteChannel.java">
  * BlobWriteChannel</a>.
  *
- * <p>The GCS Java client library includes support to GCS via gRPC.
- * When using GCS from Google Compute Engine (GCE) this library enable higher
- * total throughput across large workloads that run on hundreds or thousands of
- * VMs.</p>
+ * <p>The GCS Java client library includes support to GCS via gRPC. When using GCS from Google
+ * Compute Engine (GCE) this library enable higher total throughput across large workloads that run
+ * on hundreds or thousands of VMs.
  *
- * <p>At present, GCS gRPC is GA with Allowlist. To access this API,
- *   kindly contact the Google Cloud Storage gRPC team at
- *   gcs-grpc-contact@google.com with a list of GCS buckets you would like to
- *   Allowlist. Please note that while the **service** is GA (with Allowlist),
- *   the client library features remain experimental and subject to change
- *   without notice. The methods to create, list, query, and delete HMAC keys and notifications
- *   are unavailable in gRPC transport.</p>
+ * <p>At present, GCS gRPC is GA with Allowlist. To access this API, kindly contact the Google Cloud
+ * Storage gRPC team at gcs-grpc-contact@google.com with a list of GCS buckets you would like to
+ * Allowlist. Please note that while the **service** is GA (with Allowlist), the client library
+ * features remain experimental and subject to change without notice. The methods to create, list,
+ * query, and delete HMAC keys and notifications are unavailable in gRPC transport.
  *
  * <p>This example shows how to enable gRPC with DirectPath only supported on Google Compute Engine.
  *

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/package-info.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/package-info.java
@@ -56,6 +56,53 @@
  * href="https://github.com/googleapis/java-storage/blob/main/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobWriteChannel.java">
  * BlobWriteChannel</a>.
  *
+ * <p>The GCS Java client library includes support to GCS via gRPC.
+ * When using GCS from Google Compute Engine (GCE) this library enable higher
+ * total throughput across large workloads that run on hundreds or thousands of
+ * VMs.</p>
+ *
+ * <p>At present, GCS gRPC is GA with Allowlist. To access this API,
+ *   kindly contact the Google Cloud Storage gRPC team at
+ *   gcs-grpc-contact@google.com with a list of GCS buckets you would like to
+ *   Allowlist. Please note that while the **service** is GA (with Allowlist),
+ *   the client library features remain experimental and subject to change
+ *   without notice. The methods to create, list, query, and delete HMAC keys and notifications
+ *   are unavailable in gRPC transport.</p>
+ *
+ * <p>This example shows how to enable gRPC with DirectPath only supported on Google Compute Engine.
+ *
+ * <pre>{@code
+ * StorageOptions options = StorageOptions.grpc().setAttemptDirectPath(true).build();
+ * try (Storage storage = options.getService()) {
+ * BlobId blobId = BlobId.of("bucket", "blob_name");
+ * Blob blob = storage.get(blobId);
+ * if (blob != null) {
+ *   byte[] prevContent = blob.getContent();
+ *   System.out.println(new String(prevContent, UTF_8));
+ *   WritableByteChannel channel = blob.writer();
+ *   channel.write(ByteBuffer.wrap("Updated content".getBytes(UTF_8)));
+ *   channel.close();
+ * }
+ * }
+ * }</pre>
+ *
+ * <p>This example shows how to enable gRPC without DirectPath.
+ *
+ * <pre>{@code
+ * StorageOptions options = StorageOptions.grpc().build();
+ * try (Storage storage = options.getService()) {
+ * BlobId blobId = BlobId.of("bucket", "blob_name");
+ * Blob blob = storage.get(blobId);
+ * if (blob != null) {
+ *   byte[] prevContent = blob.getContent();
+ *   System.out.println(new String(prevContent, UTF_8));
+ *   WritableByteChannel channel = blob.writer();
+ *   channel.write(ByteBuffer.wrap("Updated content".getBytes(UTF_8)));
+ *   channel.close();
+ * }
+ * }
+ * }</pre>
+ *
  * @see <a href="https://cloud.google.com/storage/">Google Cloud Storage</a>
  */
 package com.google.cloud.storage;

--- a/samples/snippets/src/main/java/com/example/storage/QuickstartGrpcDpSample.java
+++ b/samples/snippets/src/main/java/com/example/storage/QuickstartGrpcDpSample.java
@@ -35,7 +35,7 @@ public class QuickstartGrpcDpSample {
       // The name for the new bucket
       String bucketName = args[0]; // "my-new-bucket";
 
-      // Creates the new bucket using a request to the gRPC API via DirectPath
+      // Creates the new bucket using a request to the gRPC API via Direct Google Access
       Bucket bucket = storage.create(BucketInfo.of(bucketName));
 
       System.out.printf("Bucket %s created.%n", bucket.getName());


### PR DESCRIPTION
Update google-cloud-storage package-info to include information on gRPC API in java-storage per product team request.

Borrowed some from: https://github.com/googleapis/google-cloud-cpp/pull/13688


