### PR TITLE
docs: Add summary and reference docs for Storage Control API to readme

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -1,4 +1,10 @@
 custom_content: |
+  ## About Storage Control
+  
+  The [Storage Control API][storage-control-reference] lets you perform metadata-specific, control plane, and long-running operations.
+  
+  The Storage Control API creates one space to perform metadata-specific, control plane, and long-running operations apart from the Storage API. Separating these operations from the Storage API improves API standardization and lets you run faster releases.
+  
   #### Creating an authorized service object
 
   To make authenticated requests to Google Cloud Storage, you must create a service object with credentials. You can

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -117,7 +117,6 @@ custom_content: |
     - This app uses `google-cloud` to interface with Cloud Datastore and Cloud Storage. It also uses Cloud SQL, another Google Cloud Platform service.
   - [`Flexible Environment/Storage example`](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/main/flexible/cloudstorage) - An app that uploads files to a public Cloud Storage bucket on the App Engine Flexible Environment runtime.
 
-
 versioning: |
   This library follows [Semantic Versioning](http://semver.org/), but does update [Storage interface](src/main/java/com.google.cloud.storage/Storage.java)
   to introduce new methods which can break your implementations if you implement this interface for testing purposes.

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -1,7 +1,7 @@
 custom_content: |
   ## About Storage Control
   
-  The [Storage Control API][storage-control-reference] lets you perform metadata-specific, control plane, and long-running operations.
+  The [Storage Control API](https://cloud.google.com/storage/docs/reference/rpc/) lets you perform metadata-specific, control plane, and long-running operations.
   
   The Storage Control API creates one space to perform metadata-specific, control plane, and long-running operations apart from the Storage API. Separating these operations from the Storage API improves API standardization and lets you run faster releases.
   
@@ -116,6 +116,7 @@ custom_content: |
   - [`Bookshelf`](https://github.com/GoogleCloudPlatform/getting-started-java/tree/main/bookshelf) - An App Engine application that manages a virtual bookshelf.
     - This app uses `google-cloud` to interface with Cloud Datastore and Cloud Storage. It also uses Cloud SQL, another Google Cloud Platform service.
   - [`Flexible Environment/Storage example`](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/main/flexible/cloudstorage) - An app that uploads files to a public Cloud Storage bucket on the App Engine Flexible Environment runtime.
+
 
 versioning: |
   This library follows [Semantic Versioning](http://semver.org/), but does update [Storage interface](src/main/java/com.google.cloud.storage/Storage.java)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Java idiomatic client for [Cloud Storage][product-docs].
 - [Client Library Documentation][javadocs]
 
 
+
 ## Quickstart
 
 If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
@@ -97,6 +98,13 @@ to add `google-cloud-storage` as a dependency in your code.
 
 See the [Cloud Storage client library docs][javadocs] to learn how to
 use this Cloud Storage Client Library.
+
+## About Storage Control
+
+The [Storage Control API][storage-control-reference] lets you perform metadata-specific, control plane, and long-running operations.
+
+The Storage Control API creates one space to perform metadata-specific, control plane, and long-running operations apart from the Storage API. Separating these operations from the Storage API improves API standardization and lets you run faster releases.
+
 
 
 #### Creating an authorized service object
@@ -418,6 +426,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 
 [product-docs]: https://cloud.google.com/storage
 [javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-storage/latest/history
+[storage-control-reference] https://cloud.google.com/storage/docs/reference/rpc/
 [kokoro-badge-image-1]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java7.svg
 [kokoro-badge-link-1]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java7.html
 [kokoro-badge-image-2]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java8.svg

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Java idiomatic client for [Cloud Storage][product-docs].
 - [Client Library Documentation][javadocs]
 
 
-
 ## Quickstart
 
 If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
@@ -99,13 +98,12 @@ to add `google-cloud-storage` as a dependency in your code.
 See the [Cloud Storage client library docs][javadocs] to learn how to
 use this Cloud Storage Client Library.
 
+
 ## About Storage Control
 
-The [Storage Control API][storage-control-reference] lets you perform metadata-specific, control plane, and long-running operations.
+The [Storage Control API](https://cloud.google.com/storage/docs/reference/rpc/) lets you perform metadata-specific, control plane, and long-running operations.
 
 The Storage Control API creates one space to perform metadata-specific, control plane, and long-running operations apart from the Storage API. Separating these operations from the Storage API improves API standardization and lets you run faster releases.
-
-
 
 #### Creating an authorized service object
 
@@ -426,7 +424,6 @@ Java is a registered trademark of Oracle and/or its affiliates.
 
 [product-docs]: https://cloud.google.com/storage
 [javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-storage/latest/history
-[storage-control-reference] https://cloud.google.com/storage/docs/reference/rpc/
 [kokoro-badge-image-1]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java7.svg
 [kokoro-badge-link-1]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java7.html
 [kokoro-badge-image-2]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java8.svg


### PR DESCRIPTION
We will need to add in additional reference once the quickstart is finished.
