### PR TITLE
feat: Transfer Manager ParallelCompositeUploads

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/DefaultQos.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/DefaultQos.java
@@ -19,9 +19,13 @@ package com.google.cloud.storage.transfermanager;
 final class DefaultQos implements Qos {
 
   private final long divideAndConquerThreshold;
+  private final long parallelCompositeUploadThreshold;
+  private boolean threadThresholdMet;
 
-  private DefaultQos(long divideAndConquerThreshold) {
+  private DefaultQos(long divideAndConquerThreshold, long parallelCompositeUploadThreshold, boolean threadThresholdMet) {
     this.divideAndConquerThreshold = divideAndConquerThreshold;
+    this.parallelCompositeUploadThreshold = parallelCompositeUploadThreshold;
+    this.threadThresholdMet = threadThresholdMet;
   }
 
   @Override
@@ -29,11 +33,18 @@ final class DefaultQos implements Qos {
     return objectSize > divideAndConquerThreshold;
   }
 
-  static DefaultQos of() {
-    return of(128L * 1024 * 1024);
+  @Override
+  public boolean parallelCompositeUpload(long objectSize) {
+    return threadThresholdMet && objectSize > parallelCompositeUploadThreshold;
   }
 
-  static DefaultQos of(long divideAndConquerThreshold) {
-    return new DefaultQos(divideAndConquerThreshold);
+  static DefaultQos of(long divideAndConquerThreshold, long parallelCompositeUploadThreshold, boolean threadThresholdMet) {
+    return of(divideAndConquerThreshold, parallelCompositeUploadThreshold, threadThresholdMet);
+  }
+
+  static DefaultQos of(TransferManagerConfig config) {
+    return new DefaultQos(128L * 1024 * 1024,
+        4L * config.getPerWorkerBufferSize(),
+        config.getMaxWorkers() > 2);
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/DefaultQos.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/DefaultQos.java
@@ -22,7 +22,10 @@ final class DefaultQos implements Qos {
   private final long parallelCompositeUploadThreshold;
   private boolean threadThresholdMet;
 
-  private DefaultQos(long divideAndConquerThreshold, long parallelCompositeUploadThreshold, boolean threadThresholdMet) {
+  private DefaultQos(
+      long divideAndConquerThreshold,
+      long parallelCompositeUploadThreshold,
+      boolean threadThresholdMet) {
     this.divideAndConquerThreshold = divideAndConquerThreshold;
     this.parallelCompositeUploadThreshold = parallelCompositeUploadThreshold;
     this.threadThresholdMet = threadThresholdMet;
@@ -38,13 +41,15 @@ final class DefaultQos implements Qos {
     return threadThresholdMet && objectSize > parallelCompositeUploadThreshold;
   }
 
-  static DefaultQos of(long divideAndConquerThreshold, long parallelCompositeUploadThreshold, boolean threadThresholdMet) {
+  static DefaultQos of(
+      long divideAndConquerThreshold,
+      long parallelCompositeUploadThreshold,
+      boolean threadThresholdMet) {
     return of(divideAndConquerThreshold, parallelCompositeUploadThreshold, threadThresholdMet);
   }
 
   static DefaultQos of(TransferManagerConfig config) {
-    return new DefaultQos(128L * 1024 * 1024,
-        4L * config.getPerWorkerBufferSize(),
-        config.getMaxWorkers() > 2);
+    return new DefaultQos(
+        128L * 1024 * 1024, 4L * config.getPerWorkerBufferSize(), config.getMaxWorkers() > 2);
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/DefaultQos.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/DefaultQos.java
@@ -41,13 +41,6 @@ final class DefaultQos implements Qos {
     return threadThresholdMet && objectSize > parallelCompositeUploadThreshold;
   }
 
-  static DefaultQos of(
-      long divideAndConquerThreshold,
-      long parallelCompositeUploadThreshold,
-      boolean threadThresholdMet) {
-    return of(divideAndConquerThreshold, parallelCompositeUploadThreshold, threadThresholdMet);
-  }
-
   static DefaultQos of(TransferManagerConfig config) {
     return new DefaultQos(
         128L * 1024 * 1024, 4L * config.getPerWorkerBufferSize(), config.getMaxWorkers() > 2);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/ParallelCompositeUploadCallable.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/ParallelCompositeUploadCallable.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.google.cloud.storage.transfermanager;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.SettableApiFuture;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.BlobWriteSession;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobWriteOption;
+import com.google.cloud.storage.StorageException;
+import com.google.common.io.ByteStreams;
+import java.nio.channels.FileChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+final class ParallelCompositeUploadCallable implements Callable<UploadResult> {
+  private final Storage storage;
+
+  private final BlobInfo originalBlob;
+
+  private final Path sourceFile;
+
+  private final ParallelUploadConfig parallelUploadConfig;
+
+  private final Storage.BlobWriteOption[] opts;
+
+  private final SettableApiFuture<UploadResult> result;
+
+  public ParallelCompositeUploadCallable(
+      Storage storage,
+      BlobInfo originalBlob,
+      Path sourceFile,
+      ParallelUploadConfig parallelUploadConfig,
+      BlobWriteOption[] opts) {
+    this.storage = storage;
+    this.originalBlob = originalBlob;
+    this.sourceFile = sourceFile;
+    this.parallelUploadConfig = parallelUploadConfig;
+    this.opts = opts;
+    this.result = SettableApiFuture.create();
+  }
+
+  public ApiFuture<UploadResult> getResult() {
+    return result;
+  }
+
+  public UploadResult call() throws ExecutionException, InterruptedException {
+    try {
+      UploadResult uploadResult = uploadPCU();
+      result.set(uploadResult);
+      return uploadResult;
+    } catch (Exception e) {
+      result.setException(e);
+      throw e;
+    }
+  }
+
+  private UploadResult uploadPCU() throws ExecutionException, InterruptedException {
+    BlobWriteSession session = storage.blobWriteSession(originalBlob, opts);
+    try (WritableByteChannel writableByteChannel = session.open();
+        FileChannel fc = FileChannel.open(sourceFile, StandardOpenOption.READ)) {
+      ByteStreams.copy(fc, writableByteChannel);
+    } catch (StorageException e) {
+      if (parallelUploadConfig.isSkipIfExists() && e.getCode() == 412) {
+        return UploadResult.newBuilder(originalBlob, TransferStatus.SKIPPED)
+            .setException(e)
+            .build();
+      } else {
+        return UploadResult.newBuilder(originalBlob, TransferStatus.FAILED_TO_FINISH)
+            .setException(e)
+            .build();
+      }
+    } catch (Exception e) {
+      return UploadResult.newBuilder(originalBlob, TransferStatus.FAILED_TO_FINISH)
+          .setException(e)
+          .build();
+    }
+    BlobInfo newBlob = session.getResult().get();
+    return UploadResult
+        .newBuilder(originalBlob, TransferStatus.SUCCESS)
+        .setUploadedBlob(newBlob)
+        .build();
+  }
+}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/ParallelCompositeUploadCallable.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/ParallelCompositeUploadCallable.java
@@ -5,16 +5,14 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.google.cloud.storage.transfermanager;
 
 import com.google.api.core.ApiFuture;
@@ -31,8 +29,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 final class ParallelCompositeUploadCallable implements Callable<UploadResult> {
   private final Storage storage;
@@ -97,8 +93,7 @@ final class ParallelCompositeUploadCallable implements Callable<UploadResult> {
           .build();
     }
     BlobInfo newBlob = session.getResult().get();
-    return UploadResult
-        .newBuilder(originalBlob, TransferStatus.SUCCESS)
+    return UploadResult.newBuilder(originalBlob, TransferStatus.SUCCESS)
         .setUploadedBlob(newBlob)
         .build();
   }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/Qos.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/Qos.java
@@ -19,4 +19,6 @@ package com.google.cloud.storage.transfermanager;
 interface Qos {
 
   boolean divideAndConquer(long objectSize);
+
+  boolean parallelCompositeUpload(long objectSize);
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManager.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManager.java
@@ -18,6 +18,7 @@ package com.google.cloud.storage.transfermanager;
 
 import com.google.api.core.BetaApi;
 import com.google.cloud.storage.BlobInfo;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -58,7 +59,7 @@ public interface TransferManager extends AutoCloseable {
    */
   @BetaApi
   @NonNull
-  UploadJob uploadFiles(List<Path> files, ParallelUploadConfig config);
+  UploadJob uploadFiles(List<Path> files, ParallelUploadConfig config) throws IOException;
 
   /**
    * Downloads a list of blobs in parallel. This operation will not block the invoking thread,

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerConfig.java
@@ -102,11 +102,8 @@ public final class TransferManagerConfig {
   /** The service object for {@link TransferManager} */
   @BetaApi
   public TransferManager getService() {
-    return new TransferManagerImpl(this,
-        DefaultQos.of(this));
+    return new TransferManagerImpl(this, DefaultQos.of(this));
   }
-
-
 
   @BetaApi
   public Builder toBuilder() {
@@ -117,7 +114,6 @@ public final class TransferManagerConfig {
         .setPerWorkerBufferSize(perWorkerBufferSize)
         .setStorageOptions(storageOptions);
   }
-
 
   @Override
   public boolean equals(Object o) {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerConfig.java
@@ -83,6 +83,18 @@ public final class TransferManagerConfig {
    * chunking will be beneficial
    *
    * @see Builder#setAllowParallelCompositeUpload(boolean)
+   *
+   * Note:
+   * Performing parallel composite uploads costs more money.
+   * <a href="https://cloud.google.com/storage/pricing#operations-by-class">Class A</a>
+   * operations are performed to create each part and to perform each compose. If a storage
+   * tier other than
+   *<a href="https://cloud.google.com/storage/docs/storage-classes"><code>STANDARD</code></a>
+   * is used, early deletion fees apply to deletion of the parts.
+   *
+   * Please see the <a href="https://cloud.google.com/storage/docs/parallel-composite-uploads">
+   * Parallel composite uploads</a> documentation for a more in depth explanation of the
+   * limitations of Parallel composite uploads.
    */
   @BetaApi
   public boolean isAllowParallelCompositeUpload() {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerConfig.java
@@ -83,18 +83,15 @@ public final class TransferManagerConfig {
    * chunking will be beneficial
    *
    * @see Builder#setAllowParallelCompositeUpload(boolean)
-   *
-   * Note:
-   * Performing parallel composite uploads costs more money.
-   * <a href="https://cloud.google.com/storage/pricing#operations-by-class">Class A</a>
-   * operations are performed to create each part and to perform each compose. If a storage
-   * tier other than
-   *<a href="https://cloud.google.com/storage/docs/storage-classes"><code>STANDARD</code></a>
-   * is used, early deletion fees apply to deletion of the parts.
-   *
-   * Please see the <a href="https://cloud.google.com/storage/docs/parallel-composite-uploads">
-   * Parallel composite uploads</a> documentation for a more in depth explanation of the
-   * limitations of Parallel composite uploads.
+   *     <p>Note: Performing parallel composite uploads costs more money. <a
+   *     href="https://cloud.google.com/storage/pricing#operations-by-class">Class A</a> operations
+   *     are performed to create each part and to perform each compose. If a storage tier other than
+   *     <a href="https://cloud.google.com/storage/docs/storage-classes"><code>STANDARD</code></a>
+   *     is used, early deletion fees apply to deletion of the parts.
+   *     <p>Please see the <a
+   *     href="https://cloud.google.com/storage/docs/parallel-composite-uploads">Parallel composite
+   *     uploads</a> documentation for a more in depth explanation of the limitations of Parallel
+   *     composite uploads.
    */
   @BetaApi
   public boolean isAllowParallelCompositeUpload() {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerConfig.java
@@ -34,21 +34,18 @@ public final class TransferManagerConfig {
   private final boolean allowParallelCompositeUpload;
 
   private final StorageOptions storageOptions;
-  private final Qos qos;
 
   TransferManagerConfig(
       int maxWorkers,
       int perWorkerBufferSize,
       boolean allowDivideAndConquerDownload,
       boolean allowParallelCompositeUpload,
-      StorageOptions storageOptions,
-      Qos qos) {
+      StorageOptions storageOptions) {
     this.maxWorkers = maxWorkers;
     this.perWorkerBufferSize = perWorkerBufferSize;
     this.allowDivideAndConquerDownload = allowDivideAndConquerDownload;
     this.allowParallelCompositeUpload = allowParallelCompositeUpload;
     this.storageOptions = storageOptions;
-    this.qos = qos;
   }
 
   /**
@@ -105,8 +102,11 @@ public final class TransferManagerConfig {
   /** The service object for {@link TransferManager} */
   @BetaApi
   public TransferManager getService() {
-    return new TransferManagerImpl(this);
+    return new TransferManagerImpl(this,
+        DefaultQos.of(this));
   }
+
+
 
   @BetaApi
   public Builder toBuilder() {
@@ -115,13 +115,9 @@ public final class TransferManagerConfig {
         .setAllowParallelCompositeUpload(allowParallelCompositeUpload)
         .setMaxWorkers(maxWorkers)
         .setPerWorkerBufferSize(perWorkerBufferSize)
-        .setQos(qos)
         .setStorageOptions(storageOptions);
   }
 
-  Qos getQos() {
-    return qos;
-  }
 
   @Override
   public boolean equals(Object o) {
@@ -179,7 +175,6 @@ public final class TransferManagerConfig {
     private boolean allowParallelCompositeUpload;
 
     private StorageOptions storageOptions;
-    private Qos qos;
 
     private Builder() {
       this.perWorkerBufferSize = 16 * 1024 * 1024;
@@ -187,7 +182,6 @@ public final class TransferManagerConfig {
       this.allowDivideAndConquerDownload = false;
       this.allowParallelCompositeUpload = false;
       this.storageOptions = StorageOptions.getDefaultInstance();
-      this.qos = DefaultQos.of();
     }
 
     /**
@@ -244,8 +238,8 @@ public final class TransferManagerConfig {
      * @see TransferManagerConfig#isAllowDivideAndConquerDownload()
      */
     @BetaApi
-    public Builder setAllowParallelCompositeUpload(boolean allowDivideAndConquerDownload) {
-      this.allowDivideAndConquerDownload = allowDivideAndConquerDownload;
+    public Builder setAllowParallelCompositeUpload(boolean allowParallelCompositeUpload) {
+      this.allowParallelCompositeUpload = allowParallelCompositeUpload;
       return this;
     }
 
@@ -263,12 +257,6 @@ public final class TransferManagerConfig {
       return this;
     }
 
-    @BetaApi
-    Builder setQos(Qos qos) {
-      this.qos = qos;
-      return this;
-    }
-
     /**
      * Creates a TransferManagerConfig object.
      *
@@ -281,8 +269,7 @@ public final class TransferManagerConfig {
           perWorkerBufferSize,
           allowDivideAndConquerDownload,
           allowParallelCompositeUpload,
-          storageOptions,
-          qos);
+          storageOptions);
     }
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerImpl.java
@@ -263,8 +263,9 @@ final class TransferManagerImpl implements TransferManager {
    * all the threads waiting for PCU uploads to complete, the PCU work doesn't have any threads
    * available to itself.
    *
-   * This class represents a single worker that will be submitted to the executor service and will
-   * poll a queue to process a single PCU at a time, leaving any other threads free for PCU work.
+   * <p>This class represents a single worker that will be submitted to the executor service and
+   * will poll a queue to process a single PCU at a time, leaving any other threads free for PCU
+   * work.
    */
   private final class PcuPoller implements Runnable {
 
@@ -288,8 +289,8 @@ final class TransferManagerImpl implements TransferManager {
     private final ParallelCompositeUploadCallable callable;
     private final SettableApiFuture<UploadResult> resultFuture;
 
-    private PendingPcuTask(ParallelCompositeUploadCallable callable,
-        SettableApiFuture<UploadResult> resultFuture) {
+    private PendingPcuTask(
+        ParallelCompositeUploadCallable callable, SettableApiFuture<UploadResult> resultFuture) {
       this.callable = callable;
       this.resultFuture = resultFuture;
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerImpl.java
@@ -38,10 +38,10 @@ import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BinaryOperator;
@@ -86,7 +86,7 @@ final class TransferManagerImpl implements TransferManager {
               .withExecutorSupplier(ExecutorSupplier.useExecutor(executor));
       storageOptions = storageOptions.toBuilder().setBlobWriteSessionConfig(pcuConfig).build();
     }
-    pcuQueue = new ArrayDeque<>();
+    this.pcuQueue = new ConcurrentLinkedDeque<>();
     this.storage = storageOptions.getService();
   }
 
@@ -113,7 +113,7 @@ final class TransferManagerImpl implements TransferManager {
         ParallelCompositeUploadCallable callable =
             new ParallelCompositeUploadCallable(storage, blobInfo, file, config, opts);
         SettableApiFuture<UploadResult> resultFuture = SettableApiFuture.create();
-        pcuQueue.push(new PendingPcuTask(callable, resultFuture));
+        pcuQueue.add(new PendingPcuTask(callable, resultFuture));
         uploadTasks.add(resultFuture);
         schedulePcuPoller();
       } else {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerImpl.java
@@ -25,8 +25,6 @@ import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.BlobWriteSessionConfigs;
-import com.google.cloud.storage.GrpcStorageOptions;
-import com.google.cloud.storage.HttpStorageOptions;
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig;
 import com.google.cloud.storage.ParallelCompositeUploadBlobWriteSessionConfig.ExecutorSupplier;
 import com.google.cloud.storage.Storage;
@@ -82,23 +80,11 @@ final class TransferManagerImpl implements TransferManager {
               .build();
     }
     // Create the blobWriteSessionConfig for ParallelCompositeUpload
-    ParallelCompositeUploadBlobWriteSessionConfig pcuConfig =
-        BlobWriteSessionConfigs.parallelCompositeUpload()
-            .withExecutorSupplier(ExecutorSupplier.useExecutor(executor));
-    if (storageOptions instanceof GrpcStorageOptions
-        && transferManagerConfig.isAllowParallelCompositeUpload()) {
-      storageOptions =
-          ((GrpcStorageOptions) storageOptions)
-              .toBuilder()
-              .setBlobWriteSessionConfig(pcuConfig)
-              .build();
-    } else if (storageOptions instanceof HttpStorageOptions
-        && transferManagerConfig.isAllowParallelCompositeUpload()) {
-      storageOptions =
-          ((HttpStorageOptions) storageOptions)
-              .toBuilder()
-              .setBlobWriteSessionConfig(pcuConfig)
-              .build();
+    if (transferManagerConfig.isAllowParallelCompositeUpload()) {
+      ParallelCompositeUploadBlobWriteSessionConfig pcuConfig =
+          BlobWriteSessionConfigs.parallelCompositeUpload()
+              .withExecutorSupplier(ExecutorSupplier.useExecutor(executor));
+      storageOptions = storageOptions.toBuilder().setBlobWriteSessionConfig(pcuConfig).build();
     }
     pcuQueue = new ArrayDeque<>();
     this.storage = storageOptions.getService();

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
@@ -57,6 +57,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.xml.crypto.Data;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -73,6 +74,8 @@ public class ITTransferManagerTest {
       Comparator.comparing(info -> info.getBlobId().getName());
   private static final Comparator<DownloadResult> comp2 =
       Comparator.comparing(DownloadResult::getInput, comp);
+
+  private static final long CHUNK_THRESHOLD = 2L * 1024 * 1024;
 
   @Inject public Storage storage;
   @Inject public BucketInfo bucket;
@@ -106,8 +109,8 @@ public class ITTransferManagerTest {
         writeChannel.write(content);
       }
     }
-    long size = 2L * 1024 * 1024;
-    size = size + 100L;
+    // We make this size just a bit bigger than the threshold.
+    long size = CHUNK_THRESHOLD + 100L;
     ByteBuffer chunkedContent = DataGenerator.base64Characters().genByteBuffer(size);
     try (WriteChannel writeChannel = storage.writer(blobInfoChunking)) {
       writeChannel.write(chunkedContent);
@@ -340,6 +343,55 @@ public class ITTransferManagerTest {
       }
     }
   }
+
+  @Test
+  public void uploadFilesAllowPCU() throws Exception {
+    TransferManagerConfig config =
+        TransferManagerConfigTestingInstances.defaults(storage.getOptions())
+            .toBuilder()
+            .setAllowParallelCompositeUpload(true)
+            .setPerWorkerBufferSize(128 * 1024)
+            .build();
+    long size = CHUNK_THRESHOLD + 100L;
+    try (TransferManager transferManager = config.getService();
+        TmpFile tmpFile = DataGenerator.base64Characters().tempFile(baseDir, size)) {
+      ParallelUploadConfig parallelUploadConfig =
+          ParallelUploadConfig.newBuilder().setBucketName(bucket.getName()).build();
+      UploadJob job = transferManager.uploadFiles(
+              Collections.singletonList(tmpFile.getPath()), parallelUploadConfig);
+      List<UploadResult> uploadResults = job.getUploadResults();
+      assertThat(uploadResults.get(0).getStatus()).isEqualTo(TransferStatus.SUCCESS);
+    }
+  }
+
+  @Test
+  public void uploadFilesAllowMultiplePCUAndSmallerFiles() throws Exception {
+    TransferManagerConfig config =
+        TransferManagerConfigTestingInstances.defaults(storage.getOptions())
+            .toBuilder()
+            .setAllowParallelCompositeUpload(true)
+            .setPerWorkerBufferSize(128 * 1024)
+            .build();
+    long largeFileSize = CHUNK_THRESHOLD + 100L;
+    long smallFileSize = CHUNK_THRESHOLD - 100L;
+    try (TransferManager transferManager = config.getService();
+        TmpFile tmpFile = DataGenerator.base64Characters().tempFile(baseDir, largeFileSize);
+        TmpFile tmpfile2 = DataGenerator.base64Characters().tempFile(baseDir, largeFileSize);
+        TmpFile tmpFile3 = DataGenerator.base64Characters().tempFile(baseDir, smallFileSize)) {
+      ParallelUploadConfig parallelUploadConfig =
+          ParallelUploadConfig.newBuilder().setBucketName(bucket.getName()).build();
+      List<Path> files = ImmutableList.of(tmpFile.getPath(), tmpfile2.getPath(), tmpFile3.getPath());
+      UploadJob job = transferManager.uploadFiles(files, parallelUploadConfig);
+      List<UploadResult> uploadResults = job.getUploadResults();
+      assertThat(uploadResults).hasSize(3);
+      assertThat(
+          uploadResults.stream()
+              .filter(result -> result.getStatus() == TransferStatus.SUCCESS)
+              .collect(Collectors.toList()))
+          .hasSize(3);
+    }
+  }
+
 
   @Test
   public void downloadNonexistentBucket() throws Exception {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
@@ -57,7 +57,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.xml.crypto.Data;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -357,7 +356,8 @@ public class ITTransferManagerTest {
         TmpFile tmpFile = DataGenerator.base64Characters().tempFile(baseDir, size)) {
       ParallelUploadConfig parallelUploadConfig =
           ParallelUploadConfig.newBuilder().setBucketName(bucket.getName()).build();
-      UploadJob job = transferManager.uploadFiles(
+      UploadJob job =
+          transferManager.uploadFiles(
               Collections.singletonList(tmpFile.getPath()), parallelUploadConfig);
       List<UploadResult> uploadResults = job.getUploadResults();
       assertThat(uploadResults.get(0).getStatus()).isEqualTo(TransferStatus.SUCCESS);
@@ -380,18 +380,18 @@ public class ITTransferManagerTest {
         TmpFile tmpFile3 = DataGenerator.base64Characters().tempFile(baseDir, smallFileSize)) {
       ParallelUploadConfig parallelUploadConfig =
           ParallelUploadConfig.newBuilder().setBucketName(bucket.getName()).build();
-      List<Path> files = ImmutableList.of(tmpFile.getPath(), tmpfile2.getPath(), tmpFile3.getPath());
+      List<Path> files =
+          ImmutableList.of(tmpFile.getPath(), tmpfile2.getPath(), tmpFile3.getPath());
       UploadJob job = transferManager.uploadFiles(files, parallelUploadConfig);
       List<UploadResult> uploadResults = job.getUploadResults();
       assertThat(uploadResults).hasSize(3);
       assertThat(
-          uploadResults.stream()
-              .filter(result -> result.getStatus() == TransferStatus.SUCCESS)
-              .collect(Collectors.toList()))
+              uploadResults.stream()
+                  .filter(result -> result.getStatus() == TransferStatus.SUCCESS)
+                  .collect(Collectors.toList()))
           .hasSize(3);
     }
   }
-
 
   @Test
   public void downloadNonexistentBucket() throws Exception {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/transfermanager/TransferManagerConfigTestingInstances.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/transfermanager/TransferManagerConfigTestingInstances.java
@@ -28,9 +28,8 @@ public final class TransferManagerConfigTestingInstances {
   public static TransferManagerConfig defaults(StorageOptions options) {
     return TransferManagerConfig.newBuilder()
         .setAllowDivideAndConquerDownload(false)
-        .setMaxWorkers(1)
+        .setMaxWorkers(5)
         .setPerWorkerBufferSize(512 * 1024)
-        .setQos(DefaultQos.of(2 * 1024 * 1024))
         .setStorageOptions(options)
         .build();
   }


### PR DESCRIPTION
This implements ParallelCompositeUploads(PCU) in Transfer Manager.

ParallelCompositeUpload in Transfer Manager is an opt-in feature, customers will have to update their config to allow Transfer Manager to perform PCU operations on their behalf. Transfer Manager will only do this if the following conditions are met: 

- The customer has set allowParallelCompositeUpload to true
- The file to be uploaded is 4 * the buffer per worker size
- The customer has specified enough threads that ParallelCompositeUpload can be of benefit while still cuing other work.


