### PR TITLE
fix: update grpc handling of IAM Policy etag to account for base64 encoding

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcRetryAlgorithmManager.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcRetryAlgorithmManager.java
@@ -20,6 +20,7 @@ import com.google.api.gax.retrying.ResultRetryAlgorithm;
 import com.google.iam.v1.GetIamPolicyRequest;
 import com.google.iam.v1.SetIamPolicyRequest;
 import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.protobuf.ByteString;
 import com.google.storage.v2.BidiWriteObjectRequest;
 import com.google.storage.v2.ComposeObjectRequest;
 import com.google.storage.v2.CreateBucketRequest;
@@ -168,8 +169,11 @@ final class GrpcRetryAlgorithmManager implements Serializable {
   }
 
   public ResultRetryAlgorithm<?> getFor(SetIamPolicyRequest req) {
-    // TODO: etag
-    return retryStrategy.getNonidempotentHandler();
+    if (req.getPolicy().getEtag().equals(ByteString.empty())) {
+      return retryStrategy.getNonidempotentHandler();
+    } else {
+      return retryStrategy.getIdempotentHandler();
+    }
   }
 
   public ResultRetryAlgorithm<?> getFor(StartResumableWriteRequest req) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/CtxFunctions.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/CtxFunctions.java
@@ -136,6 +136,10 @@ final class CtxFunctions {
   static final class Rpc {
     static final CtxFunction createEmptyBlob =
         (ctx, c) -> ctx.map(state -> state.with(ctx.getStorage().create(state.getBlobInfo())));
+    static final CtxFunction bucketIamPolicy =
+        (ctx, c) ->
+            ctx.map(
+                state -> state.with(ctx.getStorage().getIamPolicy(state.getBucket().getName())));
   }
 
   static final class ResourceSetup {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
@@ -19,7 +19,6 @@ package com.google.cloud.storage.conformance.retry;
 import static com.google.cloud.storage.PackagePrivateMethodWorkarounds.blobCopyWithStorage;
 import static com.google.cloud.storage.PackagePrivateMethodWorkarounds.bucketCopyWithStorage;
 import static com.google.cloud.storage.conformance.retry.Ctx.ctx;
-import static com.google.cloud.storage.conformance.retry.ITRetryConformanceTest.RetryTestCaseResolver.lift;
 import static com.google.cloud.storage.conformance.retry.State.empty;
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.Objects.requireNonNull;
@@ -168,12 +167,7 @@ public class ITRetryConformanceTest {
               .setMappings(new RpcMethodMappings())
               .setProjectId("conformance-tests")
               .setHost(testBench.getBaseUri().replaceAll("https?://", ""))
-              .setTestAllowFilter(
-                  RetryTestCaseResolver.includeAll()
-                      .and(
-                          (lift(trc -> trc.getTransport() == Transport.GRPC)
-                                  .and((m, trc) -> m == RpcMethod.storage.buckets.setIamPolicy))
-                              .negate()))
+              .setTestAllowFilter(RetryTestCaseResolver.includeAll())
               .build();
 
       List<RetryTestCase> retryTestCases;

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
@@ -685,6 +685,7 @@ final class RpcMethodMappings {
         a.add(
             RpcMethodMapping.newBuilder(240, buckets.setIamPolicy)
                 .withApplicable(TestRetryConformance::isPreconditionsProvided)
+                .withSetup(ResourceSetup.defaultSetup.andThen(Rpc.bucketIamPolicy))
                 .withTest(
                     (ctx, c) ->
                         ctx.map(
@@ -694,7 +695,7 @@ final class RpcMethodMappings {
                                         .setIamPolicy(
                                             state.getBucket().getName(),
                                             Policy.newBuilder()
-                                                .setEtag("h??")
+                                                .setEtag(state.getPolicy().getEtag())
                                                 .setVersion(3)
                                                 .setBindings(
                                                     ImmutableList.of(


### PR DESCRIPTION
Etags returned by the JSON api are base64 encoded, and IAM Policy is currently modeled around this for its public api. Update GrpcConversions to base64 decode/encode appropriately.
