### PR TITLE
chore: improve efficiency of computing total number of bytes in Buffer#totalRemaining

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Buffers.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Buffers.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
-import java.util.Arrays;
 import java.util.function.Consumer;
 
 /**
@@ -162,7 +161,11 @@ final class Buffers {
   }
 
   static long totalRemaining(ByteBuffer[] buffers, int offset, int length) {
-    ByteBuffer[] sub = Arrays.copyOfRange(buffers, offset, length);
-    return Arrays.stream(sub).mapToLong(Buffer::remaining).sum();
+    long totalRemaning = 0;
+    for (int i = offset; i < length; i++) {
+      ByteBuffer buffer = buffers[i];
+      totalRemaning += buffer.remaining();
+    }
+    return totalRemaning;
   }
 }


### PR DESCRIPTION

```
Benchmark                                  (bufferCount)  Mode  Cnt   Score   Error  Units
BuffersBenchmark.forLoop                               1  avgt    4   7.914 ± 0.301  ns/op
BuffersBenchmark.forLoop                               2  avgt    4   9.055 ± 0.052  ns/op
BuffersBenchmark.forLoop                               4  avgt    4  12.900 ± 0.032  ns/op
BuffersBenchmark.forLoop                               8  avgt    4  16.079 ± 0.022  ns/op
BuffersBenchmark.forLoop                              16  avgt    4  18.960 ± 0.071  ns/op
BuffersBenchmark.streamBufferRemaning                  1  avgt    4  30.282 ± 0.439  ns/op
BuffersBenchmark.streamBufferRemaning                  2  avgt    4  31.856 ± 0.106  ns/op
BuffersBenchmark.streamBufferRemaning                  4  avgt    4  34.241 ± 1.398  ns/op
BuffersBenchmark.streamBufferRemaning                  8  avgt    4  37.503 ± 1.711  ns/op
BuffersBenchmark.streamBufferRemaning                 16  avgt    4  43.705 ± 0.963  ns/op
```