### PR TITLE
fix: update GzipReadableByteChannel to be tolerant of one byte reads

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GzipReadableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GzipReadableByteChannel.java
@@ -54,9 +54,9 @@ final class GzipReadableByteChannel implements UnbufferedReadableByteChannel {
       // try to determine if the underlying data coming out of `source` is gzip
       byte[] firstByte = new byte[1];
       ByteBuffer wrap = ByteBuffer.wrap(firstByte);
-      // Step 1: initiate a read of the first 4 bytes of the object
+      // Step 1: initiate a read of the first byte of the object
       //   this will have minimal overhead as the messages coming from gcs are inherently windowed
-      //   if the object size is between 5 and 2MiB the remaining bytes will be held in the channel
+      //   if the object size is between 2 and 2MiB the remaining bytes will be held in the channel
       //   for later read.
       source.read(wrap);
       try {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITReadChannelGzipHandlingTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITReadChannelGzipHandlingTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.ReadChannel;
+import com.google.cloud.storage.Storage.BlobSourceOption;
+import com.google.cloud.storage.TransportCompatibility.Transport;
+import com.google.cloud.storage.it.runner.StorageITRunner;
+import com.google.cloud.storage.it.runner.annotations.Backend;
+import com.google.cloud.storage.it.runner.annotations.CrossRun;
+import com.google.cloud.storage.it.runner.annotations.Inject;
+import com.google.cloud.storage.it.runner.registry.ObjectsFixture;
+import com.google.cloud.storage.it.runner.registry.ObjectsFixture.ObjectAndContent;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(StorageITRunner.class)
+@CrossRun(
+    backends = {Backend.PROD},
+    transports = {Transport.HTTP, Transport.GRPC})
+public final class ITReadChannelGzipHandlingTest {
+
+  @Inject public Storage storage;
+  @Inject public ObjectsFixture objFixture;
+
+  @Test
+  public void nonGzipObjectReadOneByteAtATimeNoLibraryBuffering() throws IOException {
+    ObjectAndContent obj512KiB = objFixture.getObj512KiB();
+    BlobInfo info = obj512KiB.getInfo();
+    BlobId blobId = info.getBlobId();
+    byte[] bytes = new byte[1];
+    BlobSourceOption attemptGzipDecompression = BlobSourceOption.shouldReturnRawInputStream(false);
+    try (ReadChannel reader = storage.reader(blobId, attemptGzipDecompression)) {
+      reader.setChunkSize(0);
+
+      // read zero bytes, to trigger things to startup but don't actually pull out any bytes yes
+      reader.read(ByteBuffer.allocate(0));
+
+      byte[] content = obj512KiB.getContent().getBytes();
+      for (int i = 0; i < info.getSize(); i++) {
+        int read = reader.read(ByteBuffer.wrap(bytes));
+        assertThat(read).isEqualTo(1);
+        byte b = bytes[0];
+        assertThat(b).isEqualTo(content[i]);
+      }
+    }
+  }
+}


### PR DESCRIPTION
If the ReadChannel chunkSize is 0 there will be no library buffering performed during read calls. If gzip decompression support is enabled on the read channel, there is a possibility someone could read fewer than the 4 bytes we initially read.

This change updates the byte tracking to ensure single byte reads are supported.

