### PR TITLE
docs: update TransportCompatibility annotation for Storage#blobWriteSession

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
@@ -4825,7 +4825,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
    * @see GrpcStorageOptions.Builder#setBlobWriteSessionConfig(BlobWriteSessionConfig)
    */
   @BetaApi
-  @TransportCompatibility({Transport.GRPC})
+  @TransportCompatibility({Transport.GRPC, Transport.HTTP})
   default BlobWriteSession blobWriteSession(BlobInfo blobInfo, BlobWriteOption... options) {
     return throwGrpcOnly(fmtMethodName("blobWriteSession", BlobInfo.class, BlobWriteOption.class));
   }


### PR DESCRIPTION
HTTP support was added in 2.37.0, but I forgot to update the annotation then.

