### PR TITLE
fix: update grpc WriteObject response handling to provide context when a failure happens

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/AsyncStorageTaskException.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/AsyncStorageTaskException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+/**
+ * This exception is used to preserve the caller's stacktrace when invoking an async task in a sync
+ * context. It will be added as a suppressed exception when propagating the async exception. This
+ * allows callers to catch ApiException thrown in an async operation, while still maintaining the
+ * call site.
+ */
+public final class AsyncStorageTaskException extends RuntimeException {
+  // mimic of com.google.api.gax.rpc.AsyncTaskException which doesn't have a public constructor
+  // if that class is ever made public, make this class extend it
+  AsyncStorageTaskException() {
+    super("Asynchronous task failed");
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ResumableSessionFailureScenarioTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ResumableSessionFailureScenarioTest.java
@@ -16,8 +16,12 @@
 
 package com.google.cloud.storage;
 
+import static com.google.cloud.storage.ByteSizeConstants._256KiB;
+import static com.google.cloud.storage.ByteSizeConstants._512KiB;
+import static com.google.cloud.storage.ResumableSessionFailureScenario.SCENARIO_1;
 import static com.google.cloud.storage.ResumableSessionFailureScenario.isContinue;
 import static com.google.cloud.storage.ResumableSessionFailureScenario.isOk;
+import static com.google.cloud.storage.TestUtils.assertAll;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.client.http.EmptyContent;
@@ -26,8 +30,24 @@ import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.gax.grpc.GrpcCallContext;
+import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.ApiExceptionFactory;
 import com.google.api.services.storage.model.StorageObject;
+import com.google.cloud.storage.it.ChecksummedTestContent;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ByteString;
+import com.google.storage.v2.ChecksummedData;
+import com.google.storage.v2.Object;
+import com.google.storage.v2.ObjectChecksums;
+import com.google.storage.v2.WriteObjectRequest;
+import com.google.storage.v2.WriteObjectResponse;
+import io.grpc.Metadata;
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
+import io.grpc.internal.GrpcUtil;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -156,6 +176,117 @@ public final class ResumableSessionFailureScenarioTest {
 
     assertThat(storageException.getCode()).isEqualTo(0);
     assertThat(storageException).hasMessageThat().contains("|< x-goog-gcs-idempotency-token: 5");
+  }
+
+  @Test
+  public void grpc_response() throws Exception {
+    ChecksummedTestContent content =
+        ChecksummedTestContent.of(DataGenerator.base64Characters().genBytes(_256KiB));
+    WriteObjectRequest req1 =
+        WriteObjectRequest.newBuilder()
+            .setUploadId("uploadId")
+            .setChecksummedData(
+                ChecksummedData.newBuilder()
+                    .setContent(
+                        ByteString.copyFrom(DataGenerator.base64Characters().genBytes(_256KiB)))
+                    .build())
+            .build();
+    WriteObjectRequest req2 =
+        WriteObjectRequest.newBuilder()
+            .setWriteOffset(_256KiB)
+            .setChecksummedData(
+                ChecksummedData.newBuilder()
+                    .setContent(ByteString.copyFrom(content.getBytes()))
+                    .setCrc32C(content.getCrc32c())
+                    .build())
+            .build();
+    WriteObjectRequest req3 =
+        WriteObjectRequest.newBuilder()
+            .setWriteOffset(_512KiB)
+            .setFinishWrite(true)
+            .setObjectChecksums(
+                ObjectChecksums.newBuilder()
+                    .setCrc32C(345)
+                    .setMd5Hash(ByteString.copyFromUtf8("asdf"))
+                    .build())
+            .build();
+    WriteObjectResponse resp1 =
+        WriteObjectResponse.newBuilder()
+            .setResource(Object.newBuilder().setName("obj").setSize(_512KiB).build())
+            .build();
+    GrpcCallContext context =
+        GrpcCallContext.createDefault()
+            .withExtraHeaders(
+                ImmutableMap.of(
+                    "x-goog-request-params",
+                    ImmutableList.of("bucket=projects/_/bucket/bucket-name")));
+    StorageException se =
+        SCENARIO_1.toStorageException(ImmutableList.of(req1, req2, req3), resp1, context, null);
+    assertAll(
+        () ->
+            assertThat(se)
+                .hasMessageThat()
+                .contains("x-goog-request-params: bucket=projects/_/bucket/bucket-name"),
+        () -> assertThat(se).hasMessageThat().contains("upload_id: "),
+        () -> assertThat(se).hasMessageThat().contains("0:262144"),
+        () -> assertThat(se).hasMessageThat().contains(", crc32c: "), // from ChecksummedData
+        () -> assertThat(se).hasMessageThat().contains("write_offset: "),
+        () -> assertThat(se).hasMessageThat().contains("finish_write: "),
+        () -> assertThat(se).hasMessageThat().contains("object_checksums: "),
+        () -> assertThat(se).hasMessageThat().contains("crc32c: "), // from object_checksums
+        () -> assertThat(se).hasMessageThat().contains("md5_hash: "),
+        () -> assertThat(se).hasMessageThat().contains("resource {"));
+  }
+
+  @Test
+  public void grpc_apiException() throws Exception {
+    WriteObjectRequest req1 =
+        WriteObjectRequest.newBuilder()
+            .setUploadId("uploadId")
+            .setChecksummedData(
+                ChecksummedData.newBuilder()
+                    .setContent(
+                        ByteString.copyFrom(DataGenerator.base64Characters().genBytes(_256KiB)))
+                    .build())
+            .build();
+    GrpcCallContext context = Retrying.newCallContext();
+    Code code = Code.FAILED_PRECONDITION;
+    Metadata trailers = new Metadata();
+    trailers.put(GrpcUtil.USER_AGENT_KEY, "test-class/");
+    StatusRuntimeException statusRuntimeException =
+        code.toStatus().withDescription("precondition did not hold").asRuntimeException(trailers);
+    ApiException apiException =
+        ApiExceptionFactory.createException(statusRuntimeException, GrpcStatusCode.of(code), true);
+
+    StorageException se =
+        SCENARIO_1.toStorageException(ImmutableList.of(req1), null, context, apiException);
+    assertAll(
+        () -> assertThat(se).hasMessageThat().contains("upload_id: "),
+        () -> assertThat(se).hasMessageThat().contains("0:262144"),
+        () -> assertThat(se).hasMessageThat().doesNotContain("WriteObjectResponse"),
+        () -> assertThat(se).hasMessageThat().contains("Status{code=FAILED_PRECONDITION"),
+        () -> assertThat(se).hasMessageThat().contains("user-agent=test-class/"));
+  }
+
+  @Test
+  public void grpc_nonApiException() throws Exception {
+    WriteObjectRequest req1 =
+        WriteObjectRequest.newBuilder()
+            .setUploadId("uploadId")
+            .setChecksummedData(
+                ChecksummedData.newBuilder()
+                    .setContent(
+                        ByteString.copyFrom(DataGenerator.base64Characters().genBytes(_256KiB)))
+                    .build())
+            .build();
+    GrpcCallContext context = Retrying.newCallContext();
+    Cause cause = new Cause();
+    StorageException se =
+        SCENARIO_1.toStorageException(ImmutableList.of(req1), null, context, cause);
+    assertAll(
+        () -> assertThat(se).hasMessageThat().contains("upload_id: "),
+        () -> assertThat(se).hasMessageThat().contains("0:262144"),
+        () -> assertThat(se).hasMessageThat().doesNotContain("WriteObjectResponse"));
   }
 
   private static final class Cause extends RuntimeException {


### PR DESCRIPTION
Follow up to #2527 

This updated errors from grpc chunked uploads to have messages that include useful debugging information.

When a response is received but doesn't validate with the expected state: 
```
com.google.cloud.storage.StorageException: Attempt to append to already finalized resumable session.
	|> [
	|> 	com.google.storage.v2.WriteObjectRequest{
	|> 		upload_id: uploadId
	|> 		checksummed_data: {range: [0:262144]}
	|> 	}
	|> ]
	|  
	|< com.google.storage.v2.WriteObjectResponse{
	|< 	resource {
	|< 	  name: "obj"
	|< 	  size: 524288
	|< 	}
	|< }
	|
```

When an error is returned by GCS:
```
com.google.cloud.storage.StorageException: Client side data loss detected. Attempt to append to a resumable session with an offset higher than the backend has
	|> [
	|> 	com.google.storage.v2.WriteObjectRequest{
	|> 		upload_id: uploadId
	|> 		checksummed_data: {range: [262144:524288]}
	|> 	}
	|> ]
	|  
	|< Status{code=OUT_OF_RANGE, description=Upload request started at offset '262144', which is past expected offset '0'., cause=null}
	|< Metadata(content-type=application/grpc)
	| 
```

Also update exception propagation to add original call context as a suppressed exception in order to allow maintaining originating frames of the async failure.