### PR TITLE
chore: trusted-contribution bot to add /gcbrun comment

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -1,3 +1,9 @@
 trustedContributors:
 - renovate-bot
 - gcf-owl-bot[bot]
+
+annotations:
+- type: comment
+  text: "/gcbrun"
+- type: label
+  text: "kokoro:force-run"

--- a/README.md
+++ b/README.md
@@ -59,20 +59,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.38.0')
+implementation platform('com.google.cloud:libraries-bom:26.39.0')
 
 implementation 'com.google.cloud:google-cloud-storage'
 ```
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-storage:2.37.0'
+implementation 'com.google.cloud:google-cloud-storage:2.38.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "2.37.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "2.38.0"
 ```
 <!-- {x-version-update-end} -->
 
@@ -494,7 +494,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-storage.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-storage/2.37.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-storage/2.38.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/owlbot.py
+++ b/owlbot.py
@@ -37,6 +37,7 @@ java.common_templates(excludes=[
   '.kokoro/presubmit/graalvm-native-17.cfg',
   '.kokoro/requirements.in',
   '.kokoro/requirements.txt',
+  '.github/trusted-contribution.yml',
   '.github/workflows/auto-release.yaml',
   'CONTRIBUTING.md',
   'renovate.json'


### PR DESCRIPTION
Experimenting the behavior of the trusted contribution bot. From reading the configuration (https://github.com/googleapis/repo-automation-bots/pull/1682/files), it accepts multiple objects.
