### PR TITLE
fix: reduce Java 21 Virtual Thread Pinning in IO operations

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/AsyncAppendingQueue.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/AsyncAppendingQueue.java
@@ -90,7 +90,7 @@ final class AsyncAppendingQueue<@NonNull T> implements AutoCloseable {
     lock = new ReentrantLock();
   }
 
-  synchronized AsyncAppendingQueue<T> append(ApiFuture<T> value) throws ShortCircuitException {
+  AsyncAppendingQueue<T> append(ApiFuture<T> value) throws ShortCircuitException {
     lock.lock();
     try {
       checkState(state.isOpen(), "already closed");
@@ -124,7 +124,7 @@ final class AsyncAppendingQueue<@NonNull T> implements AutoCloseable {
   }
 
   @Override
-  public synchronized void close() {
+  public void close() {
     lock.lock();
     try {
       if (!state.isOpen()) {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobReadChannelV2.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobReadChannelV2.java
@@ -51,10 +51,15 @@ final class BlobReadChannelV2 extends BaseStorageReadChannel<StorageObject> {
   }
 
   @Override
-  public synchronized RestorableState<ReadChannel> capture() {
-    ApiaryReadRequest apiaryReadRequest = getApiaryReadRequest();
-    return new BlobReadChannelV2State(
-        apiaryReadRequest, blobReadChannelContext.getStorageOptions(), getChunkSize());
+  public RestorableState<ReadChannel> capture() {
+    lock.lock();
+    try {
+      ApiaryReadRequest apiaryReadRequest = getApiaryReadRequest();
+      return new BlobReadChannelV2State(
+          apiaryReadRequest, blobReadChannelContext.getStorageOptions(), getChunkSize());
+    } finally {
+      lock.unlock();
+    }
   }
 
   protected LazyReadChannel<?, StorageObject> newLazyReadChannel() {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfig.java
@@ -1052,7 +1052,8 @@ public final class ParallelCompositeUploadBlobWriteSessionConfig extends BlobWri
                 storageInternal,
                 info,
                 opts);
-        return ApiFutures.immediateFuture(channel);
+        return ApiFutures.immediateFuture(
+            StorageByteChannels.writable().createSynchronized(channel));
       }
 
       @Override

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadWritableByteChannel.java
@@ -166,7 +166,7 @@ final class ParallelCompositeUploadWritableByteChannel implements BufferedWritab
   }
 
   @Override
-  public synchronized int write(ByteBuffer src) throws IOException {
+  public int write(ByteBuffer src) throws IOException {
     if (!open) {
       throw new ClosedChannelException();
     }
@@ -190,12 +190,12 @@ final class ParallelCompositeUploadWritableByteChannel implements BufferedWritab
   }
 
   @Override
-  public synchronized boolean isOpen() {
+  public boolean isOpen() {
     return open;
   }
 
   @Override
-  public synchronized void flush() throws IOException {
+  public void flush() throws IOException {
     if (current != null) {
       ByteBuffer buf = current.getBufferHandle().get();
       internalFlush(buf);
@@ -203,7 +203,7 @@ final class ParallelCompositeUploadWritableByteChannel implements BufferedWritab
   }
 
   @Override
-  public synchronized void close() throws IOException {
+  public void close() throws IOException {
     if (!open) {
       return;
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageByteChannels.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageByteChannels.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.ScatteringByteChannel;
+import java.util.concurrent.locks.ReentrantLock;
 
 final class StorageByteChannels {
 
@@ -74,24 +75,41 @@ final class StorageByteChannels {
       implements BufferedReadableByteChannel {
 
     private final BufferedReadableByteChannel delegate;
+    private final ReentrantLock lock;
 
     public SynchronizedBufferedReadableByteChannel(BufferedReadableByteChannel delegate) {
       this.delegate = delegate;
+      this.lock = new ReentrantLock();
     }
 
     @Override
-    public synchronized int read(ByteBuffer dst) throws IOException {
-      return delegate.read(dst);
+    public int read(ByteBuffer dst) throws IOException {
+      lock.lock();
+      try {
+        return delegate.read(dst);
+      } finally {
+        lock.unlock();
+      }
     }
 
     @Override
     public boolean isOpen() {
-      return delegate.isOpen();
+      lock.lock();
+      try {
+        return delegate.isOpen();
+      } finally {
+        lock.unlock();
+      }
     }
 
     @Override
-    public synchronized void close() throws IOException {
-      delegate.close();
+    public void close() throws IOException {
+      lock.lock();
+      try {
+        delegate.close();
+      } finally {
+        lock.unlock();
+      }
     }
   }
 
@@ -99,29 +117,51 @@ final class StorageByteChannels {
       implements BufferedWritableByteChannel {
 
     private final BufferedWritableByteChannel delegate;
+    private final ReentrantLock lock;
 
     public SynchronizedBufferedWritableByteChannel(BufferedWritableByteChannel delegate) {
       this.delegate = delegate;
+      this.lock = new ReentrantLock();
     }
 
     @Override
-    public synchronized int write(ByteBuffer src) throws IOException {
-      return delegate.write(src);
+    public int write(ByteBuffer src) throws IOException {
+      lock.lock();
+      try {
+        return delegate.write(src);
+      } finally {
+        lock.unlock();
+      }
     }
 
     @Override
     public boolean isOpen() {
-      return delegate.isOpen();
+      lock.lock();
+      try {
+        return delegate.isOpen();
+      } finally {
+        lock.unlock();
+      }
     }
 
     @Override
-    public synchronized void close() throws IOException {
-      delegate.close();
+    public void close() throws IOException {
+      lock.lock();
+      try {
+        delegate.close();
+      } finally {
+        lock.unlock();
+      }
     }
 
     @Override
-    public synchronized void flush() throws IOException {
-      delegate.flush();
+    public void flush() throws IOException {
+      lock.lock();
+      try {
+        delegate.flush();
+      } finally {
+        lock.unlock();
+      }
     }
   }
 
@@ -129,34 +169,61 @@ final class StorageByteChannels {
       implements UnbufferedReadableByteChannel {
 
     private final UnbufferedReadableByteChannel delegate;
+    private final ReentrantLock lock;
 
     private SynchronizedUnbufferedReadableByteChannel(UnbufferedReadableByteChannel delegate) {
       this.delegate = delegate;
+      this.lock = new ReentrantLock();
     }
 
     @Override
-    public synchronized int read(ByteBuffer src) throws IOException {
-      return delegate.read(src);
+    public int read(ByteBuffer src) throws IOException {
+      lock.lock();
+      try {
+        return delegate.read(src);
+      } finally {
+        lock.unlock();
+      }
     }
 
     @Override
-    public synchronized long read(ByteBuffer[] dsts) throws IOException {
-      return delegate.read(dsts);
+    public long read(ByteBuffer[] dsts) throws IOException {
+      lock.lock();
+      try {
+        return delegate.read(dsts);
+      } finally {
+        lock.unlock();
+      }
     }
 
     @Override
-    public synchronized long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
-      return delegate.read(dsts, offset, length);
+    public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
+      lock.lock();
+      try {
+        return delegate.read(dsts, offset, length);
+      } finally {
+        lock.unlock();
+      }
     }
 
     @Override
     public boolean isOpen() {
-      return delegate.isOpen();
+      lock.lock();
+      try {
+        return delegate.isOpen();
+      } finally {
+        lock.unlock();
+      }
     }
 
     @Override
-    public synchronized void close() throws IOException {
-      delegate.close();
+    public void close() throws IOException {
+      lock.lock();
+      try {
+        delegate.close();
+      } finally {
+        lock.unlock();
+      }
     }
   }
 
@@ -164,50 +231,91 @@ final class StorageByteChannels {
       implements UnbufferedWritableByteChannel {
 
     private final UnbufferedWritableByteChannel delegate;
+    private final ReentrantLock lock;
 
     private SynchronizedUnbufferedWritableByteChannel(UnbufferedWritableByteChannel delegate) {
       this.delegate = delegate;
+      this.lock = new ReentrantLock();
     }
 
     @Override
-    public synchronized int write(ByteBuffer src) throws IOException {
-      return delegate.write(src);
+    public int write(ByteBuffer src) throws IOException {
+      lock.lock();
+      try {
+        return delegate.write(src);
+      } finally {
+        lock.unlock();
+      }
     }
 
     @Override
-    public synchronized long write(ByteBuffer[] srcs) throws IOException {
-      return delegate.write(srcs);
+    public long write(ByteBuffer[] srcs) throws IOException {
+      lock.lock();
+      try {
+        return delegate.write(srcs);
+      } finally {
+        lock.unlock();
+      }
     }
 
     @Override
-    public synchronized long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
-      return delegate.write(srcs, offset, length);
+    public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+      lock.lock();
+      try {
+        return delegate.write(srcs, offset, length);
+      } finally {
+        lock.unlock();
+      }
     }
 
     @Override
-    public synchronized int writeAndClose(ByteBuffer src) throws IOException {
-      return delegate.writeAndClose(src);
+    public int writeAndClose(ByteBuffer src) throws IOException {
+      lock.lock();
+      try {
+        return delegate.writeAndClose(src);
+      } finally {
+        lock.unlock();
+      }
     }
 
     @Override
-    public synchronized long writeAndClose(ByteBuffer[] srcs) throws IOException {
-      return delegate.writeAndClose(srcs);
+    public long writeAndClose(ByteBuffer[] srcs) throws IOException {
+      lock.lock();
+      try {
+        return delegate.writeAndClose(srcs);
+      } finally {
+        lock.unlock();
+      }
     }
 
     @Override
-    public synchronized long writeAndClose(ByteBuffer[] srcs, int offset, int length)
-        throws IOException {
-      return delegate.writeAndClose(srcs, offset, length);
+    public long writeAndClose(ByteBuffer[] srcs, int offset, int length) throws IOException {
+      lock.lock();
+      try {
+        return delegate.writeAndClose(srcs, offset, length);
+      } finally {
+        lock.unlock();
+      }
     }
 
     @Override
     public boolean isOpen() {
-      return delegate.isOpen();
+      lock.lock();
+      try {
+        return delegate.isOpen();
+      } finally {
+        lock.unlock();
+      }
     }
 
     @Override
-    public synchronized void close() throws IOException {
-      delegate.close();
+    public void close() throws IOException {
+      lock.lock();
+      try {
+        delegate.close();
+      } finally {
+        lock.unlock();
+      }
     }
   }
 


### PR DESCRIPTION
Setup a small workload using virtual threads and turned on pinning detection (`-Djdk.tracePinnedThreads=full`), and run various methods for uploading and downloading object data.

I then reduced the pinning sights to a minimized list (`grep 'monitor' run.log | grep 'com.google.cloud.storage' | sort -u`)
```
    com.google.cloud.storage.BaseStorageReadChannel.read(BaseStorageReadChannel.java:105) <== monitors:1
    com.google.cloud.storage.BlobWriteSessions$WritableByteChannelSessionAdapter.open(BlobWriteSessions.java:46) <== monitors:1
    com.google.cloud.storage.LazyWriteChannel.getSession(LazyWriteChannel.java:59) <== monitors:1
    com.google.cloud.storage.ParallelCompositeUploadWritableByteChannel.close(ParallelCompositeUploadWritableByteChannel.java:268) <== monitors:1
    com.google.cloud.storage.ParallelCompositeUploadWritableByteChannel.write(ParallelCompositeUploadWritableByteChannel.java:178) <== monitors:1
    com.google.cloud.storage.StorageByteChannels$SynchronizedBufferedWritableByteChannel.close(StorageByteChannels.java:119) <== monitors:1
    com.google.cloud.storage.StorageByteChannels$SynchronizedBufferedWritableByteChannel.write(StorageByteChannels.java:109) <== monitors:1
    com.google.cloud.storage.StorageByteChannels$SynchronizedUnbufferedReadableByteChannel.read(StorageByteChannels.java:139) <== monitors:1
```

To avoid pinning during IO operations, uses of synchronization have been replaced with ReenterantLock. There were a few synchronization sites that were also guarded by an outer operations synchronization, these too have been updated to use ReenterantLock.

We stick with `synchronized` for init related operations. In the case of creating a WriteChannel, the ability to open depends on the resumable session being created successfully, which requires a network request. Our objects in this area are not written in a top to bottom async friendly way to remove the synchronization at this time. Given these operations are performed at most once per WriteChannel impact is much less drastic compared to `write(ByteBuffer)` and `close()`.

After this change, I ran the same workload and we are left with only the two following pins detected
```
    com.google.cloud.storage.BlobWriteSessions$WritableByteChannelSessionAdapter.open(BlobWriteSessions.java:46) <== monitors:1
    com.google.cloud.storage.LazyWriteChannel.getSession(LazyWriteChannel.java:59) <== monitors:1
```

Some investigation into if/how this type of pinning detection can be introduced to integration suite still needs to happen. Superficially, I'm not sure if it's practical to get JUnit4 to run everything in virtual threads, we might need to depend on some other CI external validation.

Part of work needed for #2308
