### PR TITLE
fix: update grpc bidi resumable uploads to validate ack'd object size

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BidiResumableWrite.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BidiResumableWrite.java
@@ -52,7 +52,7 @@ final class BidiResumableWrite implements BidiWriteObjectRequestBuilderFactory {
 
   @Override
   public BidiWriteObjectRequest.Builder newBuilder() {
-    return writeRequest.toBuilder();
+    return writeRequest.toBuilder().clearWriteObjectSpec();
   }
 
   @Override

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BidiWriteCtx.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BidiWriteCtx.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.storage;
 
-import static com.google.cloud.storage.StorageV2ProtoUtils.fmtProto;
-
 import com.google.cloud.storage.BidiWriteCtx.BidiWriteObjectRequestBuilderFactory;
 import com.google.cloud.storage.Crc32cValue.Crc32cLengthKnown;
 import com.google.storage.v2.BidiWriteObjectRequest;
@@ -84,36 +82,5 @@ final class BidiWriteCtx<RequestFactoryT extends BidiWriteObjectRequestBuilderFa
 
     @Nullable
     String bucketName();
-
-    static BidiSimpleWriteObjectRequestBuilderFactory simple(BidiWriteObjectRequest req) {
-      return new BidiSimpleWriteObjectRequestBuilderFactory(req);
-    }
-  }
-
-  static final class BidiSimpleWriteObjectRequestBuilderFactory
-      implements BidiWriteObjectRequestBuilderFactory {
-    private final BidiWriteObjectRequest req;
-
-    private BidiSimpleWriteObjectRequestBuilderFactory(BidiWriteObjectRequest req) {
-      this.req = req;
-    }
-
-    @Override
-    public BidiWriteObjectRequest.Builder newBuilder() {
-      return req.toBuilder();
-    }
-
-    @Override
-    public @Nullable String bucketName() {
-      if (req.hasWriteObjectSpec() && req.getWriteObjectSpec().hasResource()) {
-        return req.getWriteObjectSpec().getResource().getBucket();
-      }
-      return null;
-    }
-
-    @Override
-    public String toString() {
-      return "SimpleBidiWriteObjectRequestBuilderFactory{" + "req=" + fmtProto(req) + '}';
-    }
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicBidiUnbufferedWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicBidiUnbufferedWritableByteChannel.java
@@ -66,17 +66,17 @@ final class GapicBidiUnbufferedWritableByteChannel implements UnbufferedWritable
       ResultRetryAlgorithm<?> alg,
       SettableApiFuture<BidiWriteObjectResponse> resultFuture,
       ChunkSegmenter chunkSegmenter,
-      BidiResumableWrite requestFactory,
+      BidiWriteCtx<BidiResumableWrite> writeCtx,
       Supplier<GrpcCallContext> baseContextSupplier) {
     this.write = write;
     this.deps = deps;
     this.alg = alg;
     this.baseContextSupplier = baseContextSupplier;
-    this.bucketName = requestFactory.bucketName();
+    this.bucketName = writeCtx.getRequestFactory().bucketName();
     this.resultFuture = resultFuture;
     this.chunkSegmenter = chunkSegmenter;
 
-    this.writeCtx = new BidiWriteCtx<>(requestFactory);
+    this.writeCtx = writeCtx;
     this.responseObserver = new BidiObserver();
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicBidiWritableByteChannelSessionBuilder.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicBidiWritableByteChannelSessionBuilder.java
@@ -155,7 +155,7 @@ final class GapicBidiWritableByteChannelSessionBuilder {
                             resultFuture,
                             new ChunkSegmenter(
                                 boundHasher, boundStrategy, Values.MAX_WRITE_CHUNK_BYTES_VALUE),
-                            start,
+                            new BidiWriteCtx<>(start),
                             Retrying::newCallContext))
                 .andThen(c -> new DefaultBufferedWritableByteChannel(bufferHandle, c))
                 .andThen(StorageByteChannels.writable()::createSynchronized));

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableSessionFailureScenario.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableSessionFailureScenario.java
@@ -26,11 +26,11 @@ import com.google.api.gax.rpc.ApiException;
 import com.google.cloud.BaseServiceException;
 import com.google.cloud.storage.StorageException.IOExceptionCallable;
 import com.google.common.io.CharStreams;
-import com.google.protobuf.MessageOrBuilder;
+import com.google.protobuf.Message;
+import com.google.storage.v2.BidiWriteObjectRequest;
 import com.google.storage.v2.ChecksummedData;
 import com.google.storage.v2.ObjectChecksums;
 import com.google.storage.v2.WriteObjectRequest;
-import com.google.storage.v2.WriteObjectResponse;
 import io.grpc.StatusRuntimeException;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -81,10 +81,6 @@ enum ResumableSessionFailureScenario {
   private static final String PREFIX_I = "\t|< ";
   private static final String PREFIX_O = "\t|> ";
   private static final String PREFIX_X = "\t|  ";
-  // define some constants for tab widths that are more compressed that the literals
-  private static final String T1 = "\t";
-  private static final String T2 = "\t\t";
-  private static final String T3 = "\t\t\t";
 
   private static final Predicate<String> includedHeaders =
       matches("Content-Length")
@@ -134,8 +130,10 @@ enum ResumableSessionFailureScenario {
   }
 
   StorageException toStorageException(
-      @NonNull List<@NonNull WriteObjectRequest> reqs,
-      @Nullable WriteObjectResponse resp,
+      /*In java List<WriteObjectRequest> is not a sub-type of List<Message> despite WriteObjectRequest being a Message.
+       * intentionally only define List so the compiler doesn't complain */
+      @SuppressWarnings("rawtypes") @NonNull List reqs,
+      @Nullable Message resp,
       @NonNull GrpcCallContext context,
       @Nullable Throwable cause) {
     return toStorageException(code, message, reason, reqs, resp, context, cause);
@@ -161,8 +159,8 @@ enum ResumableSessionFailureScenario {
       int code,
       String message,
       @Nullable String reason,
-      @NonNull List<@NonNull WriteObjectRequest> reqs,
-      @Nullable WriteObjectResponse resp,
+      @NonNull List reqs,
+      @Nullable Message resp,
       @NonNull GrpcCallContext context,
       @Nullable Throwable cause) {
     final StringBuilder sb = new StringBuilder();
@@ -177,35 +175,8 @@ enum ResumableSessionFailureScenario {
       } else {
         sb.append(",");
       }
-      WriteObjectRequest req = reqs.get(i);
-      sb.append("\n").append(PREFIX_O).append(T1).append(req.getClass().getName()).append("{");
-      if (req.hasUploadId()) {
-        sb.append("\n").append(PREFIX_O).append(T2).append("upload_id: ").append(req.getUploadId());
-      }
-      long writeOffset = req.getWriteOffset();
-      if (req.hasChecksummedData()) {
-        ChecksummedData checksummedData = req.getChecksummedData();
-        sb.append("\n").append(PREFIX_O).append(T2);
-        sb.append(
-            String.format(
-                "checksummed_data: {range: [%d:%d]",
-                writeOffset, writeOffset + checksummedData.getContent().size()));
-        if (checksummedData.hasCrc32C()) {
-          sb.append(", crc32c: ").append(checksummedData.getCrc32C());
-        }
-        sb.append("}");
-      } else {
-        sb.append("\n").append(PREFIX_O).append(T2).append("write_offset: ").append(writeOffset);
-      }
-      if (req.getFinishWrite()) {
-        sb.append("\n").append(PREFIX_O).append(T2).append("finish_write: true");
-      }
-      if (req.hasObjectChecksums()) {
-        ObjectChecksums objectChecksums = req.getObjectChecksums();
-        sb.append("\n").append(PREFIX_O).append(T2).append("object_checksums: ").append("{");
-        fmt(objectChecksums, PREFIX_O, T3, sb);
-        sb.append("\n").append(PREFIX_O).append(T2).append("}");
-      }
+      Message req = (Message) reqs.get(i);
+      fmt(req, PREFIX_O, Indentation.T1, sb);
       sb.append("\n").append(PREFIX_O).append("\t}");
       if (i == length - 1) {
         sb.append("\n").append(PREFIX_O).append("]");
@@ -217,7 +188,7 @@ enum ResumableSessionFailureScenario {
     // response context
     if (resp != null) {
       sb.append("\n").append(PREFIX_I).append(resp.getClass().getName()).append("{");
-      fmt(resp, PREFIX_I, T1, sb);
+      fmt(resp, PREFIX_I, Indentation.T1, sb);
       sb.append("\n").append(PREFIX_I).append("}");
       sb.append("\n").append(PREFIX_X);
     }
@@ -250,7 +221,9 @@ enum ResumableSessionFailureScenario {
         sb.append("\n").append(PREFIX_X);
       }
     }
-    return new StorageException(code, sb.toString(), reason, cause);
+    StorageException se = new StorageException(code, sb.toString(), reason, cause);
+    se.printStackTrace();
+    return se;
   }
 
   static StorageException toStorageException(
@@ -359,16 +332,122 @@ enum ResumableSessionFailureScenario {
   }
 
   private static void fmt(
-      MessageOrBuilder msg,
+      Message msg,
       @SuppressWarnings("SameParameterValue") String prefix,
-      String indentation,
+      Indentation indentation,
       StringBuilder sb) {
-    String string = msg.toString();
-    // drop the final new line before prefixing
-    string = string.replaceAll("\n$", "");
-    sb.append("\n")
-        .append(prefix)
-        .append(indentation)
-        .append(string.replaceAll("\r?\n", "\n" + prefix + indentation));
+    if (msg instanceof WriteObjectRequest) {
+      WriteObjectRequest req = (WriteObjectRequest) msg;
+      fmtWriteObjectRequest(req, prefix, indentation, sb);
+    } else if (msg instanceof BidiWriteObjectRequest) {
+      BidiWriteObjectRequest req = (BidiWriteObjectRequest) msg;
+      fmtBidiWriteObjectRequest(req, prefix, indentation, sb);
+    } else {
+      String string = msg.toString();
+      // drop the final new line before prefixing
+      string = string.replaceAll("\n$", "");
+      sb.append("\n")
+          .append(prefix)
+          .append(indentation)
+          .append(string.replaceAll("\r?\n", "\n" + prefix + indentation.indentation));
+    }
+  }
+
+  private static void fmtWriteObjectRequest(
+      WriteObjectRequest req, String prefix, Indentation t1, StringBuilder sb) {
+    Indentation t2 = t1.indent();
+    Indentation t3 = t2.indent();
+    sb.append("\n").append(prefix).append(t1).append(req.getClass().getName()).append("{");
+    if (req.hasUploadId()) {
+      sb.append("\n").append(prefix).append(t2).append("upload_id: ").append(req.getUploadId());
+    }
+    long writeOffset = req.getWriteOffset();
+    if (req.hasChecksummedData()) {
+      ChecksummedData checksummedData = req.getChecksummedData();
+      sb.append("\n").append(prefix).append(t2);
+      sb.append(
+          String.format(
+              "checksummed_data: {range: [%d:%d]",
+              writeOffset, writeOffset + checksummedData.getContent().size()));
+      if (checksummedData.hasCrc32C()) {
+        sb.append(", crc32c: ").append(checksummedData.getCrc32C());
+      }
+      sb.append("}");
+    } else {
+      sb.append("\n").append(prefix).append(t2).append("write_offset: ").append(writeOffset);
+    }
+    if (req.getFinishWrite()) {
+      sb.append("\n").append(prefix).append(t2).append("finish_write: true");
+    }
+    if (req.hasObjectChecksums()) {
+      ObjectChecksums objectChecksums = req.getObjectChecksums();
+      sb.append("\n").append(prefix).append(t2).append("object_checksums: ").append("{");
+      fmt(objectChecksums, prefix, t3, sb);
+      sb.append("\n").append(prefix).append(t2).append("}");
+    }
+  }
+
+  private static void fmtBidiWriteObjectRequest(
+      BidiWriteObjectRequest req, String prefix, Indentation t1, StringBuilder sb) {
+    Indentation t2 = t1.indent();
+    Indentation t3 = t2.indent();
+    sb.append("\n").append(prefix).append(t1).append(req.getClass().getName()).append("{");
+    if (req.hasUploadId()) {
+      sb.append("\n").append(prefix).append(t2).append("upload_id: ").append(req.getUploadId());
+    }
+    long writeOffset = req.getWriteOffset();
+    if (req.hasChecksummedData()) {
+      ChecksummedData checksummedData = req.getChecksummedData();
+      sb.append("\n").append(prefix).append(t2);
+      sb.append(
+          String.format(
+              "checksummed_data: {range: [%d:%d]",
+              writeOffset, writeOffset + checksummedData.getContent().size()));
+      if (checksummedData.hasCrc32C()) {
+        sb.append(", crc32c: ").append(checksummedData.getCrc32C());
+      }
+      sb.append("}");
+    } else {
+      sb.append("\n").append(prefix).append(t2).append("write_offset: ").append(writeOffset);
+    }
+    if (req.getFlush()) {
+      sb.append("\n").append(prefix).append(t2).append("flush: true");
+    }
+    if (req.getStateLookup()) {
+      sb.append("\n").append(prefix).append(t2).append("state_lookup: true");
+    }
+    if (req.getFinishWrite()) {
+      sb.append("\n").append(prefix).append(t2).append("finish_write: true");
+    }
+    if (req.hasObjectChecksums()) {
+      ObjectChecksums objectChecksums = req.getObjectChecksums();
+      sb.append("\n").append(prefix).append(t2).append("object_checksums: ").append("{");
+      fmt(objectChecksums, prefix, t3, sb);
+      sb.append("\n").append(prefix).append(t2).append("}");
+    }
+  }
+
+  enum Indentation {
+    T1("\t"),
+    T2("\t\t"),
+    T3("\t\t\t"),
+    T4("\t\t\t\t"),
+    ;
+
+    private final String indentation;
+
+    Indentation(String indentation) {
+      this.indentation = indentation;
+    }
+
+    Indentation indent() {
+      int ordinal = ordinal();
+      return values()[ordinal + 1];
+    }
+
+    @Override
+    public String toString() {
+      return indentation;
+    }
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableSessionFailureScenario.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableSessionFailureScenario.java
@@ -222,7 +222,6 @@ enum ResumableSessionFailureScenario {
       }
     }
     StorageException se = new StorageException(code, sb.toString(), reason, cause);
-    se.printStackTrace();
     return se;
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/FakeServer.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/FakeServer.java
@@ -17,6 +17,7 @@
 package com.google.cloud.storage;
 
 import com.google.cloud.NoCredentials;
+import com.google.cloud.storage.it.GrpcPlainRequestLoggingInterceptor;
 import com.google.storage.v2.StorageGrpc;
 import com.google.storage.v2.StorageSettings;
 import io.grpc.Server;
@@ -58,6 +59,7 @@ final class FakeServer implements AutoCloseable {
             .setHost("http://" + endpoint)
             .setProjectId("test-proj")
             .setCredentials(NoCredentials.getInstance())
+            .setGrpcInterceptorProvider(GrpcPlainRequestLoggingInterceptor.getInterceptorProvider())
             .build();
     return new FakeServer(server, grpcStorageOptions);
   }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicBidiUnbufferedWritableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicBidiUnbufferedWritableByteChannelTest.java
@@ -838,9 +838,7 @@ public final class ITGapicBidiUnbufferedWritableByteChannelTest {
   }
 
   static class BidiWriteService extends StorageImplBase {
-    private static final Logger LOGGER =
-        Logger.getLogger(
-            ITGapicUnbufferedWritableByteChannelTest.DirectWriteService.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(BidiWriteService.class.getName());
     private final BiConsumer<StreamObserver<BidiWriteObjectResponse>, List<BidiWriteObjectRequest>>
         c;
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicBidiUnbufferedWritableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicBidiUnbufferedWritableByteChannelTest.java
@@ -1,0 +1,940 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.cloud.storage.ByteSizeConstants._256KiB;
+import static com.google.cloud.storage.ByteSizeConstants._512KiB;
+import static com.google.cloud.storage.ByteSizeConstants._768KiB;
+import static com.google.cloud.storage.TestUtils.assertAll;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.assertThrows;
+
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.grpc.GrpcCallContext;
+import com.google.cloud.storage.Retrying.RetryingDependencies;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ByteString;
+import com.google.storage.v2.BidiWriteObjectRequest;
+import com.google.storage.v2.BidiWriteObjectResponse;
+import com.google.storage.v2.ChecksummedData;
+import com.google.storage.v2.Object;
+import com.google.storage.v2.StartResumableWriteRequest;
+import com.google.storage.v2.StartResumableWriteResponse;
+import com.google.storage.v2.StorageClient;
+import com.google.storage.v2.StorageGrpc.StorageImplBase;
+import io.grpc.Status.Code;
+import io.grpc.stub.CallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import java.util.logging.Logger;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.Test;
+
+public final class ITGapicBidiUnbufferedWritableByteChannelTest {
+
+  private static final ChunkSegmenter CHUNK_SEGMENTER =
+      new ChunkSegmenter(Hasher.noop(), ByteStringStrategy.copy(), _256KiB, _256KiB);
+
+  /**
+   *
+   *
+   * <h4>S.1</h4>
+   *
+   * Attempting to append to a session which has already been finalized should raise an error
+   *
+   * <table>
+   *   <caption></caption>
+   *   <tr>
+   *     <td>server state</td>
+   *     <td><pre>
+   * resource = { name = obj, size = 524288 }
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>client state</td>
+   *     <td><pre>
+   * write_offset = 0, data = [0:262144]
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>request</td>
+   *     <td><pre>
+   * BidiWriteObjectRequest{ upload_id = $UPLOAD_ID, write_offset= 0, checksummed_data.content.length = 262144 }
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>response</td>
+   *     <td><pre>
+   * onNext(BidiWriteObjectResponse{ resources = {name = obj, size = 525288 } })
+   *     </pre></td>
+   *   </tr>
+   * </table>
+   */
+  @Test
+  public void scenario1() throws Exception {
+
+    String uploadId = "uploadId";
+    BidiWriteObjectRequest req1 =
+        BidiWriteObjectRequest.newBuilder()
+            .setUploadId(uploadId)
+            .setChecksummedData(
+                ChecksummedData.newBuilder()
+                    .setContent(
+                        ByteString.copyFrom(DataGenerator.base64Characters().genBytes(_256KiB)))
+                    .build())
+            .setStateLookup(true)
+            .setFlush(true)
+            .build();
+    BidiWriteObjectResponse resp1 =
+        BidiWriteObjectResponse.newBuilder()
+            .setResource(Object.newBuilder().setName("obj").setSize(_512KiB).build())
+            .build();
+
+    ImmutableMap<List<BidiWriteObjectRequest>, BidiWriteObjectResponse> map =
+        ImmutableMap.of(ImmutableList.of(req1), resp1);
+    BidiWriteService service1 = new BidiWriteService(map);
+
+    try (FakeServer fakeServer = FakeServer.of(service1);
+        GrpcStorageImpl storage =
+            (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().getService()) {
+      StorageClient storageClient = storage.storageClient;
+
+      BidiResumableWrite resumableWrite = getResumableWrite(uploadId);
+
+      BidiWriteCtx<BidiResumableWrite> writeCtx = new BidiWriteCtx<>(resumableWrite);
+      SettableApiFuture<BidiWriteObjectResponse> done = SettableApiFuture.create();
+      //noinspection resource
+      GapicBidiUnbufferedWritableByteChannel channel =
+          new GapicBidiUnbufferedWritableByteChannel(
+              storageClient.bidiWriteObjectCallable(),
+              RetryingDependencies.attemptOnce(),
+              Retrying.neverRetry(),
+              done,
+              CHUNK_SEGMENTER,
+              writeCtx,
+              GrpcCallContext::createDefault);
+
+      ByteBuffer bb = DataGenerator.base64Characters().genByteBuffer(_256KiB);
+      StorageException se = assertThrows(StorageException.class, () -> channel.write(bb));
+      assertAll(
+          () -> assertThat(se.getCode()).isEqualTo(0),
+          () -> assertThat(se.getReason()).isEqualTo("invalid"),
+          () -> assertThat(writeCtx.getConfirmedBytes().get()).isEqualTo(0),
+          () -> assertThat(channel.isOpen()).isFalse());
+    }
+  }
+
+  /**
+   *
+   *
+   * <h4>S.2</h4>
+   *
+   * Attempting to finalize a session with fewer bytes than GCS acknowledges.
+   *
+   * <table>
+   *   <caption></caption>
+   *   <tr>
+   *     <td>server state</td>
+   *     <td><pre>
+   * persisted_size = 524288
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>client state</td>
+   *     <td><pre>
+   * write_offset = 262144, finish = true
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>request</td>
+   *     <td><pre>
+   * BidiWriteObjectRequest{ upload_id = $UPLOAD_ID, write_offset = 262144, finish_write = true}
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>response</td>
+   *     <td><pre>
+   * onNext(BidiWriteObjectResponse{ persisted_size = 525288 })
+   *     </pre></td>
+   *   </tr>
+   * </table>
+   */
+  @Test
+  public void scenario2() throws Exception {
+    String uploadId = "uploadId";
+    BidiWriteObjectRequest req1 =
+        BidiWriteObjectRequest.newBuilder()
+            .setUploadId(uploadId)
+            .setWriteOffset(_256KiB)
+            .setFinishWrite(true)
+            .build();
+    BidiWriteObjectResponse resp1 =
+        BidiWriteObjectResponse.newBuilder().setPersistedSize(_512KiB).build();
+
+    ImmutableMap<List<BidiWriteObjectRequest>, BidiWriteObjectResponse> map =
+        ImmutableMap.of(ImmutableList.of(req1), resp1);
+    BidiWriteService service1 = new BidiWriteService(map);
+
+    try (FakeServer fakeServer = FakeServer.of(service1);
+        GrpcStorageImpl storage =
+            (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().getService()) {
+      StorageClient storageClient = storage.storageClient;
+
+      SettableApiFuture<BidiWriteObjectResponse> done = SettableApiFuture.create();
+      BidiResumableWrite resumableWrite = getResumableWrite(uploadId);
+      BidiWriteCtx<BidiResumableWrite> writeCtx = new BidiWriteCtx<>(resumableWrite);
+      writeCtx.getTotalSentBytes().set(_256KiB);
+      writeCtx.getConfirmedBytes().set(_256KiB);
+
+      //noinspection resource
+      GapicBidiUnbufferedWritableByteChannel channel =
+          new GapicBidiUnbufferedWritableByteChannel(
+              storageClient.bidiWriteObjectCallable(),
+              RetryingDependencies.attemptOnce(),
+              Retrying.neverRetry(),
+              done,
+              CHUNK_SEGMENTER,
+              writeCtx,
+              GrpcCallContext::createDefault);
+
+      StorageException se = assertThrows(StorageException.class, channel::close);
+      assertAll(
+          () -> assertThat(se.getCode()).isEqualTo(0),
+          () -> assertThat(se.getReason()).isEqualTo("invalid"),
+          () -> assertThat(writeCtx.getConfirmedBytes().get()).isEqualTo(_256KiB),
+          () -> assertThat(channel.isOpen()).isFalse());
+    }
+  }
+
+  /**
+   *
+   *
+   * <h4>S.3</h4>
+   *
+   * Attempting to finalize a session with more bytes than GCS acknowledges.
+   *
+   * <table>
+   *   <caption></caption>
+   *   <tr>
+   *     <td>server state</td>
+   *     <td><pre>
+   * persisted_size = 262144
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>client state</td>
+   *     <td><pre>
+   * write_offset = 524288, finish = true
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>request</td>
+   *     <td><pre>
+   * BidiWriteObjectRequest{ upload_id = $UPLOAD_ID, write_offset = 524288, finish_write = true}
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>response</td>
+   *     <td><pre>
+   * onNext(BidiWriteObjectResponse{ persisted_size = 262144 })
+   *     </pre></td>
+   *   </tr>
+   * </table>
+   */
+  @Test
+  public void scenario3() throws Exception {
+    String uploadId = "uploadId";
+    BidiWriteObjectRequest req1 =
+        BidiWriteObjectRequest.newBuilder()
+            .setUploadId(uploadId)
+            .setWriteOffset(_512KiB)
+            .setFinishWrite(true)
+            .build();
+    BidiWriteObjectResponse resp1 =
+        BidiWriteObjectResponse.newBuilder().setPersistedSize(_256KiB).build();
+
+    ImmutableMap<List<BidiWriteObjectRequest>, BidiWriteObjectResponse> map =
+        ImmutableMap.of(ImmutableList.of(req1), resp1);
+    BidiWriteService service1 = new BidiWriteService(map);
+
+    try (FakeServer fakeServer = FakeServer.of(service1);
+        GrpcStorageImpl storage =
+            (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().getService()) {
+      StorageClient storageClient = storage.storageClient;
+
+      SettableApiFuture<BidiWriteObjectResponse> done = SettableApiFuture.create();
+      BidiResumableWrite resumableWrite = getResumableWrite(uploadId);
+      BidiWriteCtx<BidiResumableWrite> writeCtx = new BidiWriteCtx<>(resumableWrite);
+      writeCtx.getTotalSentBytes().set(_512KiB);
+      writeCtx.getConfirmedBytes().set(_512KiB);
+
+      //noinspection resource
+      GapicBidiUnbufferedWritableByteChannel channel =
+          new GapicBidiUnbufferedWritableByteChannel(
+              storageClient.bidiWriteObjectCallable(),
+              RetryingDependencies.attemptOnce(),
+              Retrying.neverRetry(),
+              done,
+              CHUNK_SEGMENTER,
+              writeCtx,
+              GrpcCallContext::createDefault);
+
+      StorageException se = assertThrows(StorageException.class, channel::close);
+      assertAll(
+          () -> assertThat(se.getCode()).isEqualTo(0),
+          () -> assertThat(se.getReason()).isEqualTo("dataLoss"),
+          () -> assertThat(writeCtx.getConfirmedBytes().get()).isEqualTo(_512KiB),
+          () -> assertThat(channel.isOpen()).isFalse());
+    }
+  }
+
+  /**
+   *
+   *
+   * <h4>S.4</h4>
+   *
+   * Attempting to finalize an already finalized session
+   *
+   * <table>
+   *   <caption></caption>
+   *   <tr>
+   *     <td>server state</td>
+   *     <td><pre>
+   * resource = {name = obj1, size = 262144}
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>client state</td>
+   *     <td><pre>
+   * write_offset = 262144, finish = true
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>request</td>
+   *     <td><pre>
+   * BidiWriteObjectRequest{ upload_id = $UPLOAD_ID, write_offset = 262144, finish_write = true}
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>response</td>
+   *     <td><pre>
+   * onNext(BidiWriteObjectResponse{ resources = {name = obj, size = 262144 } })
+   *     </pre></td>
+   *   </tr>
+   * </table>
+   */
+  @Test
+  public void scenario4() throws Exception {
+    String uploadId = "uploadId";
+    BidiWriteObjectRequest req1 =
+        BidiWriteObjectRequest.newBuilder()
+            .setUploadId(uploadId)
+            .setWriteOffset(_256KiB)
+            .setFinishWrite(true)
+            .build();
+    BidiWriteObjectResponse resp1 =
+        BidiWriteObjectResponse.newBuilder()
+            .setResource(Object.newBuilder().setName("name").setSize(_256KiB).build())
+            .build();
+
+    ImmutableMap<List<BidiWriteObjectRequest>, BidiWriteObjectResponse> map =
+        ImmutableMap.of(ImmutableList.of(req1), resp1);
+    BidiWriteService service1 = new BidiWriteService(map);
+
+    try (FakeServer fakeServer = FakeServer.of(service1);
+        GrpcStorageImpl storage =
+            (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().getService()) {
+      StorageClient storageClient = storage.storageClient;
+
+      SettableApiFuture<BidiWriteObjectResponse> done = SettableApiFuture.create();
+      BidiResumableWrite resumableWrite = getResumableWrite(uploadId);
+      BidiWriteCtx<BidiResumableWrite> writeCtx = new BidiWriteCtx<>(resumableWrite);
+      writeCtx.getTotalSentBytes().set(_256KiB);
+      writeCtx.getConfirmedBytes().set(_256KiB);
+
+      GapicBidiUnbufferedWritableByteChannel channel =
+          new GapicBidiUnbufferedWritableByteChannel(
+              storageClient.bidiWriteObjectCallable(),
+              RetryingDependencies.attemptOnce(),
+              Retrying.neverRetry(),
+              done,
+              CHUNK_SEGMENTER,
+              writeCtx,
+              GrpcCallContext::createDefault);
+
+      channel.close();
+
+      BidiWriteObjectResponse BidiWriteObjectResponse = done.get(2, TimeUnit.SECONDS);
+      assertThat(BidiWriteObjectResponse).isEqualTo(resp1);
+    }
+  }
+
+  /**
+   *
+   *
+   * <h4>S.4.1</h4>
+   *
+   * Attempting to finalize an already finalized session (ack &lt; expected)
+   *
+   * <table>
+   *   <caption></caption>
+   *   <tr>
+   *     <td>server state</td>
+   *     <td><pre>
+   * resource = {name = obj1, size = 262144}
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>client state</td>
+   *     <td><pre>
+   * write_offset = 524288, finish = true
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>request</td>
+   *     <td><pre>
+   * BidiWriteObjectRequest{ upload_id = $UPLOAD_ID, write_offset = 524288, finish_write = true}
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>response</td>
+   *     <td><pre>
+   * onNext(BidiWriteObjectResponse{ resources = {name = obj, size = 262144 } })
+   *     </pre></td>
+   *   </tr>
+   * </table>
+   */
+  @Test
+  public void scenario4_1() throws Exception {
+    String uploadId = "uploadId";
+    BidiWriteObjectRequest req1 =
+        BidiWriteObjectRequest.newBuilder()
+            .setUploadId(uploadId)
+            .setWriteOffset(_512KiB)
+            .setFinishWrite(true)
+            .build();
+    BidiWriteObjectResponse resp1 =
+        BidiWriteObjectResponse.newBuilder()
+            .setResource(Object.newBuilder().setName("name").setSize(_256KiB).build())
+            .build();
+
+    ImmutableMap<List<BidiWriteObjectRequest>, BidiWriteObjectResponse> map =
+        ImmutableMap.of(ImmutableList.of(req1), resp1);
+    BidiWriteService service1 = new BidiWriteService(map);
+
+    try (FakeServer fakeServer = FakeServer.of(service1);
+        GrpcStorageImpl storage =
+            (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().getService()) {
+      StorageClient storageClient = storage.storageClient;
+
+      SettableApiFuture<BidiWriteObjectResponse> done = SettableApiFuture.create();
+      BidiResumableWrite resumableWrite = getResumableWrite(uploadId);
+      BidiWriteCtx<BidiResumableWrite> writeCtx = new BidiWriteCtx<>(resumableWrite);
+      writeCtx.getTotalSentBytes().set(_512KiB);
+      writeCtx.getConfirmedBytes().set(_512KiB);
+
+      //noinspection resource
+      GapicBidiUnbufferedWritableByteChannel channel =
+          new GapicBidiUnbufferedWritableByteChannel(
+              storageClient.bidiWriteObjectCallable(),
+              RetryingDependencies.attemptOnce(),
+              Retrying.neverRetry(),
+              done,
+              CHUNK_SEGMENTER,
+              writeCtx,
+              GrpcCallContext::createDefault);
+
+      StorageException se = assertThrows(StorageException.class, channel::close);
+      assertAll(
+          () -> assertThat(se.getCode()).isEqualTo(0),
+          () -> assertThat(se.getReason()).isEqualTo("dataLoss"),
+          () -> assertThat(writeCtx.getConfirmedBytes().get()).isEqualTo(_512KiB),
+          () -> assertThat(channel.isOpen()).isFalse());
+    }
+  }
+
+  /**
+   *
+   *
+   * <h4>S.4.2</h4>
+   *
+   * Attempting to finalize an already finalized session (ack > expected)
+   *
+   * <table>
+   *   <caption></caption>
+   *   <tr>
+   *     <td>server state</td>
+   *     <td><pre>
+   * resource = {name = obj1, size = 786432}
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>client state</td>
+   *     <td><pre>
+   * write_offset = 524288, finish = true
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>request</td>
+   *     <td><pre>
+   * BidiWriteObjectRequest{ upload_id = $UPLOAD_ID, write_offset = 524288, finish_write = true}
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>response</td>
+   *     <td><pre>
+   * onNext(BidiWriteObjectResponse{ resources = {name = obj, size = 786432 } })
+   *     </pre></td>
+   *   </tr>
+   * </table>
+   */
+  @Test
+  public void scenario4_2() throws Exception {
+    String uploadId = "uploadId";
+    BidiWriteObjectRequest req1 =
+        BidiWriteObjectRequest.newBuilder()
+            .setUploadId(uploadId)
+            .setWriteOffset(_512KiB)
+            .setFinishWrite(true)
+            .build();
+    BidiWriteObjectResponse resp1 =
+        BidiWriteObjectResponse.newBuilder()
+            .setResource(Object.newBuilder().setName("name").setSize(_768KiB).build())
+            .build();
+
+    ImmutableMap<List<BidiWriteObjectRequest>, BidiWriteObjectResponse> map =
+        ImmutableMap.of(ImmutableList.of(req1), resp1);
+    BidiWriteService service1 = new BidiWriteService(map);
+
+    try (FakeServer fakeServer = FakeServer.of(service1);
+        GrpcStorageImpl storage =
+            (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().getService()) {
+      StorageClient storageClient = storage.storageClient;
+
+      SettableApiFuture<BidiWriteObjectResponse> done = SettableApiFuture.create();
+      BidiResumableWrite resumableWrite = getResumableWrite(uploadId);
+      BidiWriteCtx<BidiResumableWrite> writeCtx = new BidiWriteCtx<>(resumableWrite);
+      writeCtx.getTotalSentBytes().set(_512KiB);
+      writeCtx.getConfirmedBytes().set(_512KiB);
+
+      //noinspection resource
+      GapicBidiUnbufferedWritableByteChannel channel =
+          new GapicBidiUnbufferedWritableByteChannel(
+              storageClient.bidiWriteObjectCallable(),
+              RetryingDependencies.attemptOnce(),
+              Retrying.neverRetry(),
+              done,
+              CHUNK_SEGMENTER,
+              writeCtx,
+              GrpcCallContext::createDefault);
+
+      StorageException se = assertThrows(StorageException.class, channel::close);
+      assertAll(
+          () -> assertThat(se.getCode()).isEqualTo(0),
+          () -> assertThat(se.getReason()).isEqualTo("dataLoss"),
+          () -> assertThat(writeCtx.getConfirmedBytes().get()).isEqualTo(_512KiB),
+          () -> assertThat(channel.isOpen()).isFalse());
+    }
+  }
+
+  /**
+   *
+   *
+   * <h4>S.5</h4>
+   *
+   * Attempt to append to a resumable session with an offset higher than GCS expects
+   *
+   * <table>
+   *   <caption></caption>
+   *   <tr>
+   *     <td>server state</td>
+   *     <td><pre>
+   * persisted_size = 0
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>client state</td>
+   *     <td><pre>
+   * write_offset = 262144, data = [262144:524288]
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>request</td>
+   *     <td><pre>
+   * BidiWriteObjectRequest{ upload_id = $UPLOAD_ID, write_offset = 262144, checksummed_data.content.length = 262144}
+   *     </pre></td>
+   *   </tr>
+   *   <tr>
+   *     <td>response</td>
+   *     <td><pre>
+   * onError(Status{code=OUT_OF_RANGE, description="Upload request started at offset '262144', which is past expected offset '0'."})
+   *     </pre></td>
+   *   </tr>
+   * </table>
+   */
+  @Test
+  public void scenario5() throws Exception {
+    String uploadId = "uploadId";
+    BidiWriteObjectRequest req1 =
+        BidiWriteObjectRequest.newBuilder()
+            .setUploadId(uploadId)
+            .setWriteOffset(_256KiB)
+            .setChecksummedData(
+                ChecksummedData.newBuilder()
+                    .setContent(
+                        ByteString.copyFrom(DataGenerator.base64Characters().genBytes(_256KiB))))
+            .setStateLookup(true)
+            .setFlush(true)
+            .build();
+    StorageImplBase service1 =
+        new BidiWriteService(
+            (obs, requests) -> {
+              if (requests.equals(ImmutableList.of(req1))) {
+                obs.onError(
+                    TestUtils.apiException(
+                        Code.OUT_OF_RANGE,
+                        "Upload request started at offset '262144', which is past expected offset '0'."));
+              } else {
+                obs.onError(
+                    TestUtils.apiException(Code.PERMISSION_DENIED, "Unexpected request chain."));
+              }
+            });
+    try (FakeServer fakeServer = FakeServer.of(service1);
+        GrpcStorageImpl storage =
+            (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().getService()) {
+      StorageClient storageClient = storage.storageClient;
+
+      SettableApiFuture<BidiWriteObjectResponse> done = SettableApiFuture.create();
+      BidiResumableWrite resumableWrite = getResumableWrite(uploadId);
+      BidiWriteCtx<BidiResumableWrite> writeCtx = new BidiWriteCtx<>(resumableWrite);
+      writeCtx.getTotalSentBytes().set(_256KiB);
+      writeCtx.getConfirmedBytes().set(_256KiB);
+
+      //noinspection resource
+      GapicBidiUnbufferedWritableByteChannel channel =
+          new GapicBidiUnbufferedWritableByteChannel(
+              storageClient.bidiWriteObjectCallable(),
+              RetryingDependencies.attemptOnce(),
+              Retrying.neverRetry(),
+              done,
+              CHUNK_SEGMENTER,
+              writeCtx,
+              GrpcCallContext::createDefault);
+
+      ByteBuffer bb = DataGenerator.base64Characters().genByteBuffer(_256KiB);
+      StorageException se = assertThrows(StorageException.class, () -> channel.write(bb));
+      assertAll(
+          () -> assertThat(se.getCode()).isEqualTo(0),
+          () -> assertThat(se.getReason()).isEqualTo("dataLoss"),
+          () -> assertThat(writeCtx.getConfirmedBytes().get()).isEqualTo(_256KiB),
+          () -> assertThat(channel.isOpen()).isFalse());
+    }
+  }
+
+  /**
+   *
+   *
+   * <h4>S.7</h4>
+   *
+   * GCS Acknowledges more bytes than were sent in the PUT
+   *
+   * <p>The client believes the server offset is N, it sends K bytes and the server responds that N
+   * + 2K bytes are now committed.
+   *
+   * <p>The client has detected data loss and should raise an error and prevent sending of more
+   * bytes.
+   */
+  @Test
+  public void scenario7() throws Exception {
+
+    String uploadId = "uploadId";
+    BidiWriteObjectRequest req1 =
+        BidiWriteObjectRequest.newBuilder()
+            .setUploadId(uploadId)
+            .setChecksummedData(
+                ChecksummedData.newBuilder()
+                    .setContent(
+                        ByteString.copyFrom(DataGenerator.base64Characters().genBytes(_256KiB)))
+                    .build())
+            .setStateLookup(true)
+            .setFlush(true)
+            .build();
+    BidiWriteObjectResponse resp1 =
+        BidiWriteObjectResponse.newBuilder().setPersistedSize(_512KiB).build();
+
+    ImmutableMap<List<BidiWriteObjectRequest>, BidiWriteObjectResponse> map =
+        ImmutableMap.of(ImmutableList.of(req1), resp1);
+    BidiWriteService service1 = new BidiWriteService(map);
+
+    try (FakeServer fakeServer = FakeServer.of(service1);
+        GrpcStorageImpl storage =
+            (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().getService()) {
+      StorageClient storageClient = storage.storageClient;
+
+      SettableApiFuture<BidiWriteObjectResponse> done = SettableApiFuture.create();
+      BidiResumableWrite resumableWrite = getResumableWrite(uploadId);
+      BidiWriteCtx<BidiResumableWrite> writeCtx = new BidiWriteCtx<>(resumableWrite);
+
+      //noinspection resource
+      GapicBidiUnbufferedWritableByteChannel channel =
+          new GapicBidiUnbufferedWritableByteChannel(
+              storageClient.bidiWriteObjectCallable(),
+              RetryingDependencies.attemptOnce(),
+              Retrying.neverRetry(),
+              done,
+              CHUNK_SEGMENTER,
+              writeCtx,
+              GrpcCallContext::createDefault);
+
+      ByteBuffer buf = DataGenerator.base64Characters().genByteBuffer(_256KiB);
+      StorageException se = assertThrows(StorageException.class, () -> channel.write(buf));
+      assertAll(
+          () -> assertThat(se.getCode()).isEqualTo(0),
+          () -> assertThat(se.getReason()).isEqualTo("dataLoss"),
+          () -> assertThat(writeCtx.getConfirmedBytes().get()).isEqualTo(0),
+          () -> assertThat(channel.isOpen()).isFalse());
+    }
+  }
+
+  @Test
+  public void incremental_success() throws Exception {
+    String uploadId = "uploadId";
+    BidiWriteObjectRequest req1 =
+        BidiWriteObjectRequest.newBuilder()
+            .setUploadId(uploadId)
+            .setChecksummedData(
+                ChecksummedData.newBuilder()
+                    .setContent(
+                        ByteString.copyFrom(DataGenerator.base64Characters().genBytes(_256KiB)))
+                    .build())
+            .setStateLookup(true)
+            .setFlush(true)
+            .build();
+    BidiWriteObjectResponse resp1 =
+        BidiWriteObjectResponse.newBuilder().setPersistedSize(_256KiB).build();
+
+    ImmutableMap<List<BidiWriteObjectRequest>, BidiWriteObjectResponse> map =
+        ImmutableMap.of(ImmutableList.of(req1), resp1);
+    BidiWriteService service1 = new BidiWriteService(map);
+
+    try (FakeServer fakeServer = FakeServer.of(service1);
+        GrpcStorageImpl storage =
+            (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().getService()) {
+      StorageClient storageClient = storage.storageClient;
+
+      SettableApiFuture<BidiWriteObjectResponse> done = SettableApiFuture.create();
+      BidiResumableWrite resumableWrite = getResumableWrite(uploadId);
+      BidiWriteCtx<BidiResumableWrite> writeCtx = new BidiWriteCtx<>(resumableWrite);
+
+      //noinspection resource
+      GapicBidiUnbufferedWritableByteChannel channel =
+          new GapicBidiUnbufferedWritableByteChannel(
+              storageClient.bidiWriteObjectCallable(),
+              RetryingDependencies.attemptOnce(),
+              Retrying.neverRetry(),
+              done,
+              CHUNK_SEGMENTER,
+              writeCtx,
+              GrpcCallContext::createDefault);
+
+      ByteBuffer buf = DataGenerator.base64Characters().genByteBuffer(_256KiB);
+      int written = channel.write(buf);
+      assertAll(
+          () -> assertThat(buf.remaining()).isEqualTo(0),
+          () -> assertThat(written).isEqualTo(_256KiB),
+          () -> assertThat(writeCtx.getTotalSentBytes().get()).isEqualTo(_256KiB),
+          () -> assertThat(writeCtx.getConfirmedBytes().get()).isEqualTo(_256KiB));
+    }
+  }
+
+  @Test
+  public void incremental_partialSuccess() throws Exception {
+    String uploadId = "uploadId";
+    BidiWriteObjectRequest req1 =
+        BidiWriteObjectRequest.newBuilder()
+            .setUploadId(uploadId)
+            .setChecksummedData(
+                ChecksummedData.newBuilder()
+                    .setContent(
+                        ByteString.copyFrom(DataGenerator.base64Characters().genBytes(_512KiB)))
+                    .build())
+            .setStateLookup(true)
+            .setFlush(true)
+            .build();
+    BidiWriteObjectResponse resp1 =
+        BidiWriteObjectResponse.newBuilder().setPersistedSize(_256KiB).build();
+
+    ImmutableMap<List<BidiWriteObjectRequest>, BidiWriteObjectResponse> map =
+        ImmutableMap.of(ImmutableList.of(req1), resp1);
+    BidiWriteService service1 = new BidiWriteService(map);
+
+    try (FakeServer fakeServer = FakeServer.of(service1);
+        GrpcStorageImpl storage =
+            (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().getService()) {
+      StorageClient storageClient = storage.storageClient;
+
+      SettableApiFuture<BidiWriteObjectResponse> done = SettableApiFuture.create();
+      BidiResumableWrite resumableWrite = getResumableWrite(uploadId);
+      BidiWriteCtx<BidiResumableWrite> writeCtx = new BidiWriteCtx<>(resumableWrite);
+
+      ChunkSegmenter chunkSegmenter =
+          new ChunkSegmenter(Hasher.noop(), ByteStringStrategy.copy(), _512KiB, _256KiB);
+      //noinspection resource
+      GapicBidiUnbufferedWritableByteChannel channel =
+          new GapicBidiUnbufferedWritableByteChannel(
+              storageClient.bidiWriteObjectCallable(),
+              RetryingDependencies.attemptOnce(),
+              Retrying.neverRetry(),
+              done,
+              chunkSegmenter,
+              writeCtx,
+              GrpcCallContext::createDefault);
+
+      ByteBuffer buf = DataGenerator.base64Characters().genByteBuffer(_512KiB);
+      int written = channel.write(buf);
+      assertAll(
+          () -> assertThat(buf.remaining()).isEqualTo(_256KiB),
+          () -> assertThat(written).isEqualTo(_256KiB),
+          () ->
+              assertWithMessage("totalSentBytes")
+                  .that(writeCtx.getTotalSentBytes().get())
+                  .isEqualTo(_256KiB),
+          () ->
+              assertWithMessage("confirmedBytes")
+                  .that(writeCtx.getConfirmedBytes().get())
+                  .isEqualTo(_256KiB));
+    }
+  }
+
+  private static @NonNull BidiResumableWrite getResumableWrite(String uploadId) {
+    StartResumableWriteRequest req = StartResumableWriteRequest.getDefaultInstance();
+    StartResumableWriteResponse resp =
+        StartResumableWriteResponse.newBuilder().setUploadId(uploadId).build();
+    return new BidiResumableWrite(
+        req, resp, id -> BidiWriteObjectRequest.newBuilder().setUploadId(id).build());
+  }
+
+  static class BidiWriteService extends StorageImplBase {
+    private static final Logger LOGGER =
+        Logger.getLogger(
+            ITGapicUnbufferedWritableByteChannelTest.DirectWriteService.class.getName());
+    private final BiConsumer<StreamObserver<BidiWriteObjectResponse>, List<BidiWriteObjectRequest>>
+        c;
+
+    private ImmutableList.Builder<BidiWriteObjectRequest> requests;
+
+    BidiWriteService(
+        BiConsumer<StreamObserver<BidiWriteObjectResponse>, List<BidiWriteObjectRequest>> c) {
+      this.c = c;
+      this.requests = new ImmutableList.Builder<>();
+    }
+
+    BidiWriteService(ImmutableMap<List<BidiWriteObjectRequest>, BidiWriteObjectResponse> writes) {
+      this(
+          (obs, build) -> {
+            if (writes.containsKey(build)) {
+              obs.onNext(writes.get(build));
+              last(build)
+                  .filter(BidiWriteObjectRequest::getFinishWrite)
+                  .ifPresent(ignore -> obs.onCompleted());
+            } else {
+              logUnexpectedRequest(writes.keySet(), build);
+              obs.onError(
+                  TestUtils.apiException(Code.PERMISSION_DENIED, "Unexpected request chain."));
+            }
+          });
+    }
+
+    private static <T> Optional<T> last(List<T> l) {
+      if (l.isEmpty()) {
+        return Optional.empty();
+      } else {
+        return Optional.of(l.get(l.size() - 1));
+      }
+    }
+
+    private static void logUnexpectedRequest(
+        Set<List<BidiWriteObjectRequest>> writes, List<BidiWriteObjectRequest> build) {
+      Collector<CharSequence, ?, String> joining = Collectors.joining(",\n\t", "[\n\t", "\n]");
+      Collector<CharSequence, ?, String> oneLine = Collectors.joining(",", "[", "]");
+      String msg =
+          String.format(
+              "Unexpected Request Chain.%nexpected one of: %s%n        but was: %s",
+              writes.stream()
+                  .map(l -> l.stream().map(StorageV2ProtoUtils::fmtProto).collect(oneLine))
+                  .collect(joining),
+              build.stream().map(StorageV2ProtoUtils::fmtProto).collect(oneLine));
+      LOGGER.warning(msg);
+    }
+
+    @Override
+    public StreamObserver<BidiWriteObjectRequest> bidiWriteObject(
+        StreamObserver<BidiWriteObjectResponse> obs) {
+      return new Adapter() {
+        @Override
+        public void onNext(BidiWriteObjectRequest value) {
+          requests.add(value);
+          if ((value.getFlush() && value.getStateLookup()) || value.getFinishWrite()) {
+            ImmutableList<BidiWriteObjectRequest> build = requests.build();
+            c.accept(obs, build);
+          }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+          requests = new ImmutableList.Builder<>();
+        }
+
+        @Override
+        public void onCompleted() {
+          requests = new ImmutableList.Builder<>();
+        }
+      };
+    }
+  }
+
+  private abstract static class Adapter extends CallStreamObserver<BidiWriteObjectRequest> {
+
+    private Adapter() {}
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public void setOnReadyHandler(Runnable onReadyHandler) {}
+
+    @Override
+    public void disableAutoInboundFlowControl() {}
+
+    @Override
+    public void request(int count) {}
+
+    @Override
+    public void setMessageCompression(boolean enable) {}
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/GrpcPlainRequestLoggingInterceptor.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/GrpcPlainRequestLoggingInterceptor.java
@@ -20,6 +20,7 @@ import com.google.api.gax.grpc.GrpcInterceptorProvider;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.MessageOrBuilder;
+import com.google.storage.v2.BidiWriteObjectRequest;
 import com.google.storage.v2.WriteObjectRequest;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -109,6 +110,8 @@ public final class GrpcPlainRequestLoggingInterceptor implements ClientIntercept
   static String fmtProto(@NonNull Object obj) {
     if (obj instanceof WriteObjectRequest) {
       return fmtProto((WriteObjectRequest) obj);
+    } else if (obj instanceof BidiWriteObjectRequest) {
+      return fmtProto((BidiWriteObjectRequest) obj);
     } else if (obj instanceof MessageOrBuilder) {
       return fmtProto((MessageOrBuilder) obj);
     } else {
@@ -127,6 +130,22 @@ public final class GrpcPlainRequestLoggingInterceptor implements ClientIntercept
       ByteString content = msg.getChecksummedData().getContent();
       if (content.size() > 20) {
         WriteObjectRequest.Builder b = msg.toBuilder();
+        ByteString snip = ByteString.copyFromUtf8(String.format("<snip (%d)>", content.size()));
+        ByteString trim = content.substring(0, 20).concat(snip);
+        b.getChecksummedDataBuilder().setContent(trim);
+
+        return b.build().toString();
+      }
+    }
+    return msg.toString();
+  }
+
+  @NonNull
+  static String fmtProto(@NonNull BidiWriteObjectRequest msg) {
+    if (msg.hasChecksummedData()) {
+      ByteString content = msg.getChecksummedData().getContent();
+      if (content.size() > 20) {
+        BidiWriteObjectRequest.Builder b = msg.toBuilder();
         ByteString snip = ByteString.copyFromUtf8(String.format("<snip (%d)>", content.size()));
         ByteString trim = content.substring(0, 20).concat(snip);
         b.getChecksummedDataBuilder().setContent(trim);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/GrpcPlainRequestLoggingInterceptor.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/GrpcPlainRequestLoggingInterceptor.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.MessageOrBuilder;
 import com.google.storage.v2.BidiWriteObjectRequest;
+import com.google.storage.v2.ReadObjectResponse;
 import com.google.storage.v2.WriteObjectRequest;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -112,6 +113,8 @@ public final class GrpcPlainRequestLoggingInterceptor implements ClientIntercept
       return fmtProto((WriteObjectRequest) obj);
     } else if (obj instanceof BidiWriteObjectRequest) {
       return fmtProto((BidiWriteObjectRequest) obj);
+    } else if (obj instanceof ReadObjectResponse) {
+      return fmtProto((ReadObjectResponse) obj);
     } else if (obj instanceof MessageOrBuilder) {
       return fmtProto((MessageOrBuilder) obj);
     } else {
@@ -146,6 +149,22 @@ public final class GrpcPlainRequestLoggingInterceptor implements ClientIntercept
       ByteString content = msg.getChecksummedData().getContent();
       if (content.size() > 20) {
         BidiWriteObjectRequest.Builder b = msg.toBuilder();
+        ByteString snip = ByteString.copyFromUtf8(String.format("<snip (%d)>", content.size()));
+        ByteString trim = content.substring(0, 20).concat(snip);
+        b.getChecksummedDataBuilder().setContent(trim);
+
+        return b.build().toString();
+      }
+    }
+    return msg.toString();
+  }
+
+  @NonNull
+  static String fmtProto(@NonNull ReadObjectResponse msg) {
+    if (msg.hasChecksummedData()) {
+      ByteString content = msg.getChecksummedData().getContent();
+      if (content.size() > 20) {
+        ReadObjectResponse.Builder b = msg.toBuilder();
         ByteString snip = ByteString.copyFromUtf8(String.format("<snip (%d)>", content.size()));
         ByteString trim = content.substring(0, 20).concat(snip);
         b.getChecksummedDataBuilder().setContent(trim);


### PR DESCRIPTION
Follow up to #2527 and #2514

The tests added in this PR account for ~940 of the added lines, however their scenarios are the same as the other upload scenario tests just using the different proto types. The remaining ~300 lines are the fix and small refactor to get the tests passing. I've left individual commits in the PR to make it easier to drill down if needed.


* Part 1, add tests and simulation server
  * Tests are a port of those added in #2527 using BidiWriteObjectRequest and BidiWriteObjectResponse
  * simulation server is a port of com.google.cloud.storage.ITGapicUnbufferedWritableByteChannelTest.DirectWriteService using BidiWriteObjectRequest and BidiWriteObjectResponse

* Cleanup unused inner-class

* Move request trimming inline rather than at the end

* Update GapicBidiUnbufferedWritableByteChannel to correctly handle failure scenarios {1, 2, 3, 4, 4_1, 4_2, 5, 7}
    
  Refactor ResumableSessionFailureScenario to accept Message and List rather than WriteObjectResponse and List<WriteObjectRequest>.
    
  The shape of BidiWriteObjectRequest/WriteObjectRequest and BidiWriteObjectResponse/WriteObjectResponse are largely the same (bidi has two extra fields) so rather than overloading toStorageException yet again, this time there is a single method for grpc messages that internally can branch when formatting the request. In this case, we're quite safe taking this relaxed typing because it is an internal API that is only called from a grpc context where protos will be used.

* Update GapicBidiUnbufferedWritableByteChannel to correctly handle partial consumption of content
    
  Tests passing now.
    
  Separate tracking of client detected errors and stream errors.
    
  When await is invoked, if a client detected error is present AND a stream error is present, the client detected error will take precedence. If a stream error happens and the client detected error has not yet been observed, the stream error will be added as a suppressed exception to the client detected error.