### PR TITLE
chore: update renovate config to apply grouping to recently added dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,6 +46,7 @@
       "semanticCommitScope": null
     },
     {
+      "groupName": "maven plugins",
       "packagePatterns": [
         "^org.apache.maven",
         "^org.jacoco:",
@@ -58,8 +59,15 @@
       "semanticCommitScope": "deps"
     },
     {
+      "groupName": "storage release dependencies",
       "packagePatterns": [
         "^com.google.cloud:google-cloud-storage",
+        "^com.google.api.grpc:proto-google-cloud-storage-v2",
+        "^com.google.api.grpc:grpc-google-cloud-storage-v2",
+        "^com.google.api.grpc:gapic-google-cloud-storage-v2",
+        "^com.google.api.grpc:proto-google-cloud-storage-control-v2",
+        "^com.google.api.grpc:grpc-google-cloud-storage-control-v2",
+        "^com.google.cloud:google-cloud-storage-control",
         "^com.google.cloud:libraries-bom",
         "^com.google.cloud.samples:shared-configuration"
       ],
@@ -67,8 +75,11 @@
       "semanticCommitScope": "deps"
     },
     {
+      "groupName": "test libraries",
       "packagePatterns": [
         "^junit:junit",
+        "^org.junit",
+        "^net.jqwik",
         "^com.google.truth:truth",
         "^org.mockito:mockito-core",
         "^org.objenesis:objenesis",


### PR DESCRIPTION
Renovate will open individual PRs for mutli-module projects where we depend on multiple artifacts. In an effort to make reviews of these PRs simpler, and to reduce CI compute time group them together.


