### PR TITLE
chore: remove OwlBot required status check from sync-repo-settings.yaml

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -15,7 +15,6 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - OwlBot Post Processor
       - 'Kokoro - Test: Java GraalVM Native Image'
       - 'Kokoro - Test: Java 17 GraalVM Native Image'
       - javadoc


### PR DESCRIPTION
Follow up to https://github.com/googleapis/java-storage/pull/2566 that disabled owlbot in favor of hermetic generator