### PR TITLE
fix: update grpc resumable upload error categorization to be more tolerant

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedFinalizeOnCloseResumableWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedFinalizeOnCloseResumableWritableByteChannel.java
@@ -17,6 +17,7 @@
 package com.google.cloud.storage;
 
 import static com.google.cloud.storage.GrpcUtils.contextWithBucketName;
+import static com.google.cloud.storage.Utils.nullSafeList;
 
 import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.grpc.GrpcCallContext;
@@ -26,7 +27,6 @@ import com.google.api.gax.rpc.ClientStreamingCallable;
 import com.google.cloud.storage.ChunkSegmenter.ChunkSegment;
 import com.google.cloud.storage.Crc32cValue.Crc32cLengthKnown;
 import com.google.cloud.storage.UnbufferedWritableByteChannelSession.UnbufferedWritableByteChannel;
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import com.google.storage.v2.ChecksummedData;
 import com.google.storage.v2.ObjectChecksums;
@@ -230,7 +230,7 @@ final class GapicUnbufferedFinalizeOnCloseResumableWritableByteChannel
                 tmp.getCode(),
                 tmp.getMessage(),
                 tmp.getReason(),
-                ImmutableList.of(lastWrittenRequest),
+                nullSafeList(lastWrittenRequest),
                 null,
                 context,
                 t);
@@ -251,7 +251,7 @@ final class GapicUnbufferedFinalizeOnCloseResumableWritableByteChannel
                 0,
                 "onComplete without preceding onNext, unable to determine success.",
                 "invalid",
-                ImmutableList.of(lastWrittenRequest),
+                nullSafeList(lastWrittenRequest),
                 null,
                 context,
                 null));
@@ -263,11 +263,11 @@ final class GapicUnbufferedFinalizeOnCloseResumableWritableByteChannel
         } else if (finalSize < totalSentBytes) {
           clientDetectedError(
               ResumableSessionFailureScenario.SCENARIO_4_1.toStorageException(
-                  ImmutableList.of(lastWrittenRequest), last, context, null));
+                  nullSafeList(lastWrittenRequest), last, context, null));
         } else {
           clientDetectedError(
               ResumableSessionFailureScenario.SCENARIO_4_2.toStorageException(
-                  ImmutableList.of(lastWrittenRequest), last, context, null));
+                  nullSafeList(lastWrittenRequest), last, context, null));
         }
       } else if (!finalizing || last.hasPersistedSize()) { // unexpected incremental response
         clientDetectedError(
@@ -275,14 +275,14 @@ final class GapicUnbufferedFinalizeOnCloseResumableWritableByteChannel
                 0,
                 "Unexpected incremental response for finalizing request.",
                 "invalid",
-                ImmutableList.of(lastWrittenRequest),
+                nullSafeList(lastWrittenRequest),
                 last,
                 context,
                 null));
       } else {
         clientDetectedError(
             ResumableSessionFailureScenario.SCENARIO_0.toStorageException(
-                ImmutableList.of(lastWrittenRequest), last, context, null));
+                nullSafeList(lastWrittenRequest), last, context, null));
       }
     }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableSessionFailureScenario.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableSessionFailureScenario.java
@@ -169,6 +169,9 @@ enum ResumableSessionFailureScenario {
     Map<String, List<String>> extraHeaders = context.getExtraHeaders();
     recordHeadersTo(extraHeaders, PREFIX_O, sb);
     int length = reqs.size();
+    if (length == 0) {
+      sb.append("\n").append(PREFIX_O).append("[]");
+    }
     for (int i = 0; i < length; i++) {
       if (i == 0) {
         sb.append("\n").append(PREFIX_O).append("[");

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Utils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Utils.java
@@ -25,6 +25,7 @@ import com.google.api.gax.rpc.ApiCallContext;
 import com.google.cloud.storage.Conversions.Codec;
 import com.google.cloud.storage.UnifiedOpts.NamedField;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import com.google.common.io.BaseEncoding;
@@ -309,5 +310,13 @@ final class Utils {
   @NonNull
   static GrpcCallContext merge(@NonNull GrpcCallContext l, @NonNull GrpcCallContext r) {
     return (GrpcCallContext) l.merge(r);
+  }
+
+  static <T> ImmutableList<T> nullSafeList(@Nullable T t) {
+    if (t == null) {
+      return ImmutableList.of();
+    } else {
+      return ImmutableList.of(t);
+    }
   }
 }


### PR DESCRIPTION
When a client is shutting down, the Channel pool will deliver an error to our stream observer. This could happen before we are able to actually write a message. Update GapicUnbufferedFinalizeOnCloseResumableWritableByteChannel to not attempt to pass null to ImmutableList.of().

Sample exception
```
java.lang.NullPointerException
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:906)
	at com.google.common.collect.SingletonImmutableList.<init>(SingletonImmutableList.java:41)
	at com.google.common.collect.ImmutableList.of(ImmutableList.java:101)
	at com.google.cloud.storage.GapicUnbufferedFinalizeOnCloseResumableWritableByteChannel$Observer.onError(GapicUnbufferedFinalizeOnCloseResumableWritableByteChannel.java:233)
	at com.google.api.gax.tracing.TracedClientStreamingCallable$TracedResponseObserver.onError(TracedClientStreamingCallable.java:167)
	at com.google.api.gax.grpc.GrpcExceptionTranslatingStreamObserver.onError(GrpcExceptionTranslatingStreamObserver.java:60)
	at com.google.api.gax.grpc.ApiStreamObserverDelegate.onError(ApiStreamObserverDelegate.java:55)
	at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:481)
	at io.grpc.PartialForwardingClientCallListener.onClose(PartialForwardingClientCallListener.java:39)
	at io.grpc.ForwardingClientCallListener.onClose(ForwardingClientCallListener.java:23)
	at io.grpc.ForwardingClientCallListener$SimpleForwardingClientCallListener.onClose(ForwardingClientCallListener.java:40)
	at com.google.api.gax.grpc.ChannelPool$ReleasingClientCall$1.onClose(ChannelPool.java:570)
```