### PR TITLE
test: Turn DirectPath quickstart test back on and fix abandoned storage instance in GRPC test

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
@@ -258,5 +258,6 @@ public final class ITGrpcTest {
         () ->
             assertThat(
                 storage.getOptions().getHost().equals("https://storage.my-universe-domain.com")));
+    storage.close();
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
@@ -251,13 +251,11 @@ public final class ITGrpcTest {
 
   @Test
   public void testGrpcUniverseDomainMatchesHost() throws Exception {
-    Storage storage =
-        StorageOptions.grpc().setUniverseDomain("my-universe-domain.com").build().getService();
+    StorageOptions storageOptions =
+        StorageOptions.grpc().setUniverseDomain("my-universe-domain.com").build();
     assertAll(
-        () -> assertThat(storage.getOptions().getUniverseDomain().equals("my-universe-domain.com")),
+        () -> assertThat(storageOptions.getUniverseDomain().equals("my-universe-domain.com")),
         () ->
-            assertThat(
-                storage.getOptions().getHost().equals("https://storage.my-universe-domain.com")));
-    storage.close();
+            assertThat(storageOptions.getHost().equals("https://storage.my-universe-domain.com")));
   }
 }

--- a/samples/snippets/src/test/java/com/example/storage/QuickstartSampleIT.java
+++ b/samples/snippets/src/test/java/com/example/storage/QuickstartSampleIT.java
@@ -70,7 +70,6 @@ public class QuickstartSampleIT {
     assertThat(got).contains(String.format("Bucket %s created.", bucketName));
   }
 
-  @Ignore("https://github.com/googleapis/java-storage/issues/2612")
   @Test
   public void testQuickstartGrpcDp() throws Exception {
     QuickstartGrpcDpSample.main(bucketName);


### PR DESCRIPTION
Closing instance of storage that gets abandoned and then eventually cleaned up which results in a long error message that pollutes the logs

Fixes issue #2612 



