### PR TITLE
chore: fix samples pom.xml issues

### DIFF
--- a/samples/install-without-bom/pom.xml
+++ b/samples/install-without-bom/pom.xml
@@ -30,12 +30,12 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>2.40.1</version>
+      <version>2.41.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage-control</artifactId>
-      <version>2.41.0</version><!-- {x-version-update:google-cloud-storage:current} -->
+      <version>2.41.0</version>
     </dependency>
     <!-- [END storage_install_without_bom] -->
 
@@ -68,12 +68,6 @@
       <artifactId>google-cloud-pubsub</artifactId>
       <version>1.131.0</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-storage-control</artifactId>
-      <version>2.40.1</version>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
 

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -79,5 +79,7 @@
       <version>1.131.0</version>
       <scope>test</scope>
     </dependency>
+  <!-- [START storage_install_with_bom] -->
   </dependencies>
+  <!-- [END storage_install_with_bom] -->
 </project>


### PR DESCRIPTION
* Close `dependencies` element for `storage_install_with_bom`
* Remove release please comment for storage control from `storage_install_without_bom`. Instead, allow renovate-bot to update when the version is available in maven central.
* remove duplicate declaration of `google-cloud-storage-control` in install-without-bom/pom.xml

