### PR TITLE
chore: remove unused image tag in .OwlBot-hermetic.yaml

### DIFF
--- a/.github/.OwlBot-hermetic.yaml
+++ b/.github/.OwlBot-hermetic.yaml
@@ -11,10 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-docker:
-  image: "gcr.io/cloud-devrel-public-resources/owlbot-java:latest"
-
 deep-preserve-regex:
 - "/google-.*/src/test/java/com/google/storage/control/v2/ITFoldersTest.java"
 


### PR DESCRIPTION
This removes the unused image tag in this file. Part of the cleanup after enabling Hermetic Library generation in this repo.
