### PR TITLE
fix: update grpc based ReadObject rpcs to remove race condition between cancellation and message handling

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedReadableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedReadableByteChannel.java
@@ -19,38 +19,52 @@ package com.google.cloud.storage;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.SettableApiFuture;
-import com.google.api.gax.rpc.ServerStream;
+import com.google.api.gax.retrying.ResultRetryAlgorithm;
+import com.google.api.gax.rpc.ApiExceptions;
 import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StateCheckingResponseObserver;
+import com.google.api.gax.rpc.StreamController;
+import com.google.cloud.BaseServiceException;
+import com.google.cloud.storage.Conversions.Decoder;
 import com.google.cloud.storage.Crc32cValue.Crc32cLengthKnown;
+import com.google.cloud.storage.Retrying.RetryingDependencies;
 import com.google.cloud.storage.UnbufferedReadableByteChannelSession.UnbufferedReadableByteChannel;
 import com.google.protobuf.ByteString;
 import com.google.storage.v2.ChecksummedData;
 import com.google.storage.v2.Object;
 import com.google.storage.v2.ReadObjectRequest;
 import com.google.storage.v2.ReadObjectResponse;
-import java.io.Closeable;
+import io.grpc.Status.Code;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ScatteringByteChannel;
-import java.util.Iterator;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicLong;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 final class GapicUnbufferedReadableByteChannel
     implements UnbufferedReadableByteChannel, ScatteringByteChannel {
+  private static final java.lang.Object EOF_MARKER = new java.lang.Object();
 
   private final SettableApiFuture<Object> result;
   private final ServerStreamingCallable<ReadObjectRequest, ReadObjectResponse> read;
   private final ReadObjectRequest req;
   private final Hasher hasher;
-  private final LazyServerStreamIterator iter;
   private final ResponseContentLifecycleManager rclm;
+  private final RetryingDependencies retryingDeps;
+  private final ResultRetryAlgorithm<?> alg;
+  private final SimpleBlockingQueue<java.lang.Object> queue;
 
-  private boolean open = true;
-  private boolean complete = false;
+  private final AtomicLong fetchOffset;
+  private volatile ReadObjectObserver readObjectObserver;
+  private volatile boolean open = true;
+  private volatile boolean complete = false;
+
   private long blobOffset;
-
   private Object metadata;
-
   private ResponseContentLifecycleHandle leftovers;
 
   GapicUnbufferedReadableByteChannel(
@@ -58,14 +72,21 @@ final class GapicUnbufferedReadableByteChannel
       ServerStreamingCallable<ReadObjectRequest, ReadObjectResponse> read,
       ReadObjectRequest req,
       Hasher hasher,
+      RetryingDependencies retryingDependencies,
+      ResultRetryAlgorithm<?> alg,
       ResponseContentLifecycleManager rclm) {
     this.result = result;
     this.read = read;
     this.req = req;
     this.hasher = hasher;
+    this.fetchOffset = new AtomicLong(req.getReadOffset());
     this.blobOffset = req.getReadOffset();
     this.rclm = rclm;
-    this.iter = new LazyServerStreamIterator();
+    this.retryingDeps = retryingDependencies;
+    this.alg = alg;
+    // The reasoning for 2 elements below allow for a single response and the EOF/error signal
+    // from onComplete or onError. Same thing com.google.api.gax.rpc.QueuingResponseObserver does.
+    this.queue = new SimpleBlockingQueue<>(2);
   }
 
   @Override
@@ -90,47 +111,65 @@ final class GapicUnbufferedReadableByteChannel
         continue;
       }
 
-      if (iter.hasNext()) {
-        ReadObjectResponse resp = iter.next();
-        ResponseContentLifecycleHandle handle = rclm.get(resp);
-        if (resp.hasMetadata()) {
-          Object respMetadata = resp.getMetadata();
-          if (metadata == null) {
-            metadata = respMetadata;
-          } else if (metadata.getGeneration() != respMetadata.getGeneration()) {
-            throw closeWithError(
-                String.format(
-                    "Mismatch Generation between subsequent reads. Expected %d but received %d",
-                    metadata.getGeneration(), respMetadata.getGeneration()));
-          }
-
-          if (!result.isDone()) {
-            result.set(metadata);
-          }
+      ensureStreamOpen();
+      java.lang.Object take;
+      try {
+        take = queue.poll();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new InterruptedIOException();
+      }
+      if (take instanceof Throwable) {
+        Throwable throwable = (Throwable) take;
+        BaseServiceException coalesce = StorageException.coalesce(throwable);
+        if (alg.shouldRetry(coalesce, null)) {
+          readObjectObserver = null;
+          continue;
         }
-        ChecksummedData checksummedData = resp.getChecksummedData();
-        ByteString content = checksummedData.getContent();
-        int contentSize = content.size();
-        // Very important to know whether a crc32c value is set. Without checking, protobuf will
-        // happily return 0, which is a valid crc32c value.
-        if (checksummedData.hasCrc32C()) {
-          Crc32cLengthKnown expected = Crc32cValue.of(checksummedData.getCrc32C(), contentSize);
-          try {
-            hasher.validate(expected, content.asReadOnlyByteBufferList());
-          } catch (IOException e) {
-            close();
-            throw e;
-          }
-        }
-        handle.copy(c, dsts, offset, length);
-        if (handle.hasRemaining()) {
-          leftovers = handle;
-        } else {
-          handle.close();
-        }
-      } else {
+        throw coalesce;
+      }
+      if (take == EOF_MARKER) {
         complete = true;
         break;
+      }
+      readObjectObserver.request();
+
+      ReadObjectResponse resp = (ReadObjectResponse) take;
+      ResponseContentLifecycleHandle handle = rclm.get(resp);
+      if (resp.hasMetadata()) {
+        Object respMetadata = resp.getMetadata();
+        if (metadata == null) {
+          metadata = respMetadata;
+        } else if (metadata.getGeneration() != respMetadata.getGeneration()) {
+          throw closeWithError(
+              String.format(
+                  "Mismatch Generation between subsequent reads. Expected %d but received %d",
+                  metadata.getGeneration(), respMetadata.getGeneration()));
+        }
+
+        if (!result.isDone()) {
+          result.set(metadata);
+        }
+      }
+      ChecksummedData checksummedData = resp.getChecksummedData();
+      ByteString content = checksummedData.getContent();
+      int contentSize = content.size();
+      // Very important to know whether a crc32c value is set. Without checking, protobuf will
+      // happily return 0, which is a valid crc32c value.
+      if (checksummedData.hasCrc32C()) {
+        Crc32cLengthKnown expected = Crc32cValue.of(checksummedData.getCrc32C(), contentSize);
+        try {
+          hasher.validate(expected, content.asReadOnlyByteBufferList());
+        } catch (IOException e) {
+          close();
+          throw e;
+        }
+      }
+      handle.copy(c, dsts, offset, length);
+      if (handle.hasRemaining()) {
+        leftovers = handle;
+      } else {
+        handle.close();
       }
     }
     long read = c.read();
@@ -153,12 +192,71 @@ final class GapicUnbufferedReadableByteChannel
         leftovers.close();
       }
     } finally {
-      iter.close();
+      ReadObjectObserver obs = readObjectObserver;
+      if (obs != null && !obs.cancellation.isDone()) {
+        obs.cancel();
+        drainQueue();
+        ApiExceptions.callAndTranslateApiException(obs.cancellation);
+      }
+      drainQueue();
+    }
+  }
+
+  private void drainQueue() throws IOException {
+    IOException ioException = null;
+    while (queue.nonEmpty()) {
+      try {
+        java.lang.Object queueValue = queue.poll();
+        if (queueValue instanceof ReadObjectResponse) {
+          ReadObjectResponse resp = (ReadObjectResponse) queueValue;
+          ResponseContentLifecycleHandle handle = rclm.get(resp);
+          handle.close();
+        } else if (queueValue == EOF_MARKER || queueValue instanceof Throwable) {
+          break;
+        }
+      } catch (IOException e) {
+        if (ioException == null) {
+          ioException = e;
+        } else if (ioException != e) {
+          ioException.addSuppressed(e);
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        if (ioException == null) {
+          ioException = new InterruptedIOException();
+        } else {
+          ioException.addSuppressed(e);
+        }
+      }
+    }
+    if (ioException != null) {
+      throw ioException;
     }
   }
 
   ApiFuture<Object> getResult() {
     return result;
+  }
+
+  private void ensureStreamOpen() {
+    if (readObjectObserver == null) {
+      readObjectObserver =
+          Retrying.run(
+              retryingDeps,
+              alg,
+              () -> {
+                ReadObjectObserver tmp = new ReadObjectObserver();
+                ReadObjectRequest request = req;
+                long currentFetchOffset = fetchOffset.get();
+                if (request.getReadOffset() != currentFetchOffset) {
+                  request = req.toBuilder().setReadOffset(currentFetchOffset).build();
+                }
+                read.call(request, tmp);
+                ApiExceptions.callAndTranslateApiException(tmp.open);
+                return tmp;
+              },
+              Decoder.identity());
+    }
   }
 
   private IOException closeWithError(String message) throws IOException {
@@ -168,83 +266,89 @@ final class GapicUnbufferedReadableByteChannel
     throw new IOException(message, cause);
   }
 
-  private final class LazyServerStreamIterator implements Iterator<ReadObjectResponse>, Closeable {
-    private ServerStream<ReadObjectResponse> serverStream;
-    private Iterator<ReadObjectResponse> responseIterator;
+  private final class ReadObjectObserver extends StateCheckingResponseObserver<ReadObjectResponse> {
 
-    private volatile boolean streamInitialized = false;
+    private final SettableApiFuture<Void> open = SettableApiFuture.create();
+    private final SettableApiFuture<Throwable> cancellation = SettableApiFuture.create();
+
+    private volatile StreamController controller;
+
+    void request() {
+      controller.request(1);
+    }
+
+    void cancel() {
+      controller.cancel();
+    }
 
     @Override
-    public boolean hasNext() {
+    protected void onStartImpl(StreamController controller) {
+      this.controller = controller;
+      controller.disableAutoInboundFlowControl();
+      controller.request(1);
+    }
+
+    @Override
+    protected void onResponseImpl(ReadObjectResponse response) {
       try {
-        return ensureResponseIteratorOpen().hasNext();
-      } catch (RuntimeException e) {
-        if (!result.isDone()) {
-          result.setException(StorageException.coalesce(e));
-        }
-        reset();
-        throw e;
+        open.set(null);
+        queue.offer(response);
+        fetchOffset.addAndGet(response.getChecksummedData().getContent().size());
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw Code.ABORTED.toStatus().withCause(e).asRuntimeException();
       }
     }
 
     @Override
-    public ReadObjectResponse next() {
+    protected void onErrorImpl(Throwable t) {
+      open.setException(t);
+      if (t instanceof CancellationException) {
+        cancellation.set(t);
+      }
       try {
-        return ensureResponseIteratorOpen().next();
-      } catch (RuntimeException e) {
-        if (!result.isDone()) {
-          result.setException(StorageException.coalesce(e));
-        }
-        reset();
-        throw e;
+        queue.offer(t);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw Code.ABORTED.toStatus().withCause(e).asRuntimeException();
       }
     }
 
     @Override
-    public void close() {
-      if (serverStream != null) {
-        serverStream.cancel();
-        if (responseIterator != null) {
-          IOException ioException = null;
-          while (responseIterator.hasNext()) {
-            try {
-              ReadObjectResponse next = responseIterator.next();
-              ResponseContentLifecycleHandle handle = rclm.get(next);
-              handle.close();
-            } catch (IOException e) {
-              if (ioException == null) {
-                ioException = e;
-              } else if (ioException != e) {
-                ioException.addSuppressed(e);
-              }
-            }
-          }
-        }
+    protected void onCompleteImpl() {
+      try {
+        cancellation.set(null);
+        queue.offer(EOF_MARKER);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw Code.ABORTED.toStatus().withCause(e).asRuntimeException();
       }
     }
+  }
 
-    private Iterator<ReadObjectResponse> ensureResponseIteratorOpen() {
-      boolean initialized = streamInitialized;
-      if (initialized) {
-        return responseIterator;
-      } else {
-        synchronized (this) {
-          if (!streamInitialized) {
-            if (serverStream == null) {
-              serverStream = read.call(req);
-            }
-            responseIterator = serverStream.iterator();
-            streamInitialized = true;
-          }
-          return responseIterator;
-        }
-      }
+  /**
+   * Simplified wrapper around an {@link java.util.concurrent.ArrayBlockingQueue}. We don't need the
+   * majority of methods/functionality just blocking offer/poll.
+   */
+  static final class SimpleBlockingQueue<T> {
+
+    private final ArrayBlockingQueue<T> queue;
+
+    SimpleBlockingQueue(int poolMaxSize) {
+      this.queue = new ArrayBlockingQueue<>(poolMaxSize);
     }
 
-    private void reset() {
-      serverStream = null;
-      responseIterator = null;
-      streamInitialized = false;
+    public boolean nonEmpty() {
+      return !queue.isEmpty();
+    }
+
+    @NonNull
+    public T poll() throws InterruptedException {
+      return queue.take();
+    }
+
+    public void offer(@NonNull T element) throws InterruptedException {
+      queue.put(element);
     }
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -749,6 +749,8 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
 
     return new GrpcBlobReadChannel(
         storageClient.readObjectCallable().withDefaultCallContext(grpcCallContext),
+        getOptions(),
+        retryAlgorithmManager.getFor(request),
         responseContentLifecycleManager,
         request,
         !opts.autoGzipDecompression());
@@ -1910,6 +1912,8 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
         .read()
         .byteChannel(
             storageClient.readObjectCallable().withDefaultCallContext(grpcCallContext),
+            getOptions(),
+            retryAlgorithmManager.getFor(readObjectRequest),
             responseContentLifecycleManager)
         .setAutoGzipDecompression(!opts.autoGzipDecompression())
         .unbuffered()

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
@@ -330,9 +330,7 @@ public final class GrpcStorageOptions extends StorageOptions
         .startResumableWriteSettings()
         .setRetrySettings(baseRetrySettings)
         .setRetryableCodes(startResumableWriteRetryableCodes);
-    // for ReadObject we are configuring the server stream handling to do its own retries, so wire
-    // things through. Retryable codes will be controlled closer to the use site as idempotency
-    // considerations need to be made.
+    // for ReadObject disable retries and move the total timeout to the idle timeout
     builder
         .readObjectSettings()
         .setRetrySettings(readRetrySettings)

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicUnbufferedReadableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicUnbufferedReadableByteChannelTest.java
@@ -128,6 +128,8 @@ public final class ITGapicUnbufferedReadableByteChannelTest {
                               contextWithRetryForCodes(StatusCode.Code.DATA_LOSS)),
                       start,
                       Hasher.noop(),
+                      server.getGrpcStorageOptions(),
+                      StorageRetryStrategy.getDefaultStorageRetryStrategy().getIdempotentHandler(),
                       ResponseContentLifecycleManager.noop()));
       byte[] actualBytes = new byte[40];
       try (UnbufferedReadableByteChannel c = session.open()) {
@@ -157,6 +159,8 @@ public final class ITGapicUnbufferedReadableByteChannelTest {
                               contextWithRetryForCodes(StatusCode.Code.DATA_LOSS)),
                       start,
                       Hasher.noop(),
+                      server.getGrpcStorageOptions(),
+                      StorageRetryStrategy.getDefaultStorageRetryStrategy().getIdempotentHandler(),
                       ResponseContentLifecycleManager.noop()));
       byte[] actualBytes = new byte[40];
       ImmutableList<ByteBuffer> buffers = TestUtils.subDivide(actualBytes, 2);
@@ -216,6 +220,8 @@ public final class ITGapicUnbufferedReadableByteChannelTest {
                               contextWithRetryForCodes(StatusCode.Code.DATA_LOSS)),
                       start,
                       Hasher.noop(),
+                      server.getGrpcStorageOptions(),
+                      StorageRetryStrategy.getDefaultStorageRetryStrategy().getIdempotentHandler(),
                       ResponseContentLifecycleManager.noop()));
       byte[] actualBytes = new byte[40];
       try (UnbufferedReadableByteChannel c = session.open()) {
@@ -264,6 +270,8 @@ public final class ITGapicUnbufferedReadableByteChannelTest {
                               contextWithRetryForCodes(StatusCode.Code.DATA_LOSS)),
                       start,
                       Hasher.enabled(),
+                      server.getGrpcStorageOptions(),
+                      StorageRetryStrategy.getDefaultStorageRetryStrategy().getIdempotentHandler(),
                       ResponseContentLifecycleManager.noop()));
       byte[] actualBytes = new byte[40];
       try (UnbufferedReadableByteChannel c = session.open()) {
@@ -304,6 +312,8 @@ public final class ITGapicUnbufferedReadableByteChannelTest {
                               contextWithRetryForCodes(StatusCode.Code.DATA_LOSS)),
                       start,
                       Hasher.enabled(),
+                      server.getGrpcStorageOptions(),
+                      StorageRetryStrategy.getDefaultStorageRetryStrategy().getIdempotentHandler(),
                       ResponseContentLifecycleManager.noop()));
       byte[] actualBytes = new byte[41];
       //noinspection resource

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGzipReadableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGzipReadableByteChannelTest.java
@@ -126,6 +126,8 @@ public class ITGzipReadableByteChannelTest {
               .read()
               .byteChannel(
                   storageClient.getInstance().readObjectCallable(),
+                  fakeServer.getInstance().getGrpcStorageOptions(),
+                  StorageRetryStrategy.getDefaultStorageRetryStrategy().getIdempotentHandler(),
                   ResponseContentLifecycleManager.noop())
               .setHasher(Hasher.noop())
               .setAutoGzipDecompression(true)
@@ -147,6 +149,8 @@ public class ITGzipReadableByteChannelTest {
               .read()
               .byteChannel(
                   storageClient.getInstance().readObjectCallable(),
+                  fakeServer.getInstance().getGrpcStorageOptions(),
+                  StorageRetryStrategy.getDefaultStorageRetryStrategy().getIdempotentHandler(),
                   ResponseContentLifecycleManager.noop())
               .setHasher(Hasher.noop())
               .setAutoGzipDecompression(false)
@@ -199,6 +203,8 @@ public class ITGzipReadableByteChannelTest {
               .read()
               .byteChannel(
                   storageClient.getInstance().readObjectCallable(),
+                  fakeServer.getInstance().getGrpcStorageOptions(),
+                  StorageRetryStrategy.getDefaultStorageRetryStrategy().getIdempotentHandler(),
                   ResponseContentLifecycleManager.noop())
               .setHasher(Hasher.noop())
               .setAutoGzipDecompression(true)
@@ -220,6 +226,8 @@ public class ITGzipReadableByteChannelTest {
               .read()
               .byteChannel(
                   storageClient.getInstance().readObjectCallable(),
+                  fakeServer.getInstance().getGrpcStorageOptions(),
+                  StorageRetryStrategy.getDefaultStorageRetryStrategy().getIdempotentHandler(),
                   ResponseContentLifecycleManager.noop())
               .setHasher(Hasher.noop())
               .setAutoGzipDecompression(false)
@@ -241,6 +249,8 @@ public class ITGzipReadableByteChannelTest {
               .read()
               .byteChannel(
                   storageClient.getInstance().readObjectCallable(),
+                  fakeServer.getInstance().getGrpcStorageOptions(),
+                  StorageRetryStrategy.getDefaultStorageRetryStrategy().getIdempotentHandler(),
                   ResponseContentLifecycleManager.noop())
               .setHasher(Hasher.noop())
               .unbuffered()
@@ -324,7 +334,11 @@ public class ITGzipReadableByteChannelTest {
         ReadableByteChannelSession<?, Object> session =
             ResumableMedia.gapic()
                 .read()
-                .byteChannel(sc.readObjectCallable(), ResponseContentLifecycleManager.noop())
+                .byteChannel(
+                    sc.readObjectCallable(),
+                    fakeServer.getGrpcStorageOptions(),
+                    StorageRetryStrategy.getDefaultStorageRetryStrategy().getIdempotentHandler(),
+                    ResponseContentLifecycleManager.noop())
                 .setHasher(Hasher.noop())
                 .setAutoGzipDecompression(true)
                 .unbuffered()

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/TestUtils.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/TestUtils.java
@@ -20,14 +20,12 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.api.core.ApiClock;
 import com.google.api.core.NanoClock;
-import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.api.gax.grpc.GrpcStatusCode;
 import com.google.api.gax.retrying.BasicResultRetryAlgorithm;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.ApiExceptionFactory;
 import com.google.api.gax.rpc.ErrorDetails;
-import com.google.api.gax.rpc.StatusCode;
 import com.google.cloud.RetryHelper;
 import com.google.cloud.RetryHelper.RetryHelperException;
 import com.google.cloud.http.BaseHttpServiceException;
@@ -111,10 +109,6 @@ public final class TestUtils {
         ErrorDetails.builder().setRawErrorMessages(ImmutableList.of(Any.pack(debugInfo))).build();
     return ApiExceptionFactory.createException(
         statusRuntimeException, GrpcStatusCode.of(code), true, errorDetails);
-  }
-
-  public static GrpcCallContext contextWithRetryForCodes(StatusCode.Code... code) {
-    return GrpcCallContext.createDefault().withRetryableCodes(ImmutableSet.copyOf(code));
   }
 
   public static ImmutableList<ByteBuffer> subDivide(byte[] bytes, int division) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageReadChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITStorageReadChannelTest.java
@@ -117,7 +117,7 @@ public final class ITStorageReadChannelTest {
 
   @Test
   public void storageReadChannel_shouldAllowDisablingBufferingBySettingChunkSize_lteq0()
-      throws IOException {
+      throws Exception {
     int _512KiB = 512 * 1024;
     int _1MiB = 1024 * 1024;
 
@@ -130,6 +130,7 @@ public final class ITStorageReadChannelTest {
     }
 
     try (ReadChannel c = storage.reader(info.getBlobId())) {
+      ApiFuture<BlobInfo> infoFuture = getBlobInfoFromReadChannelFunction(c);
       c.setChunkSize(0);
 
       ByteBuffer buf = ByteBuffer.allocate(_1MiB);
@@ -140,6 +141,8 @@ public final class ITStorageReadChannelTest {
       String actual = xxd(buf);
       String expected = xxd(uncompressedBytes);
       assertThat(actual).isEqualTo(expected);
+      BlobInfo blobInfo = infoFuture.get(3, TimeUnit.SECONDS);
+      assertThat(blobInfo.getBlobId()).isEqualTo(info.getBlobId());
     }
   }
 


### PR DESCRIPTION
Update GapicUnbufferedReadableByteChannel to manage the grpc stream itself rather than using the stream iterator provided by gax. This allows us to ensure the cancellation is observed and our draining performs before returning from close().

As a side effect of not using the gax stream iterator, we now must handle stream restarts ourselves. GrpcStorageOptions.ReadObjectResumptionStrategy has been removed entirely, while RetryingDependencies and ResultRetryAlgorithm are now plumbed all the way down to the GapicUnbufferedReadableByteChannel.

