### PR TITLE
chore: fix error message for JournalingBlobWriteSessionConfig

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JournalingBlobWriteSessionConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JournalingBlobWriteSessionConfig.java
@@ -215,7 +215,7 @@ public final class JournalingBlobWriteSessionConfig extends BlobWriteSessionConf
 
         return new JournalingUpload<>(session, start);
       } else {
-        return CrossTransportUtils.throwHttpJsonOnly(BlobWriteSessionConfigs.class, "journaling");
+        return CrossTransportUtils.throwGrpcOnly(BlobWriteSessionConfigs.class, "journaling");
       }
     }
 


### PR DESCRIPTION
Now properly reports grpc only rather than incorrect http only.

This line actually executing was guarded upstream of its construction, but this is being cleaned up for the sake of completeness.
