### PR TITLE
chore: Remove release-please configs from README.

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -6,7 +6,6 @@ custom_content: |
   The Storage Control API creates one space to perform metadata-specific, control plane, and long-running operations apart from the Storage API. Separating these operations from the Storage API improves API standardization and lets you run faster releases.
   
   If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
-  <!-- {x-version-update-start:libraries-bom:released} -->
   ```xml
   <dependencyManagement>
       <dependencies>
@@ -30,7 +29,6 @@ custom_content: |
   
   If you are using Maven without the BOM, add this to your dependencies:
 
-  <!-- {x-version-update-start:google-cloud-storage-control:released} -->
 
   ```xml
   <dependency>

--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
 
 If you are using Maven without the BOM, add this to your dependencies:
 
-<!-- {x-version-update-start:google-cloud-storage:released} -->
-
 ```xml
 <dependency>
   <groupId>com.google.cloud</groupId>
@@ -75,7 +73,6 @@ If you are using SBT, add this to your dependencies:
 ```Scala
 libraryDependencies += "com.google.cloud" % "google-cloud-storage" % "2.43.1"
 ```
-<!-- {x-version-update-end} -->
 
 ## Authentication
 


### PR DESCRIPTION
The versions in REAME are now managed by hermetic build generation scripts, release-please configuration should be remove from README to prevent double-edit.
In addition, release-please configurations were [misconfigured for libraries-bom](https://github.com/googleapis/java-storage/blame/003d6faaa3d64310cf91a1e304247e2f44a5c9c7/README.md#L63),  we have been incorrectly using the storage version for libraries-bom in README.
