### PR TITLE
chore: test gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file:
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>libraries-bom</artifactId>
-      <version>26.47.0</version>
+      <version>26.48.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>
@@ -60,7 +60,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:2.43.1')
+implementation platform('com.google.cloud:libraries-bom:26.48.0')
 
 implementation 'com.google.cloud:google-cloud-storage'
 ```
@@ -512,7 +512,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [kokoro-badge-link-5]: http://storage.googleapis.com/cloud-devrel-public/java/badges/java-storage/java11.html
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-storage.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-storage/2.43.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-storage/2.43.1
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -1,6 +1,6 @@
-gapic_generator_version: 2.46.0
-googleapis_commitish: 5c181aaf78bd1ae2e08c3a2971cd9e87b6e00986
-libraries_bom_version: 26.47.0
+gapic_generator_version: 2.47.0
+googleapis_commitish: 1f8352cf46df74d7db6fd544181655c590689b8c
+libraries_bom_version: 26.48.0
 libraries:
   - api_shortname: storage
     name_pretty: Cloud Storage


### PR DESCRIPTION
This pull request is generated with proto changes between [googleapis/googleapis@5c181aa](https://github.com/googleapis/googleapis/commit/5c181aaf78bd1ae2e08c3a2971cd9e87b6e00986) (exclusive) and [googleapis/googleapis@1f8352c](https://github.com/googleapis/googleapis/commit/1f8352cf46df74d7db6fd544181655c590689b8c) (inclusive).

BEGIN_COMMIT_OVERRIDE
BEGIN_NESTED_COMMIT
fix(deps): update the Java code generator (gapic-generator-java) to 2.47.0
END_NESTED_COMMIT
BEGIN_NESTED_COMMIT
chore: update the libraries_bom version to 26.48.0
END_NESTED_COMMIT
END_COMMIT_OVERRIDE