### PR TITLE
chore: Any changes to the hermetic build inputs should trigger re-regeneration

### DIFF
--- a/.github/workflows/hermetic_library_generation.yaml
+++ b/.github/workflows/hermetic_library_generation.yaml
@@ -18,6 +18,10 @@ on:
   pull_request:
     paths:
       - 'generation_config.yaml'
+      - '.readme-partials.yaml'
+      - 'owlbot.py'
+      - 'versions.txt'
+      - '.github/.OwlBot-hermetic.yaml'
 
 env:
   REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
Any changes to the hermetic build inputs should trigger re-regeneration, hence add all of them to `paths` in `hermetic_library_generation.yaml`. This is to resolve an issue found yesterday that hermetic code generation was not triggered in this PR https://github.com/googleapis/java-storage/pull/2755.
We don't have `paths` configured for any other handwritten libraries. IIRC, it was added for a special use case in Storage, @BenWhitehead can you please verify the changes in this PR does not affect other use cases?