### PR TITLE
feat: Take in a module name when creating a span

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -148,7 +148,6 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
           StandardOpenOption.CREATE,
           StandardOpenOption.TRUNCATE_EXISTING);
   private static final BucketSourceOption[] EMPTY_BUCKET_SOURCE_OPTIONS = new BucketSourceOption[0];
-  private static final String OTEL_MODULE_NAME = "storage.client";
 
   private static final Opts<Fields> ALL_BLOB_FIELDS =
       Opts.from(UnifiedOpts.fields(ImmutableSet.copyOf(BlobField.values())));
@@ -203,7 +202,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
   @Override
   public Bucket create(BucketInfo bucketInfo, BucketTargetOption... options) {
     OpenTelemetryTraceUtil.Span otelSpan =
-        openTelemetryTraceUtil.startSpan("create", OTEL_MODULE_NAME);
+        openTelemetryTraceUtil.startSpan("create", this.getClass().getName());
     Opts<BucketTargetOpt> opts = Opts.unwrap(options).resolveFrom(bucketInfo).prepend(defaultOpts);
     GrpcCallContext grpcCallContext =
         opts.grpcMetadataMapper().apply(GrpcCallContext.createDefault());
@@ -251,7 +250,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
     Opts<ObjectTargetOpt> opts = Opts.unwrap(options).resolveFrom(blobInfo);
     // Start the otel span to retain information of the origin of the request
     OpenTelemetryTraceUtil.Span otelSpan =
-        openTelemetryTraceUtil.startSpan("create", OTEL_MODULE_NAME);
+        openTelemetryTraceUtil.startSpan("create", this.getClass().getName());
     try (OpenTelemetryTraceUtil.Scope unused = otelSpan.makeCurrent()) {
       return internalDirectUpload(
               blobInfo,
@@ -271,7 +270,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
   @Override
   public Blob create(BlobInfo blobInfo, InputStream content, BlobWriteOption... options) {
     OpenTelemetryTraceUtil.Span otelSpan =
-        openTelemetryTraceUtil.startSpan("create", OTEL_MODULE_NAME);
+        openTelemetryTraceUtil.startSpan("create", this.getClass().getName());
     try (OpenTelemetryTraceUtil.Scope ununsed = otelSpan.makeCurrent()) {
       requireNonNull(blobInfo, "blobInfo must be non null");
       InputStream inputStreamParam = firstNonNull(content, new ByteArrayInputStream(ZERO_BYTES));
@@ -834,7 +833,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
     requireNonNull(blobInfo, "blobInfo must be non null");
     requireNonNull(buf, "content must be non null");
     OpenTelemetryTraceUtil.Span otelSpan =
-        openTelemetryTraceUtil.startSpan("internalDirectUpload(BlobInfo)", OTEL_MODULE_NAME, ctx);
+        openTelemetryTraceUtil.startSpan("internalDirectUpload", this.getClass().getName(), ctx);
     Opts<ObjectTargetOpt> optsWithDefaults = opts.prepend(defaultOpts);
     GrpcCallContext grpcCallContext =
         optsWithDefaults.grpcMetadataMapper().apply(GrpcCallContext.createDefault());

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -148,6 +148,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
           StandardOpenOption.CREATE,
           StandardOpenOption.TRUNCATE_EXISTING);
   private static final BucketSourceOption[] EMPTY_BUCKET_SOURCE_OPTIONS = new BucketSourceOption[0];
+  private static final String OTEL_MODULE_NAME = "storage.client";
 
   private static final Opts<Fields> ALL_BLOB_FIELDS =
       Opts.from(UnifiedOpts.fields(ImmutableSet.copyOf(BlobField.values())));
@@ -201,7 +202,8 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
 
   @Override
   public Bucket create(BucketInfo bucketInfo, BucketTargetOption... options) {
-    OpenTelemetryTraceUtil.Span otelSpan = openTelemetryTraceUtil.startSpan("create");
+    OpenTelemetryTraceUtil.Span otelSpan =
+        openTelemetryTraceUtil.startSpan("create", OTEL_MODULE_NAME);
     Opts<BucketTargetOpt> opts = Opts.unwrap(options).resolveFrom(bucketInfo).prepend(defaultOpts);
     GrpcCallContext grpcCallContext =
         opts.grpcMetadataMapper().apply(GrpcCallContext.createDefault());
@@ -248,7 +250,8 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
       BlobInfo blobInfo, byte[] content, int offset, int length, BlobTargetOption... options) {
     Opts<ObjectTargetOpt> opts = Opts.unwrap(options).resolveFrom(blobInfo);
     // Start the otel span to retain information of the origin of the request
-    OpenTelemetryTraceUtil.Span otelSpan = openTelemetryTraceUtil.startSpan("create");
+    OpenTelemetryTraceUtil.Span otelSpan =
+        openTelemetryTraceUtil.startSpan("create", OTEL_MODULE_NAME);
     try (OpenTelemetryTraceUtil.Scope unused = otelSpan.makeCurrent()) {
       return internalDirectUpload(
               blobInfo,
@@ -267,7 +270,8 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
 
   @Override
   public Blob create(BlobInfo blobInfo, InputStream content, BlobWriteOption... options) {
-    OpenTelemetryTraceUtil.Span otelSpan = openTelemetryTraceUtil.startSpan("create");
+    OpenTelemetryTraceUtil.Span otelSpan =
+        openTelemetryTraceUtil.startSpan("create", OTEL_MODULE_NAME);
     try (OpenTelemetryTraceUtil.Scope ununsed = otelSpan.makeCurrent()) {
       requireNonNull(blobInfo, "blobInfo must be non null");
       InputStream inputStreamParam = firstNonNull(content, new ByteArrayInputStream(ZERO_BYTES));
@@ -830,7 +834,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
     requireNonNull(blobInfo, "blobInfo must be non null");
     requireNonNull(buf, "content must be non null");
     OpenTelemetryTraceUtil.Span otelSpan =
-        openTelemetryTraceUtil.startSpan("internalDirectUpload(BlobInfo)", ctx);
+        openTelemetryTraceUtil.startSpan("internalDirectUpload(BlobInfo)", OTEL_MODULE_NAME, ctx);
     Opts<ObjectTargetOpt> optsWithDefaults = opts.prepend(defaultOpts);
     GrpcCallContext grpcCallContext =
         optsWithDefaults.grpcMetadataMapper().apply(GrpcCallContext.createDefault());

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/otel/NoOpOpenTelemetryInstance.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/otel/NoOpOpenTelemetryInstance.java
@@ -24,13 +24,13 @@ import javax.annotation.Nonnull;
 class NoOpOpenTelemetryInstance implements OpenTelemetryTraceUtil {
 
   @Override
-  public OpenTelemetryTraceUtil.Span startSpan(String spanName) {
+  public OpenTelemetryTraceUtil.Span startSpan(String spanName, String module) {
     return new Span();
   }
 
   @Override
   public OpenTelemetryTraceUtil.Span startSpan(
-      String spanName, OpenTelemetryTraceUtil.Context parent) {
+      String spanName, String module, OpenTelemetryTraceUtil.Context parent) {
     return new Span();
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/otel/OpenTelemetryInstance.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/otel/OpenTelemetryInstance.java
@@ -153,8 +153,8 @@ class OpenTelemetryInstance implements OpenTelemetryTraceUtil {
   }
 
   @Override
-  public OpenTelemetryTraceUtil.Span startSpan(String methodName) {
-    String formatSpanName = String.format("%s.%s/%s", "storage", "client", methodName);
+  public OpenTelemetryTraceUtil.Span startSpan(String methodName, String module) {
+    String formatSpanName = String.format("%s/%s", module, methodName);
     SpanBuilder spanBuilder = tracer.spanBuilder(formatSpanName).setSpanKind(SpanKind.CLIENT);
     io.opentelemetry.api.trace.Span span =
         addSettingsAttributesToCurrentSpan(spanBuilder).startSpan();
@@ -163,9 +163,9 @@ class OpenTelemetryInstance implements OpenTelemetryTraceUtil {
 
   @Override
   public OpenTelemetryTraceUtil.Span startSpan(
-      String methodName, OpenTelemetryTraceUtil.Context parent) {
+      String methodName, String module, OpenTelemetryTraceUtil.Context parent) {
     assert (parent instanceof OpenTelemetryInstance.Context);
-    String formatSpanName = String.format("%s.%s/%s", "storage", "client", methodName);
+    String formatSpanName = String.format("%s/%s", module, methodName);
     SpanBuilder spanBuilder =
         tracer
             .spanBuilder(formatSpanName)

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/otel/OpenTelemetryTraceUtil.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/otel/OpenTelemetryTraceUtil.java
@@ -76,13 +76,13 @@ public interface OpenTelemetryTraceUtil {
   }
 
   /** Starts a new span with the given name, sets it as the current span, and returns it. */
-  Span startSpan(String spanName);
+  Span startSpan(String spanName, String module);
 
   /**
    * Starts a new span with the given name and the given context as its parent, sets it as the
    * current span, and returns it.
    */
-  Span startSpan(String spanName, Context parent);
+  Span startSpan(String spanName, String module, Context parent);
 
   /** Returns the current span. */
   @Nonnull

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java
@@ -106,6 +106,7 @@ public class HttpStorageRpc implements StorageRpc {
   public static final String NO_ACL_PROJECTION = "noAcl";
   private static final String ENCRYPTION_KEY_PREFIX = "x-goog-encryption-";
   private static final String SOURCE_ENCRYPTION_KEY_PREFIX = "x-goog-copy-source-encryption-";
+  private static final String OTEL_MODULE_NAME = "storage.spi.v1";
 
   // declare this HttpStatus code here as it's not included in java.net.HttpURLConnection
   private static final int SC_REQUESTED_RANGE_NOT_SATISFIABLE = 416;
@@ -360,7 +361,8 @@ public class HttpStorageRpc implements StorageRpc {
 
   @Override
   public Bucket create(Bucket bucket, Map<Option, ?> options) {
-    OpenTelemetryTraceUtil.Span otelSpan = openTelemetryTraceUtil.startSpan("create");
+    OpenTelemetryTraceUtil.Span otelSpan =
+        openTelemetryTraceUtil.startSpan("create", OTEL_MODULE_NAME);
     Span span = startSpan(HttpStorageRpcSpans.SPAN_NAME_CREATE_BUCKET);
     Scope scope = tracer.withSpan(span);
     try (OpenTelemetryTraceUtil.Scope unused = otelSpan.makeCurrent()) {
@@ -388,7 +390,8 @@ public class HttpStorageRpc implements StorageRpc {
   @Override
   public StorageObject create(
       StorageObject storageObject, final InputStream content, Map<Option, ?> options) {
-    OpenTelemetryTraceUtil.Span otelSpan = openTelemetryTraceUtil.startSpan("create");
+    OpenTelemetryTraceUtil.Span otelSpan =
+        openTelemetryTraceUtil.startSpan("create", OTEL_MODULE_NAME);
     Span span = startSpan(HttpStorageRpcSpans.SPAN_NAME_CREATE_OBJECT);
     Scope scope = tracer.withSpan(span);
     try (OpenTelemetryTraceUtil.Scope unused = otelSpan.makeCurrent()) {
@@ -848,7 +851,8 @@ public class HttpStorageRpc implements StorageRpc {
   @Override
   public long read(
       StorageObject from, Map<Option, ?> options, long position, OutputStream outputStream) {
-    OpenTelemetryTraceUtil.Span otelSpan = openTelemetryTraceUtil.startSpan("read");
+    OpenTelemetryTraceUtil.Span otelSpan =
+        openTelemetryTraceUtil.startSpan("read", OTEL_MODULE_NAME);
     Span span = startSpan(HttpStorageRpcSpans.SPAN_NAME_READ);
     Scope scope = tracer.withSpan(span);
     try (OpenTelemetryTraceUtil.Scope unused = otelSpan.makeCurrent()) {
@@ -886,7 +890,8 @@ public class HttpStorageRpc implements StorageRpc {
   @Override
   public Tuple<String, byte[]> read(
       StorageObject from, Map<Option, ?> options, long position, int bytes) {
-    OpenTelemetryTraceUtil.Span otelSpan = openTelemetryTraceUtil.startSpan("read");
+    OpenTelemetryTraceUtil.Span otelSpan =
+        openTelemetryTraceUtil.startSpan("read", OTEL_MODULE_NAME);
     Span span = startSpan(HttpStorageRpcSpans.SPAN_NAME_READ);
     Scope scope = tracer.withSpan(span);
     try (OpenTelemetryTraceUtil.Scope unused = otelSpan.makeCurrent()) {
@@ -1166,7 +1171,8 @@ public class HttpStorageRpc implements StorageRpc {
 
   @Override
   public RewriteResponse openRewrite(RewriteRequest rewriteRequest) {
-    OpenTelemetryTraceUtil.Span otelSpan = openTelemetryTraceUtil.startSpan("openRewrite");
+    OpenTelemetryTraceUtil.Span otelSpan =
+        openTelemetryTraceUtil.startSpan("openRewrite", OTEL_MODULE_NAME);
     Span span = startSpan(HttpStorageRpcSpans.SPAN_NAME_OPEN_REWRITE);
     Scope scope = tracer.withSpan(span);
     try (OpenTelemetryTraceUtil.Scope unused = otelSpan.makeCurrent()) {
@@ -1180,7 +1186,8 @@ public class HttpStorageRpc implements StorageRpc {
 
   @Override
   public RewriteResponse continueRewrite(RewriteResponse previousResponse) {
-    OpenTelemetryTraceUtil.Span otelSpan = openTelemetryTraceUtil.startSpan("continueRewrite");
+    OpenTelemetryTraceUtil.Span otelSpan =
+        openTelemetryTraceUtil.startSpan("continueRewrite", OTEL_MODULE_NAME);
     Span span = startSpan(HttpStorageRpcSpans.SPAN_NAME_CONTINUE_REWRITE);
     Scope scope = tracer.withSpan(span);
     try (OpenTelemetryTraceUtil.Scope unused = otelSpan.makeCurrent()) {
@@ -1197,7 +1204,8 @@ public class HttpStorageRpc implements StorageRpc {
 
   private RewriteResponse rewrite(
       RewriteRequest req, String token, OpenTelemetryTraceUtil.Context ctx) {
-    OpenTelemetryTraceUtil.Span otelSpan = openTelemetryTraceUtil.startSpan("rewrite", ctx);
+    OpenTelemetryTraceUtil.Span otelSpan =
+        openTelemetryTraceUtil.startSpan("rewrite", OTEL_MODULE_NAME, ctx);
     try (OpenTelemetryTraceUtil.Scope unused = otelSpan.makeCurrent()) {
       String userProject = Option.USER_PROJECT.getString(req.sourceOptions);
       if (userProject == null) {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java
@@ -1856,12 +1856,4 @@ public class HttpStorageRpc implements StorageRpc {
     error.setMessage(statusMessage);
     return translate(error);
   }
-  private static StorageException buildStorageException(int statusCode, String statusMessage, OpenTelemetryTraceUtil.Span otelSpan) {
-    GoogleJsonError error = new GoogleJsonError();
-    error.setCode(statusCode);
-    error.setMessage(statusMessage);
-    StorageException ex = translate(error);
-    otelSpan.recordException(ex);
-    return ex;
-  }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java
@@ -1856,4 +1856,12 @@ public class HttpStorageRpc implements StorageRpc {
     error.setMessage(statusMessage);
     return translate(error);
   }
+  private static StorageException buildStorageException(int statusCode, String statusMessage, OpenTelemetryTraceUtil.Span otelSpan) {
+    GoogleJsonError error = new GoogleJsonError();
+    error.setCode(statusCode);
+    error.setMessage(statusMessage);
+    StorageException ex = translate(error);
+    otelSpan.recordException(ex);
+    return ex;
+  }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java
@@ -106,7 +106,6 @@ public class HttpStorageRpc implements StorageRpc {
   public static final String NO_ACL_PROJECTION = "noAcl";
   private static final String ENCRYPTION_KEY_PREFIX = "x-goog-encryption-";
   private static final String SOURCE_ENCRYPTION_KEY_PREFIX = "x-goog-copy-source-encryption-";
-  private static final String OTEL_MODULE_NAME = "storage.spi.v1";
 
   // declare this HttpStatus code here as it's not included in java.net.HttpURLConnection
   private static final int SC_REQUESTED_RANGE_NOT_SATISFIABLE = 416;
@@ -362,7 +361,7 @@ public class HttpStorageRpc implements StorageRpc {
   @Override
   public Bucket create(Bucket bucket, Map<Option, ?> options) {
     OpenTelemetryTraceUtil.Span otelSpan =
-        openTelemetryTraceUtil.startSpan("create", OTEL_MODULE_NAME);
+        openTelemetryTraceUtil.startSpan("create", this.getClass().getName());
     Span span = startSpan(HttpStorageRpcSpans.SPAN_NAME_CREATE_BUCKET);
     Scope scope = tracer.withSpan(span);
     try (OpenTelemetryTraceUtil.Scope unused = otelSpan.makeCurrent()) {
@@ -391,7 +390,7 @@ public class HttpStorageRpc implements StorageRpc {
   public StorageObject create(
       StorageObject storageObject, final InputStream content, Map<Option, ?> options) {
     OpenTelemetryTraceUtil.Span otelSpan =
-        openTelemetryTraceUtil.startSpan("create", OTEL_MODULE_NAME);
+        openTelemetryTraceUtil.startSpan("create", this.getClass().getName());
     Span span = startSpan(HttpStorageRpcSpans.SPAN_NAME_CREATE_OBJECT);
     Scope scope = tracer.withSpan(span);
     try (OpenTelemetryTraceUtil.Scope unused = otelSpan.makeCurrent()) {
@@ -852,7 +851,7 @@ public class HttpStorageRpc implements StorageRpc {
   public long read(
       StorageObject from, Map<Option, ?> options, long position, OutputStream outputStream) {
     OpenTelemetryTraceUtil.Span otelSpan =
-        openTelemetryTraceUtil.startSpan("read", OTEL_MODULE_NAME);
+        openTelemetryTraceUtil.startSpan("read", this.getClass().getName());
     Span span = startSpan(HttpStorageRpcSpans.SPAN_NAME_READ);
     Scope scope = tracer.withSpan(span);
     try (OpenTelemetryTraceUtil.Scope unused = otelSpan.makeCurrent()) {
@@ -891,7 +890,7 @@ public class HttpStorageRpc implements StorageRpc {
   public Tuple<String, byte[]> read(
       StorageObject from, Map<Option, ?> options, long position, int bytes) {
     OpenTelemetryTraceUtil.Span otelSpan =
-        openTelemetryTraceUtil.startSpan("read", OTEL_MODULE_NAME);
+        openTelemetryTraceUtil.startSpan("read", this.getClass().getName());
     Span span = startSpan(HttpStorageRpcSpans.SPAN_NAME_READ);
     Scope scope = tracer.withSpan(span);
     try (OpenTelemetryTraceUtil.Scope unused = otelSpan.makeCurrent()) {
@@ -1172,7 +1171,7 @@ public class HttpStorageRpc implements StorageRpc {
   @Override
   public RewriteResponse openRewrite(RewriteRequest rewriteRequest) {
     OpenTelemetryTraceUtil.Span otelSpan =
-        openTelemetryTraceUtil.startSpan("openRewrite", OTEL_MODULE_NAME);
+        openTelemetryTraceUtil.startSpan("openRewrite", this.getClass().getName());
     Span span = startSpan(HttpStorageRpcSpans.SPAN_NAME_OPEN_REWRITE);
     Scope scope = tracer.withSpan(span);
     try (OpenTelemetryTraceUtil.Scope unused = otelSpan.makeCurrent()) {
@@ -1187,7 +1186,7 @@ public class HttpStorageRpc implements StorageRpc {
   @Override
   public RewriteResponse continueRewrite(RewriteResponse previousResponse) {
     OpenTelemetryTraceUtil.Span otelSpan =
-        openTelemetryTraceUtil.startSpan("continueRewrite", OTEL_MODULE_NAME);
+        openTelemetryTraceUtil.startSpan("continueRewrite", this.getClass().getName());
     Span span = startSpan(HttpStorageRpcSpans.SPAN_NAME_CONTINUE_REWRITE);
     Scope scope = tracer.withSpan(span);
     try (OpenTelemetryTraceUtil.Scope unused = otelSpan.makeCurrent()) {
@@ -1205,7 +1204,7 @@ public class HttpStorageRpc implements StorageRpc {
   private RewriteResponse rewrite(
       RewriteRequest req, String token, OpenTelemetryTraceUtil.Context ctx) {
     OpenTelemetryTraceUtil.Span otelSpan =
-        openTelemetryTraceUtil.startSpan("rewrite", OTEL_MODULE_NAME, ctx);
+        openTelemetryTraceUtil.startSpan("rewrite", this.getClass().getName(), ctx);
     try (OpenTelemetryTraceUtil.Scope unused = otelSpan.makeCurrent()) {
       String userProject = Option.USER_PROJECT.getString(req.sourceOptions);
       if (userProject == null) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITHttpOpenTelemetryTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITHttpOpenTelemetryTest.java
@@ -16,9 +16,7 @@
 
 package com.google.cloud.storage;
 
-import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.fail;
 
 import com.google.cloud.NoCredentials;
 import com.google.cloud.storage.Storage.BlobSourceOption;
@@ -58,7 +56,6 @@ public class ITHttpOpenTelemetryTest {
   private static final byte[] helloWorldGzipBytes = TestUtils.gzipBytes(helloWorldTextBytes);
   @Inject public Generator generator;
   @Inject public BucketInfo testBucket;
-
 
   @Before
   public void setUp() {
@@ -152,6 +149,8 @@ public class ITHttpOpenTelemetryTest {
           "com.google.cloud.google-cloud-storage", getAttributeValue(span, "gcp.client.artifact"));
       Assert.assertEquals("http", getAttributeValue(span, "rpc.system"));
     }
+    Assert.assertTrue(spanData.stream().anyMatch(x -> x.getName().contains("openRewrite")));
+    Assert.assertTrue(spanData.stream().anyMatch(x -> x.getName().contains("rewrite")));
   }
 
   private String getAttributeValue(SpanData spanData, String key) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITHttpOpenTelemetryTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITHttpOpenTelemetryTest.java
@@ -149,8 +149,6 @@ public class ITHttpOpenTelemetryTest {
           "com.google.cloud.google-cloud-storage", getAttributeValue(span, "gcp.client.artifact"));
       Assert.assertEquals("http", getAttributeValue(span, "rpc.system"));
     }
-    Assert.assertTrue(spanData.stream().anyMatch(x -> x.getName().contains("openRewrite")));
-    Assert.assertTrue(spanData.stream().anyMatch(x -> x.getName().contains("rewrite")));
   }
 
   private String getAttributeValue(SpanData spanData, String key) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITHttpOpenTelemetryTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITHttpOpenTelemetryTest.java
@@ -16,7 +16,9 @@
 
 package com.google.cloud.storage;
 
+import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.fail;
 
 import com.google.cloud.NoCredentials;
 import com.google.cloud.storage.Storage.BlobSourceOption;
@@ -56,6 +58,7 @@ public class ITHttpOpenTelemetryTest {
   private static final byte[] helloWorldGzipBytes = TestUtils.gzipBytes(helloWorldTextBytes);
   @Inject public Generator generator;
   @Inject public BucketInfo testBucket;
+
 
   @Before
   public void setUp() {


### PR DESCRIPTION
`SpanData{spanContext=ImmutableSpanContext{traceId=c49154a1f7a6a4adb7188e566fcd7d12, spanId=7dd45a835177a216, traceFlags=01, traceState=ArrayBasedTraceState{entries=[]}, remote=false, valid=true}, parentSpanContext=ImmutableSpanContext{traceId=00000000000000000000000000000000, spanId=0000000000000000, traceFlags=00, traceState=ArrayBasedTraceState{entries=[]}, remote=false, valid=false}, resource=Resource{schemaUrl=null, attributes={service.name="unknown_service:java", telemetry.sdk.language="java", telemetry.sdk.name="opentelemetry", telemetry.sdk.version="1.42.1"}}, instrumentationScopeInfo=InstrumentationScopeInfo{name=cloud.google.com/java/storage, version=, schemaUrl=null, attributes={}}, name=com.google.cloud.storage.GrpcStorageImpl/create, kind=CLIENT, startEpochNanos=1731105737865150000, endEpochNanos=1731105739962999167, attributes=AttributesMap{data={gcp.client.repo=googleapis/java-storage, gcp.client.service=Storage, gcp.client.version=, gcp.client.artifact=com.google.cloud.google-cloud-storage, rpc.system=grpc}, capacity=128, totalAddedValues=5}, totalAttributeCount=5, events=[], totalRecordedEvents=0, links=[], totalRecordedLinks=0, status=ImmutableStatusData{statusCode=UNSET, description=}, hasEnded=true}`

notable change seen here
`name=com.google.cloud.storage.GrpcStorageImpl/create`