### PR TITLE
feat: introduce `java.time` methods and variables

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -189,8 +189,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
   public void close() throws Exception {
     try (StorageClient s = storageClient) {
       s.shutdownNow();
-      org.threeten.bp.Duration terminationAwaitDuration =
-          getOptions().getTerminationAwaitDuration();
+      java.time.Duration terminationAwaitDuration = getOptions().getTerminationAwaitDuration();
       s.awaitTermination(terminationAwaitDuration.toMillis(), TimeUnit.MILLISECONDS);
     }
   }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
@@ -129,7 +129,7 @@ public final class GrpcStorageOptions extends StorageOptions
     this.terminationAwaitDuration =
         MoreObjects.firstNonNull(
             builder.terminationAwaitDuration,
-            serviceDefaults.getTerminationAwaitJavaTimeDuration());
+            serviceDefaults.getTerminationAwaitDurationJavaTime());
     this.attemptDirectPath = builder.attemptDirectPath;
     this.enableGrpcClientMetrics = builder.enableGrpcClientMetrics;
     this.grpcClientMetricsManuallyEnabled = builder.grpcMetricsManuallyEnabled;
@@ -665,14 +665,14 @@ public final class GrpcStorageOptions extends StorageOptions
       return StorageRetryStrategy.getDefaultStorageRetryStrategy();
     }
 
-    /** This method is obsolete. Use {@link #getTerminationAwaitJavaTimeDuration()} instead. */
-    @ObsoleteApi("Use getTerminationAwaitDurationDuration() instead")
+    /** This method is obsolete. Use {@link #getTerminationAwaitDurationJavaTime()} instead. */
+    @ObsoleteApi("Use getTerminationAwaitDurationJavaTime() instead")
     public org.threeten.bp.Duration getTerminationAwaitDuration() {
-      return toThreetenDuration(getTerminationAwaitJavaTimeDuration());
+      return toThreetenDuration(getTerminationAwaitDurationJavaTime());
     }
 
     /** @since 2.14.0 */
-    public java.time.Duration getTerminationAwaitJavaTimeDuration() {
+    public java.time.Duration getTerminationAwaitDurationJavaTime() {
       return java.time.Duration.ofMinutes(1);
     }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
@@ -129,7 +129,7 @@ public final class GrpcStorageOptions extends StorageOptions
     this.terminationAwaitDuration =
         MoreObjects.firstNonNull(
             builder.terminationAwaitDuration,
-            serviceDefaults.getTerminationAwaitDurationDuration());
+            serviceDefaults.getTerminationAwaitJavaTimeDuration());
     this.attemptDirectPath = builder.attemptDirectPath;
     this.enableGrpcClientMetrics = builder.enableGrpcClientMetrics;
     this.grpcClientMetricsManuallyEnabled = builder.grpcMetricsManuallyEnabled;
@@ -440,12 +440,12 @@ public final class GrpcStorageOptions extends StorageOptions
     }
 
     /**
-     * This method is obsolete. Use {@link #setTerminationAwaitDurationDuration(java.time.Duration)}
+     * This method is obsolete. Use {@link #setTerminationAwaitJavaTimeDuration(java.time.Duration)}
      * instead.
      */
-    @ObsoleteApi("Use setTerminationAwaitDurationDuration(java.time.Duration) instead")
+    @ObsoleteApi("Use setTerminationAwaitJavaTimeDuration(java.time.Duration) instead")
     public Builder setTerminationAwaitDuration(org.threeten.bp.Duration terminationAwaitDuration) {
-      return setTerminationAwaitDurationDuration(toJavaTimeDuration(terminationAwaitDuration));
+      return setTerminationAwaitJavaTimeDuration(toJavaTimeDuration(terminationAwaitDuration));
     }
 
     /**
@@ -456,7 +456,7 @@ public final class GrpcStorageOptions extends StorageOptions
      * @return the builder
      * @since 2.14.0
      */
-    public Builder setTerminationAwaitDurationDuration(
+    public Builder setTerminationAwaitJavaTimeDuration(
         java.time.Duration terminationAwaitDuration) {
       this.terminationAwaitDuration =
           requireNonNull(terminationAwaitDuration, "terminationAwaitDuration must be non null");
@@ -665,14 +665,14 @@ public final class GrpcStorageOptions extends StorageOptions
       return StorageRetryStrategy.getDefaultStorageRetryStrategy();
     }
 
-    /** This method is obsolete. Use {@link #getTerminationAwaitDurationDuration()} instead. */
+    /** This method is obsolete. Use {@link #getTerminationAwaitJavaTimeDuration()} instead. */
     @ObsoleteApi("Use getTerminationAwaitDurationDuration() instead")
     public org.threeten.bp.Duration getTerminationAwaitDuration() {
-      return toThreetenDuration(getTerminationAwaitDurationDuration());
+      return toThreetenDuration(getTerminationAwaitJavaTimeDuration());
     }
 
     /** @since 2.14.0 */
-    public java.time.Duration getTerminationAwaitDurationDuration() {
+    public java.time.Duration getTerminationAwaitJavaTimeDuration() {
       return java.time.Duration.ofMinutes(1);
     }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/testing/RemoteStorageHelper.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/testing/RemoteStorageHelper.java
@@ -32,6 +32,7 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.common.base.Strings;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -44,7 +45,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.threeten.bp.Duration;
 
 /**
  * Utility to create a remote storage configuration for testing. Storage options can be obtained via
@@ -233,13 +233,13 @@ public class RemoteStorageHelper {
   private static RetrySettings retrySettings() {
     return RetrySettings.newBuilder()
         .setMaxAttempts(10)
-        .setMaxRetryDelay(Duration.ofMillis(30000L))
-        .setTotalTimeout(Duration.ofMillis(120000L))
-        .setInitialRetryDelay(Duration.ofMillis(250L))
+        .setMaxRetryDelayDuration(Duration.ofMillis(30000L))
+        .setTotalTimeoutDuration(Duration.ofMillis(120000L))
+        .setInitialRetryDelayDuration(Duration.ofMillis(250L))
         .setRetryDelayMultiplier(1.0)
-        .setInitialRpcTimeout(Duration.ofMillis(120000L))
+        .setInitialRpcTimeoutDuration(Duration.ofMillis(120000L))
         .setRpcTimeoutMultiplier(1.0)
-        .setMaxRpcTimeout(Duration.ofMillis(120000L))
+        .setMaxRpcTimeoutDuration(Duration.ofMillis(120000L))
         .build();
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicReadTimeoutTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicReadTimeoutTest.java
@@ -36,10 +36,10 @@ import com.google.storage.v2.StorageSettings;
 import io.grpc.Status.Code;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 import org.junit.Test;
-import org.threeten.bp.Duration;
 
 /**
  * ReadObject leverages gRPC ServerStream to read a stream of ReadObjectResponse messages spanning
@@ -48,7 +48,7 @@ import org.threeten.bp.Duration;
  * #getTotalTimeout()}, gax will interrupt the stream with a DEADLINE_EXCEEDED error.
  *
  * <p>Instead of relying on total stream timeout, we rely on idleTimeout for the stream via {@link
- * com.google.api.gax.rpc.ServerStreamingCallSettings.Builder#setIdleTimeout(Duration)}.
+ * com.google.api.gax.rpc.ServerStreamingCallSettings.Builder#setIdleTimeoutDuration(Duration)}.
  *
  * <p>These tests force specific timeout scenarios to happen against an in-process grpc server to
  * ensure our configuration of the StorageClient properly translates to the behavior we want.
@@ -117,7 +117,7 @@ public final class ITGapicReadTimeoutTest {
               .setRetrySettings(
                   RetrySettings.newBuilder()
                       .setMaxAttempts(3)
-                      .setTotalTimeout(Duration.ofMillis(totalTimeoutMillis))
+                      .setTotalTimeoutDuration(Duration.ofMillis(totalTimeoutMillis))
                       .build())
               .build()
               .getStorageSettings();
@@ -196,7 +196,7 @@ public final class ITGapicReadTimeoutTest {
               .setRetrySettings(
                   RetrySettings.newBuilder()
                       .setMaxAttempts(3)
-                      .setTotalTimeout(Duration.ofMillis(totalTimeoutMillis))
+                      .setTotalTimeoutDuration(Duration.ofMillis(totalTimeoutMillis))
                       .build())
               .build()
               .getStorageSettings();

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobWriteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobWriteChannelTest.java
@@ -55,16 +55,16 @@ import com.google.common.collect.ImmutableMap;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.logging.Logger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.threeten.bp.Clock;
-import org.threeten.bp.Instant;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.ZoneOffset;
-import org.threeten.bp.format.DateTimeFormatter;
 
 @RunWith(StorageITRunner.class)
 @SingleBackend(Backend.TEST_BENCH)

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITHmacTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITHmacTest.java
@@ -32,11 +32,11 @@ import com.google.cloud.storage.it.runner.StorageITRunner;
 import com.google.cloud.storage.it.runner.annotations.Backend;
 import com.google.cloud.storage.it.runner.annotations.CrossRun;
 import com.google.cloud.storage.it.runner.annotations.Inject;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.stream.StreamSupport;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.threeten.bp.Duration;
-import org.threeten.bp.Instant;
 
 @RunWith(StorageITRunner.class)
 @CrossRun(

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestBench.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestBench.java
@@ -53,6 +53,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -60,7 +61,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.threeten.bp.Duration;
 
 /**
  * A {@link ManagedLifecycle} which integrates with the <a target="_blank"
@@ -260,10 +260,10 @@ public final class TestBench implements ManagedLifecycle {
             runWithRetries(
                 TestBench.this::listRetryTests,
                 RetrySettings.newBuilder()
-                    .setTotalTimeout(Duration.ofSeconds(30))
-                    .setInitialRetryDelay(Duration.ofMillis(500))
+                    .setTotalTimeoutDuration(Duration.ofSeconds(30))
+                    .setInitialRetryDelayDuration(Duration.ofMillis(500))
                     .setRetryDelayMultiplier(1.5)
-                    .setMaxRetryDelay(Duration.ofSeconds(5))
+                    .setMaxRetryDelayDuration(Duration.ofSeconds(5))
                     .build(),
                 new BasicResultRetryAlgorithm<List<RetryTestResource>>() {
                   @Override
@@ -335,10 +335,10 @@ public final class TestBench implements ManagedLifecycle {
             throw new NotShutdownException();
           },
           RetrySettings.newBuilder()
-              .setTotalTimeout(Duration.ofSeconds(30))
-              .setInitialRetryDelay(Duration.ofMillis(500))
+              .setTotalTimeoutDuration(Duration.ofSeconds(30))
+              .setInitialRetryDelayDuration(Duration.ofMillis(500))
               .setRetryDelayMultiplier(1.5)
-              .setMaxRetryDelay(Duration.ofSeconds(5))
+              .setMaxRetryDelayDuration(Duration.ofSeconds(5))
               .build(),
           new BasicResultRetryAlgorithm<List<?>>() {
             @Override

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/testing/RemoteStorageHelperTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/testing/RemoteStorageHelperTest.java
@@ -34,6 +34,7 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -43,7 +44,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.threeten.bp.Duration;
 
 public class RemoteStorageHelperTest {
 
@@ -273,8 +273,8 @@ public class RemoteStorageHelperTest {
     assertEquals(60000, ((HttpTransportOptions) options.getTransportOptions()).getConnectTimeout());
     assertEquals(60000, ((HttpTransportOptions) options.getTransportOptions()).getReadTimeout());
     assertEquals(10, options.getRetrySettings().getMaxAttempts());
-    assertEquals(Duration.ofMillis(30000), options.getRetrySettings().getMaxRetryDelay());
-    assertEquals(Duration.ofMillis(120000), options.getRetrySettings().getTotalTimeout());
-    assertEquals(Duration.ofMillis(250), options.getRetrySettings().getInitialRetryDelay());
+    assertEquals(Duration.ofMillis(30000), options.getRetrySettings().getMaxRetryDelayDuration());
+    assertEquals(Duration.ofMillis(120000), options.getRetrySettings().getTotalTimeoutDuration());
+    assertEquals(Duration.ofMillis(250), options.getRetrySettings().getInitialRetryDelayDuration());
   }
 }


### PR DESCRIPTION
This PR introduces `java.time` alternatives to existing `org.threeten.bp.*` methods, as well as switching internal variables (if any) to `java.time`

The main constraint is to keep the changes backwards compatible, so for each existing threeten method "`method1(org.threeten.bp.Duration)`" we will add an alternative with a _Duration_ (or _Timestamp_ when applicable) suffix: "`method1Duration(java.time.Duration)`".

For most cases, the implementation will be held in the `java.time` method and the old threeten method will just delegate the call to it. However, for the case of abstract classes, the implementation will be kept in the threeten method to avoid breaking changes (i.e. users that already overloaded the method in their user code).