### PR TITLE
ci: full airlock settings [not for review]

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>com.google.cloud.artifactregistry</groupId>
+    <artifactId>artifactregistry-maven-wagon</artifactId>
+    <version>2.2.4</version>
+  </extension>
+</extensions>

--- a/.mvn/settings_airlock.xml
+++ b/.mvn/settings_airlock.xml
@@ -1,0 +1,16 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <!--
+      This settings.xml file forces the builds to download artifacts from Airlock.
+      This does not require changes in pom.xml files.
+    -->
+    <mirrors>
+        <mirror>
+            <id>mirror-of-all</id>
+            <name>Airlock Maven 3P Trusted</name>
+            <url>artifactregistry://us-maven.pkg.dev/artifact-foundry-prod/maven-3p-trusted</url>
+            <mirrorOf>*</mirrorOf>
+        </mirror>
+    </mirrors>
+</settings>

--- a/.mvn/settings_airlock_bootstrap.xml
+++ b/.mvn/settings_airlock_bootstrap.xml
@@ -1,0 +1,21 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <!--
+      This settings.xml file helps to download the artifactregistry-maven-wagon extension in local
+      Maven repository with repository ID "mirror-of-all", which is the same as the repository
+      ID in settings_airlock.xml. Because this correspondence, Maven will not try to download
+      the artifactregistry-maven-wagon from Airlock when this artifact and its dependencies are
+      available in the local Maven repository.
+    -->
+
+    <mirrors>
+        <mirror>
+            <id>mirror-of-all</id>
+            <name>AR Maven Central mirror</name>
+            <url>https://repo1.maven.org/maven2</url>
+            <mirrorOf>*</mirrorOf>
+        </mirror>
+    </mirrors>
+
+</settings>


### PR DESCRIPTION
b/384085175. I referenced https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools/issues/83#issuecomment-1524022896.

Step 1:

mvn --settings .mvn/settings_airlock_bootstrap.xml dependency:get -Dartifact=com.google.cloud.artifactregistry:artifactregistry-maven-wagon:2.2.4

Step 2:

mvn --settings .mvn/settings_airlock.xml clean install -DskipTests
