### PR TITLE
ci: full airlock settings [not for review]

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>com.google.cloud.artifactregistry</groupId>
+    <artifactId>artifactregistry-maven-wagon</artifactId>
+    <version>2.2.4</version>
+  </extension>
+</extensions>

--- a/.mvn/settings_airlock.xml
+++ b/.mvn/settings_airlock.xml
@@ -1,0 +1,16 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <!--
+      This settings.xml file forces the builds to download artifacts from Airlock.
+      This does not require changes in pom.xml files.
+    -->
+    <mirrors>
+        <mirror>
+            <id>mirror-of-all</id>
+            <name>Airlock Maven 3P Trusted</name>
+            <url>artifactregistry://us-maven.pkg.dev/artifact-foundry-prod/maven-3p-trusted</url>
+            <mirrorOf>*</mirrorOf>
+        </mirror>
+    </mirrors>
+</settings>

--- a/.mvn/settings_airlock_bootstrap.xml
+++ b/.mvn/settings_airlock_bootstrap.xml
@@ -1,0 +1,21 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <!--
+      This settings.xml file helps to download the artifactregistry-maven-wagon extension in local
+      Maven repository with repository ID "mirror-of-all", which is the same as the repository
+      ID in settings_airlock.xml. Because this correspondence, Maven will not try to download
+      the artifactregistry-maven-wagon from Airlock when this artifact and its dependencies are
+      available in the local Maven repository.
+    -->
+
+    <mirrors>
+        <mirror>
+            <id>mirror-of-all</id>
+            <name>AR Maven Central mirror</name>
+            <url>https://repo1.maven.org/maven2</url>
+            <mirrorOf>*</mirrorOf>
+        </mirror>
+    </mirrors>
+
+</settings>


### PR DESCRIPTION
b/384085175. This pull request is based on the release 1 month ago. I referenced https://github.com/GoogleCloudPlatform/artifact-registry-maven-tools/issues/83#issuecomment-1524022896.

# Step 0

```
git clone https://github.com/suztomo/java-storage
cd java-storage
git checkout airlock_settings
```

# Step 1

This command downloads the artifactregistry-maven-wagon extension and its dependencies to local Maven repository.

```
mvn -V --settings .mvn/settings_airlock_bootstrap.xml dependency:get -Dartifact=com.google.cloud.artifactregistry:artifactregistry-maven-wagon:2.2.4
```

It succeeds as of Dec 13th.

# Step 2

This command builds the project using artifacts in the Artifact Registry Maven repository. It uses the artifactregistry-maven-wagon extension.

```
mvn -V -U --settings .mvn/settings_airlock.xml clean install -DskipTests
```

It fails as of Dec 13th: `[ERROR] Failed to execute goal org.apache.maven.plugins:maven-clean-plugin:2.5:clean (default-clean) on project google-cloud-storage-parent: Execution default-clean of goal org.apache.maven.plugins:maven-clean-plugin:2.5:clean failed: Plugin org.apache.maven.plugins:maven-clean-plugin:2.5 or one of its dependencies could not be resolved: org.codehaus.plexus:plexus-utils:jar:3.0 was not found in artifactregistry://us-maven.pkg.dev/artifact-foundry-prod/maven-3p-trusted during a previous attempt.`

# Maven environment

```
~/java-storage $ mvn --version
Apache Maven 3.8.8 (4c87b05d9aedce574290d1acc98575ed5eb6cd39)
Maven home: /Users/suztomo/.sdkman/candidates/maven/current
Java version: 11.0.24, vendor: Eclipse Adoptium, runtime: /Users/suztomo/.sdkman/candidates/java/11.0.24-tem
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "15.1.1", arch: "aarch64", family: "mac"
```