### PR TITLE
test: make registry fixture names more "name~spacy" to appear better in otel traces

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITUniverseDomainTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITUniverseDomainTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.storage.it;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assume.assumeNotNull;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
@@ -43,6 +44,10 @@ public class ITUniverseDomainTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
+    assumeNotNull(TEST_UNIVERSE_DOMAIN);
+    assumeNotNull(TEST_PROJECT_ID);
+    assumeNotNull(TEST_UNIVERSE_LOCATION);
+    assumeNotNull(CREDENTIAL_PATH);
     GoogleCredentials creds =
         ServiceAccountCredentials.fromStream(Files.newInputStream(Paths.get(CREDENTIAL_PATH)))
             .toBuilder()

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/BackendResources.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/BackendResources.java
@@ -87,7 +87,7 @@ final class BackendResources implements ManagedLifecycle {
     ProtectedBucketNames protectedBucketNames = new ProtectedBucketNames();
     TestRunScopedInstance<StorageInstance> storageJson =
         TestRunScopedInstance.of(
-            "STORAGE_JSON_" + backend.name(),
+            "fixture/STORAGE/[JSON][" + backend.name() + "]",
             () -> {
               HttpStorageOptions.Builder optionsBuilder;
               switch (backend) {
@@ -108,7 +108,7 @@ final class BackendResources implements ManagedLifecycle {
             });
     TestRunScopedInstance<StorageInstance> storageGrpc =
         TestRunScopedInstance.of(
-            "STORAGE_GRPC_" + backend.name(),
+            "fixture/STORAGE/[GRPC][" + backend.name() + "]",
             () -> {
               GrpcStorageOptions.Builder optionsBuilder;
               switch (backend) {
@@ -137,7 +137,7 @@ final class BackendResources implements ManagedLifecycle {
             });
     TestRunScopedInstance<StorageControlInstance> ctrl =
         TestRunScopedInstance.of(
-            "STORAGE_CONTROL_" + backend.name(),
+            "fixture/STORAGE_CONTROL/[" + backend.name() + "]",
             () -> {
               StorageControlSettings.Builder builder;
               switch (backend) {
@@ -176,7 +176,7 @@ final class BackendResources implements ManagedLifecycle {
             });
     TestRunScopedInstance<BucketInfoShim> bucket =
         TestRunScopedInstance.of(
-            "BUCKET_" + backend.name(),
+            "fixture/BUCKET/[" + backend.name() + "]",
             () -> {
               String bucketName = String.format("java-storage-grpc-%s", UUID.randomUUID());
               protectedBucketNames.add(bucketName);
@@ -185,7 +185,7 @@ final class BackendResources implements ManagedLifecycle {
             });
     TestRunScopedInstance<BucketInfoShim> bucketRp =
         TestRunScopedInstance.of(
-            "BUCKET_REQUESTER_PAYS_" + backend.name(),
+            "fixture/BUCKET/[" + backend.name() + "]/REQUESTER_PAYS",
             () -> {
               String bucketName = String.format("java-storage-grpc-rp-%s", UUID.randomUUID());
               protectedBucketNames.add(bucketName);
@@ -196,7 +196,7 @@ final class BackendResources implements ManagedLifecycle {
             });
     TestRunScopedInstance<BucketInfoShim> bucketVersioned =
         TestRunScopedInstance.of(
-            "BUCKET_VERSIONED_" + backend.name(),
+            "fixture/BUCKET/[" + backend.name() + "]/VERSIONED",
             () -> {
               String bucketName = String.format("java-storage-grpc-v-%s", UUID.randomUUID());
               protectedBucketNames.add(bucketName);
@@ -207,7 +207,7 @@ final class BackendResources implements ManagedLifecycle {
             });
     TestRunScopedInstance<BucketInfoShim> bucketHns =
         TestRunScopedInstance.of(
-            "BUCKET_HNS_" + backend.name(),
+            "fixture/BUCKET/[" + backend.name() + "]/HNS",
             () -> {
               String bucketName = String.format("java-storage-grpc-hns-%s", UUID.randomUUID());
               protectedBucketNames.add(bucketName);
@@ -225,22 +225,23 @@ final class BackendResources implements ManagedLifecycle {
             });
     TestRunScopedInstance<ObjectsFixture> objectsFixture =
         TestRunScopedInstance.of(
-            "OBJECTS_FIXTURE_" + backend.name(),
+            "fixture/OBJECTS/[" + backend.name() + "]",
             () -> new ObjectsFixture(storageJson.get().getStorage(), bucket.get().getBucketInfo()));
     TestRunScopedInstance<ObjectsFixture> objectsFixtureRp =
         TestRunScopedInstance.of(
-            "OBJECTS_FIXTURE_REQUESTER_PAYS_" + backend.name(),
+            "fixture/OBJECTS/[" + backend.name() + "]/REQUESTER_PAYS",
             () ->
                 new ObjectsFixture(storageJson.get().getStorage(), bucketRp.get().getBucketInfo()));
     TestRunScopedInstance<ObjectsFixture> objectsFixtureHns =
         TestRunScopedInstance.of(
-            "OBJECTS_FIXTURE_HNS_" + backend.name(),
+            "fixture/OBJECTS/[" + backend.name() + "]/HNS",
             () ->
                 new ObjectsFixture(
                     storageJson.get().getStorage(), bucketHns.get().getBucketInfo()));
     TestRunScopedInstance<KmsFixture> kmsFixture =
         TestRunScopedInstance.of(
-            "KMS_FIXTURE_" + backend.name(), () -> KmsFixture.of(storageJson.get().getStorage()));
+            "fixture/KMS/[" + backend.name() + "]",
+            () -> KmsFixture.of(storageJson.get().getStorage()));
 
     return new BackendResources(
         backend,

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/Registry.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/Registry.java
@@ -73,14 +73,14 @@ public final class Registry extends RunListener {
               new ThreadFactoryBuilder().setDaemon(true).setNameFormat("test-run-%d").build()));
 
   private final TestRunScopedInstance<TestBench> testBench =
-      TestRunScopedInstance.of("TEST_BENCH", () -> TestBench.newBuilder().build());
+      TestRunScopedInstance.of("fixture/TEST_BENCH", () -> TestBench.newBuilder().build());
 
   private final TestRunScopedInstance<Generator> generator =
-      TestRunScopedInstance.of("GENERATOR", Generator::new);
+      TestRunScopedInstance.of("fixture/GENERATOR", Generator::new);
 
   final TestRunScopedInstance<OtelSdkShim> otelSdk =
       TestRunScopedInstance.of(
-          "OTEL_SDK",
+          "fixture/OTEL_SDK",
           () -> {
             String projectId = StorageOptions.getDefaultInstance().getProjectId();
             return new OtelSdkShim(projectId);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestRunScopedInstance.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestRunScopedInstance.java
@@ -53,7 +53,7 @@ final class TestRunScopedInstance<T extends ManagedLifecycle> implements Supplie
         if (instance == null) {
           // if we don't short-circuit for OTEL_SDK we will cause a stack overflow, because we would
           // be trying to get our instance to record that we're starting our instance.
-          if (name.equals("OTEL_SDK")) {
+          if (name.equals("fixture/OTEL_SDK")) {
             T tmp = ctor.get();
             tmp.start();
             instance = tmp;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8054aae0-0052-4b9e-8e81-fb1bbca3baa2)
