### PR TITLE
docs: update storage_copy_file to include MegabytesCopiedPerChunk

### DIFF
--- a/samples/snippets/src/test/java/com/example/storage/ITObjectSnippets.java
+++ b/samples/snippets/src/test/java/com/example/storage/ITObjectSnippets.java
@@ -134,7 +134,7 @@ public class ITObjectSnippets {
   }
 
   @Test
-  public void testCopyObject() {
+  public void testCopyObject() throws Exception {
     String newBucket = RemoteStorageHelper.generateBucketName();
     storage.create(BucketInfo.newBuilder(newBucket).build());
     try {


### PR DESCRIPTION
The GCS API that underpins `Storage#copy(CopyRequest)` is [`storage.objects.rewrite`](https://cloud.google.com/storage/docs/json_api/v1/objects/rewrite).

A rewrite is technically what we now refer to in Google Cloud API land as a Long Running Operation, meaning it's structured in such a way as to be able to take longer than would normally be acceptable for a single RPC.

In the case of performing the rewrite, GCS is "moving" the bytes over the google network and won't respond to the request at all until complete. If it takes GCS more than the client configured read timeout to actually "move" the bytes, the client interprets it as a read timeout and fails out.

Update the code snippet for copy to make it more robust to large objects.