### PR TITLE
feat(transfer-manager): add ParallelUploadConfig.Builder#setUploadBlobInfoFactory

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/BucketNameMismatchException.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/BucketNameMismatchException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.transfermanager;
+
+public final class BucketNameMismatchException extends RuntimeException {
+
+  public BucketNameMismatchException(String actual, String expected) {
+    super(
+        String.format(
+            "Bucket name in produced BlobInfo did not match bucket name from config. (%s != %s)",
+            actual, expected));
+  }
+}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerUtils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/TransferManagerUtils.java
@@ -26,14 +26,6 @@ final class TransferManagerUtils {
 
   private TransferManagerUtils() {}
 
-  static String createBlobName(ParallelUploadConfig config, Path file) {
-    if (config.getPrefix().isEmpty()) {
-      return file.toString();
-    } else {
-      return config.getPrefix().concat(file.toString());
-    }
-  }
-
   static Path createDestPath(ParallelDownloadConfig config, BlobInfo originalBlob) {
     Path newPath =
         config

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/transfermanager/TransferManagerTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/transfermanager/TransferManagerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.transfermanager;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.transfermanager.ParallelUploadConfig.UploadBlobInfoFactory;
+import java.util.function.Function;
+import org.junit.Test;
+
+public final class TransferManagerTest {
+
+  @Test
+  public void uploadBlobInfoFactory_prefixObjectNames_leadingSlash() {
+    UploadBlobInfoFactory factory = UploadBlobInfoFactory.prefixObjectNames("asdf");
+
+    BlobInfo info = factory.apply("bucket", "/f/i/l/e/n/a/m/e.txt");
+    assertThat(info.getBucket()).isEqualTo("bucket");
+    assertThat(info.getName()).isEqualTo("asdf/f/i/l/e/n/a/m/e.txt");
+  }
+
+  @Test
+  public void uploadBlobInfoFactory_prefixObjectNames() {
+    UploadBlobInfoFactory factory = UploadBlobInfoFactory.prefixObjectNames("asdf");
+
+    BlobInfo info = factory.apply("bucket", "n/a/m/e.txt");
+    assertThat(info.getBucket()).isEqualTo("bucket");
+    assertThat(info.getName()).isEqualTo("asdf/n/a/m/e.txt");
+  }
+
+  @Test
+  public void uploadBlobInfoFactory_transformFileName() {
+    UploadBlobInfoFactory factory =
+        UploadBlobInfoFactory.transformFileName(
+            Function.<String>identity().andThen(s -> s + "|").compose(s -> "|" + s));
+
+    BlobInfo info = factory.apply("bucket", "/e.txt");
+    assertThat(info.getBucket()).isEqualTo("bucket");
+    assertThat(info.getName()).isEqualTo("|/e.txt|");
+  }
+
+  @Test
+  public void uploadBlobInfoFactory_default_doesNotModify() {
+    UploadBlobInfoFactory factory = UploadBlobInfoFactory.defaultInstance();
+
+    BlobInfo info = factory.apply("bucket", "/e.txt");
+    assertThat(info.getBucket()).isEqualTo("bucket");
+    assertThat(info.getName()).isEqualTo("/e.txt");
+  }
+}


### PR DESCRIPTION
When uploading a file from the files system, there are scenarios when a job would need to customize the actual BlobInfo used to upload to GCS.

Add the new UploadBlobInfoFactory which allows a user to produce their own BlobInfo instance given the bucketName and fileName. When producing the BlobInfo the application can also customize other metadata fields.

A few convenience adapter methods are available in UploadBlobInfoFactory to simplify common operations.

Fixes #2638

