### PR TITLE
fix: update kms key handling when opening a resumable upload to clear the value in the json to be null rather than empty string

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java
@@ -1082,7 +1082,7 @@ public class HttpStorageRpc implements StorageRpc {
     try {
       String kmsKeyName = object.getKmsKeyName();
       if (kmsKeyName != null && kmsKeyName.contains("cryptoKeyVersions")) {
-        object.setKmsKeyName("");
+        object.setKmsKeyName(Data.nullOf(String.class));
       }
       Insert req =
           storage


### PR DESCRIPTION


Related to b/395940239

