### PR TITLE
feat: add new Options to allow per method header values

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
@@ -96,7 +96,6 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -159,6 +158,11 @@ public final class GrpcStorageOptions extends StorageOptions
   @InternalApi
   StorageSettings getStorageSettings() throws IOException {
     return resolveSettingsAndOpts().x();
+  }
+
+  @InternalApi
+  GrpcInterceptorProvider getGrpcInterceptorProvider() {
+    return grpcInterceptorProvider;
   }
 
   private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
@@ -225,7 +229,7 @@ public final class GrpcStorageOptions extends StorageOptions
           Map<String, List<String>> requestMetadata = credentials.getRequestMetadata(uri);
           for (Entry<String, List<String>> e : requestMetadata.entrySet()) {
             String key = e.getKey();
-            if ("x-goog-user-project".equals(key.trim().toLowerCase(Locale.ENGLISH))) {
+            if ("x-goog-user-project".equals(Utils.headerNameToLowerCase(key.trim()))) {
               List<String> value = e.getValue();
               if (!value.isEmpty()) {
                 foundQuotaProject = true;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSession.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSession.java
@@ -54,14 +54,13 @@ final class JsonResumableSession {
    * have the concept of nested retry handling.
    */
   ResumableOperationResult<@Nullable StorageObject> query() {
-    return new JsonResumableSessionQueryTask(context, resumableWrite.getUploadId()).call();
+    return new JsonResumableSessionQueryTask(context, resumableWrite).call();
   }
 
   ResumableOperationResult<@Nullable StorageObject> put(
       RewindableContent content, HttpContentRange contentRange) {
     JsonResumableSessionPutTask task =
-        new JsonResumableSessionPutTask(
-            context, resumableWrite.getUploadId(), content, contentRange);
+        new JsonResumableSessionPutTask(context, resumableWrite, content, contentRange);
     HttpRpcContext httpRpcContext = HttpRpcContext.getInstance();
     try {
       httpRpcContext.newInvocationId();

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionPutTask.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionPutTask.java
@@ -17,6 +17,7 @@
 package com.google.cloud.storage;
 
 import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpResponseException;
@@ -31,6 +32,7 @@ import io.opencensus.trace.Status;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Locale;
+import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -38,7 +40,7 @@ final class JsonResumableSessionPutTask
     implements Callable<ResumableOperationResult<@Nullable StorageObject>> {
 
   private final HttpClientContext context;
-  private final String uploadId;
+  private final JsonResumableWrite jsonResumableWrite;
   private final RewindableContent content;
   private final HttpContentRange originalContentRange;
 
@@ -47,11 +49,11 @@ final class JsonResumableSessionPutTask
   @VisibleForTesting
   JsonResumableSessionPutTask(
       HttpClientContext httpClientContext,
-      String uploadId,
+      JsonResumableWrite jsonResumableWrite,
       RewindableContent content,
       HttpContentRange originalContentRange) {
     this.context = httpClientContext;
-    this.uploadId = uploadId;
+    this.jsonResumableWrite = jsonResumableWrite;
     this.content = content;
     this.originalContentRange = originalContentRange;
     this.contentRange = originalContentRange;
@@ -87,13 +89,18 @@ final class JsonResumableSessionPutTask
     boolean success = false;
     boolean finalizing = originalContentRange.isFinalizing();
 
+    String uploadId = jsonResumableWrite.getUploadId();
     HttpRequest req =
         context
             .getRequestFactory()
             .buildPutRequest(new GenericUrl(uploadId), content)
             .setParser(context.getObjectParser());
     req.setThrowExceptionOnExecuteError(false);
-    req.getHeaders().setContentRange(contentRange.getHeaderValue());
+    HttpHeaders headers = req.getHeaders();
+    headers.setContentRange(contentRange.getHeaderValue());
+    for (Entry<String, String> e : jsonResumableWrite.getExtraheaders().entrySet()) {
+      headers.set(e.getKey(), e.getValue());
+    }
 
     HttpResponse response = null;
     try {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionPutTask.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionPutTask.java
@@ -98,7 +98,7 @@ final class JsonResumableSessionPutTask
     req.setThrowExceptionOnExecuteError(false);
     HttpHeaders headers = req.getHeaders();
     headers.setContentRange(contentRange.getHeaderValue());
-    for (Entry<String, String> e : jsonResumableWrite.getExtraheaders().entrySet()) {
+    for (Entry<String, String> e : jsonResumableWrite.getExtraHeaders().entrySet()) {
       headers.set(e.getKey(), e.getValue());
     }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionQueryTask.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionQueryTask.java
@@ -20,6 +20,7 @@ import static com.google.cloud.storage.HttpClientContext.firstHeaderValue;
 
 import com.google.api.client.http.EmptyContent;
 import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpResponseException;
@@ -27,6 +28,7 @@ import com.google.api.services.storage.model.StorageObject;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Locale;
+import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -34,15 +36,16 @@ final class JsonResumableSessionQueryTask
     implements Callable<ResumableOperationResult<@Nullable StorageObject>> {
 
   private final HttpClientContext context;
-  private final String uploadId;
+  private final JsonResumableWrite jsonResumableWrite;
 
-  JsonResumableSessionQueryTask(HttpClientContext context, String uploadId) {
+  JsonResumableSessionQueryTask(HttpClientContext context, JsonResumableWrite jsonResumableWrite) {
     this.context = context;
-    this.uploadId = uploadId;
+    this.jsonResumableWrite = jsonResumableWrite;
   }
 
   public ResumableOperationResult<@Nullable StorageObject> call() {
     HttpResponse response = null;
+    String uploadId = jsonResumableWrite.getUploadId();
     try {
       HttpRequest req =
           context
@@ -50,7 +53,11 @@ final class JsonResumableSessionQueryTask
               .buildPutRequest(new GenericUrl(uploadId), new EmptyContent())
               .setParser(context.getObjectParser());
       req.setThrowExceptionOnExecuteError(false);
-      req.getHeaders().setContentRange(HttpContentRange.query().getHeaderValue());
+      HttpHeaders headers = req.getHeaders();
+      headers.setContentRange(HttpContentRange.query().getHeaderValue());
+      for (Entry<String, String> e : jsonResumableWrite.getExtraheaders().entrySet()) {
+        headers.set(e.getKey(), e.getValue());
+      }
 
       response = req.execute();
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionQueryTask.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionQueryTask.java
@@ -55,7 +55,7 @@ final class JsonResumableSessionQueryTask
       req.setThrowExceptionOnExecuteError(false);
       HttpHeaders headers = req.getHeaders();
       headers.setContentRange(HttpContentRange.query().getHeaderValue());
-      for (Entry<String, String> e : jsonResumableWrite.getExtraheaders().entrySet()) {
+      for (Entry<String, String> e : jsonResumableWrite.getExtraHeaders().entrySet()) {
         headers.set(e.getKey(), e.getValue());
       }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableWrite.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableWrite.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.cloud.storage.spi.v1.StorageRpc;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.stream.JsonReader;
 import java.io.IOException;
@@ -58,6 +59,12 @@ final class JsonResumableWrite implements Serializable {
     this.signedUrl = signedUrl;
     this.uploadId = uploadId;
     this.beginOffset = beginOffset;
+  }
+
+  ImmutableMap<String, String> getExtraheaders() {
+    return MoreObjects.firstNonNull(
+        (ImmutableMap<String, String>) options.get(StorageRpc.Option.EXTRA_HEADERS),
+        ImmutableMap.of());
   }
 
   public @NonNull String getUploadId() {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableWrite.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableWrite.java
@@ -61,10 +61,12 @@ final class JsonResumableWrite implements Serializable {
     this.beginOffset = beginOffset;
   }
 
-  ImmutableMap<String, String> getExtraheaders() {
-    return MoreObjects.firstNonNull(
-        (ImmutableMap<String, String>) options.get(StorageRpc.Option.EXTRA_HEADERS),
-        ImmutableMap.of());
+  ImmutableMap<String, String> getExtraHeaders() {
+    Object tmp = options.get(StorageRpc.Option.EXTRA_HEADERS);
+    if (tmp != null) {
+      return (ImmutableMap<String, String>) tmp;
+    }
+    return ImmutableMap.of();
   }
 
   public @NonNull String getUploadId() {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableWrite.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableWrite.java
@@ -62,9 +62,11 @@ final class JsonResumableWrite implements Serializable {
   }
 
   ImmutableMap<String, String> getExtraHeaders() {
-    Object tmp = options.get(StorageRpc.Option.EXTRA_HEADERS);
-    if (tmp != null) {
-      return (ImmutableMap<String, String>) tmp;
+    if (options != null) {
+      Object tmp = options.get(StorageRpc.Option.EXTRA_HEADERS);
+      if (tmp != null) {
+        return (ImmutableMap<String, String>) tmp;
+      }
     }
     return ImmutableMap.of();
   }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableSessionFailureScenario.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableSessionFailureScenario.java
@@ -35,7 +35,6 @@ import io.grpc.StatusRuntimeException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -295,12 +294,12 @@ enum ResumableSessionFailureScenario {
   // The header names from HttpHeaders are lower cased, define some utility methods to create
   // predicates where we can specify values ignoring case
   private static Predicate<String> matches(String expected) {
-    String lower = expected.toLowerCase(Locale.US);
+    String lower = Utils.headerNameToLowerCase(expected);
     return lower::equals;
   }
 
   private static Predicate<String> startsWith(String prefix) {
-    String lower = prefix.toLowerCase(Locale.US);
+    String lower = Utils.headerNameToLowerCase(prefix);
     return s -> s.startsWith(lower);
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
@@ -472,6 +472,59 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     }
 
     /**
+     * A set of extra headers to be set for all requests performed within the scope of the operation
+     * this option is passed to (a get, read, resumable upload etc).
+     *
+     * <p>If the same header name is specified across multiple options provided to a method, the
+     * first occurrence will be the value included in the request(s).
+     *
+     * <p>The following headers are not allowed to be specified, and will result in an {@link
+     * IllegalArgumentException}.
+     *
+     * <ol>
+     *   <li>{@code Accept-Encoding}
+     *   <li>{@code Cache-Control}
+     *   <li>{@code Connection}
+     *   <li>{@code Content-ID}
+     *   <li>{@code Content-Length}
+     *   <li>{@code Content-Range}
+     *   <li>{@code Content-Transfer-Encoding}
+     *   <li>{@code Content-Type}
+     *   <li>{@code Date}
+     *   <li>{@code ETag}
+     *   <li>{@code If-Match}
+     *   <li>{@code If-None-Match}
+     *   <li>{@code Keep-Alive}
+     *   <li>{@code Range}
+     *   <li>{@code TE}
+     *   <li>{@code Trailer}
+     *   <li>{@code Transfer-Encoding}
+     *   <li>{@code User-Agent}
+     *   <li>{@code X-Goog-Api-Client}
+     *   <li>{@code X-Goog-Content-Length-Range}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Encryption-Key}
+     *   <li>{@code X-Goog-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Gcs-Idempotency-Token}
+     *   <li>{@code X-Goog-Meta-*}
+     *   <li>{@code X-Goog-User-Project}
+     *   <li>{@code X-HTTP-Method-Override}
+     *   <li>{@code X-Upload-Content-Length}
+     *   <li>{@code X-Upload-Content-Type}
+     * </ol>
+     *
+     * @since 2.49.0
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static BucketTargetOption extraHeaders(
+        @NonNull ImmutableMap<String, String> extraHeaders) {
+      return new BucketTargetOption(UnifiedOpts.extraHeaders(extraHeaders));
+    }
+
+    /**
      * Deduplicate any options which are the same parameter. The value which comes last in {@code
      * os} will be the value included in the return.
      */
@@ -543,6 +596,59 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BucketSourceOption requestedPolicyVersion(long version) {
       return new BucketSourceOption(UnifiedOpts.requestedPolicyVersion(version));
+    }
+
+    /**
+     * A set of extra headers to be set for all requests performed within the scope of the operation
+     * this option is passed to (a get, read, resumable upload etc).
+     *
+     * <p>If the same header name is specified across multiple options provided to a method, the
+     * first occurrence will be the value included in the request(s).
+     *
+     * <p>The following headers are not allowed to be specified, and will result in an {@link
+     * IllegalArgumentException}.
+     *
+     * <ol>
+     *   <li>{@code Accept-Encoding}
+     *   <li>{@code Cache-Control}
+     *   <li>{@code Connection}
+     *   <li>{@code Content-ID}
+     *   <li>{@code Content-Length}
+     *   <li>{@code Content-Range}
+     *   <li>{@code Content-Transfer-Encoding}
+     *   <li>{@code Content-Type}
+     *   <li>{@code Date}
+     *   <li>{@code ETag}
+     *   <li>{@code If-Match}
+     *   <li>{@code If-None-Match}
+     *   <li>{@code Keep-Alive}
+     *   <li>{@code Range}
+     *   <li>{@code TE}
+     *   <li>{@code Trailer}
+     *   <li>{@code Transfer-Encoding}
+     *   <li>{@code User-Agent}
+     *   <li>{@code X-Goog-Api-Client}
+     *   <li>{@code X-Goog-Content-Length-Range}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Encryption-Key}
+     *   <li>{@code X-Goog-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Gcs-Idempotency-Token}
+     *   <li>{@code X-Goog-Meta-*}
+     *   <li>{@code X-Goog-User-Project}
+     *   <li>{@code X-HTTP-Method-Override}
+     *   <li>{@code X-Upload-Content-Length}
+     *   <li>{@code X-Upload-Content-Type}
+     * </ol>
+     *
+     * @since 2.49.0
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static BucketSourceOption extraHeaders(
+        @NonNull ImmutableMap<String, String> extraHeaders) {
+      return new BucketSourceOption(UnifiedOpts.extraHeaders(extraHeaders));
     }
 
     /**
@@ -634,6 +740,59 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     }
 
     /**
+     * A set of extra headers to be set for all requests performed within the scope of the operation
+     * this option is passed to (a get, read, resumable upload etc).
+     *
+     * <p>If the same header name is specified across multiple options provided to a method, the
+     * first occurrence will be the value included in the request(s).
+     *
+     * <p>The following headers are not allowed to be specified, and will result in an {@link
+     * IllegalArgumentException}.
+     *
+     * <ol>
+     *   <li>{@code Accept-Encoding}
+     *   <li>{@code Cache-Control}
+     *   <li>{@code Connection}
+     *   <li>{@code Content-ID}
+     *   <li>{@code Content-Length}
+     *   <li>{@code Content-Range}
+     *   <li>{@code Content-Transfer-Encoding}
+     *   <li>{@code Content-Type}
+     *   <li>{@code Date}
+     *   <li>{@code ETag}
+     *   <li>{@code If-Match}
+     *   <li>{@code If-None-Match}
+     *   <li>{@code Keep-Alive}
+     *   <li>{@code Range}
+     *   <li>{@code TE}
+     *   <li>{@code Trailer}
+     *   <li>{@code Transfer-Encoding}
+     *   <li>{@code User-Agent}
+     *   <li>{@code X-Goog-Api-Client}
+     *   <li>{@code X-Goog-Content-Length-Range}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Encryption-Key}
+     *   <li>{@code X-Goog-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Gcs-Idempotency-Token}
+     *   <li>{@code X-Goog-Meta-*}
+     *   <li>{@code X-Goog-User-Project}
+     *   <li>{@code X-HTTP-Method-Override}
+     *   <li>{@code X-Upload-Content-Length}
+     *   <li>{@code X-Upload-Content-Type}
+     * </ol>
+     *
+     * @since 2.49.0
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static ListHmacKeysOption extraHeaders(
+        @NonNull ImmutableMap<String, String> extraHeaders) {
+      return new ListHmacKeysOption(UnifiedOpts.extraHeaders(extraHeaders));
+    }
+
+    /**
      * Deduplicate any options which are the same parameter. The value which comes last in {@code
      * os} will be the value included in the return.
      */
@@ -692,6 +851,59 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     }
 
     /**
+     * A set of extra headers to be set for all requests performed within the scope of the operation
+     * this option is passed to (a get, read, resumable upload etc).
+     *
+     * <p>If the same header name is specified across multiple options provided to a method, the
+     * first occurrence will be the value included in the request(s).
+     *
+     * <p>The following headers are not allowed to be specified, and will result in an {@link
+     * IllegalArgumentException}.
+     *
+     * <ol>
+     *   <li>{@code Accept-Encoding}
+     *   <li>{@code Cache-Control}
+     *   <li>{@code Connection}
+     *   <li>{@code Content-ID}
+     *   <li>{@code Content-Length}
+     *   <li>{@code Content-Range}
+     *   <li>{@code Content-Transfer-Encoding}
+     *   <li>{@code Content-Type}
+     *   <li>{@code Date}
+     *   <li>{@code ETag}
+     *   <li>{@code If-Match}
+     *   <li>{@code If-None-Match}
+     *   <li>{@code Keep-Alive}
+     *   <li>{@code Range}
+     *   <li>{@code TE}
+     *   <li>{@code Trailer}
+     *   <li>{@code Transfer-Encoding}
+     *   <li>{@code User-Agent}
+     *   <li>{@code X-Goog-Api-Client}
+     *   <li>{@code X-Goog-Content-Length-Range}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Encryption-Key}
+     *   <li>{@code X-Goog-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Gcs-Idempotency-Token}
+     *   <li>{@code X-Goog-Meta-*}
+     *   <li>{@code X-Goog-User-Project}
+     *   <li>{@code X-HTTP-Method-Override}
+     *   <li>{@code X-Upload-Content-Length}
+     *   <li>{@code X-Upload-Content-Type}
+     * </ol>
+     *
+     * @since 2.49.0
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static CreateHmacKeyOption extraHeaders(
+        @NonNull ImmutableMap<String, String> extraHeaders) {
+      return new CreateHmacKeyOption(UnifiedOpts.extraHeaders(extraHeaders));
+    }
+
+    /**
      * Deduplicate any options which are the same parameter. The value which comes last in {@code
      * os} will be the value included in the return.
      */
@@ -726,6 +938,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
 
   /** Class for specifying getHmacKey options */
   class GetHmacKeyOption extends Option<HmacKeySourceOpt> {
+
     private GetHmacKeyOption(HmacKeySourceOpt opt) {
       super(opt);
     }
@@ -746,6 +959,59 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static GetHmacKeyOption projectId(@NonNull String projectId) {
       return new GetHmacKeyOption(UnifiedOpts.projectId(projectId));
+    }
+
+    /**
+     * A set of extra headers to be set for all requests performed within the scope of the operation
+     * this option is passed to (a get, read, resumable upload etc).
+     *
+     * <p>If the same header name is specified across multiple options provided to a method, the
+     * first occurrence will be the value included in the request(s).
+     *
+     * <p>The following headers are not allowed to be specified, and will result in an {@link
+     * IllegalArgumentException}.
+     *
+     * <ol>
+     *   <li>{@code Accept-Encoding}
+     *   <li>{@code Cache-Control}
+     *   <li>{@code Connection}
+     *   <li>{@code Content-ID}
+     *   <li>{@code Content-Length}
+     *   <li>{@code Content-Range}
+     *   <li>{@code Content-Transfer-Encoding}
+     *   <li>{@code Content-Type}
+     *   <li>{@code Date}
+     *   <li>{@code ETag}
+     *   <li>{@code If-Match}
+     *   <li>{@code If-None-Match}
+     *   <li>{@code Keep-Alive}
+     *   <li>{@code Range}
+     *   <li>{@code TE}
+     *   <li>{@code Trailer}
+     *   <li>{@code Transfer-Encoding}
+     *   <li>{@code User-Agent}
+     *   <li>{@code X-Goog-Api-Client}
+     *   <li>{@code X-Goog-Content-Length-Range}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Encryption-Key}
+     *   <li>{@code X-Goog-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Gcs-Idempotency-Token}
+     *   <li>{@code X-Goog-Meta-*}
+     *   <li>{@code X-Goog-User-Project}
+     *   <li>{@code X-HTTP-Method-Override}
+     *   <li>{@code X-Upload-Content-Length}
+     *   <li>{@code X-Upload-Content-Type}
+     * </ol>
+     *
+     * @since 2.49.0
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static GetHmacKeyOption extraHeaders(
+        @NonNull ImmutableMap<String, String> extraHeaders) {
+      return new GetHmacKeyOption(UnifiedOpts.extraHeaders(extraHeaders));
     }
 
     /**
@@ -782,6 +1048,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
 
   /** Class for specifying deleteHmacKey options */
   class DeleteHmacKeyOption extends Option<HmacKeyTargetOpt> {
+
     private DeleteHmacKeyOption(HmacKeyTargetOpt opt) {
       super(opt);
     }
@@ -793,6 +1060,59 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static DeleteHmacKeyOption userProject(@NonNull String userProject) {
       return new DeleteHmacKeyOption(UnifiedOpts.userProject(userProject));
+    }
+
+    /**
+     * A set of extra headers to be set for all requests performed within the scope of the operation
+     * this option is passed to (a get, read, resumable upload etc).
+     *
+     * <p>If the same header name is specified across multiple options provided to a method, the
+     * first occurrence will be the value included in the request(s).
+     *
+     * <p>The following headers are not allowed to be specified, and will result in an {@link
+     * IllegalArgumentException}.
+     *
+     * <ol>
+     *   <li>{@code Accept-Encoding}
+     *   <li>{@code Cache-Control}
+     *   <li>{@code Connection}
+     *   <li>{@code Content-ID}
+     *   <li>{@code Content-Length}
+     *   <li>{@code Content-Range}
+     *   <li>{@code Content-Transfer-Encoding}
+     *   <li>{@code Content-Type}
+     *   <li>{@code Date}
+     *   <li>{@code ETag}
+     *   <li>{@code If-Match}
+     *   <li>{@code If-None-Match}
+     *   <li>{@code Keep-Alive}
+     *   <li>{@code Range}
+     *   <li>{@code TE}
+     *   <li>{@code Trailer}
+     *   <li>{@code Transfer-Encoding}
+     *   <li>{@code User-Agent}
+     *   <li>{@code X-Goog-Api-Client}
+     *   <li>{@code X-Goog-Content-Length-Range}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Encryption-Key}
+     *   <li>{@code X-Goog-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Gcs-Idempotency-Token}
+     *   <li>{@code X-Goog-Meta-*}
+     *   <li>{@code X-Goog-User-Project}
+     *   <li>{@code X-HTTP-Method-Override}
+     *   <li>{@code X-Upload-Content-Length}
+     *   <li>{@code X-Upload-Content-Type}
+     * </ol>
+     *
+     * @since 2.49.0
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static DeleteHmacKeyOption extraHeaders(
+        @NonNull ImmutableMap<String, String> extraHeaders) {
+      return new DeleteHmacKeyOption(UnifiedOpts.extraHeaders(extraHeaders));
     }
 
     /**
@@ -830,6 +1150,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
 
   /** Class for specifying updateHmacKey options */
   class UpdateHmacKeyOption extends Option<HmacKeyTargetOpt> {
+
     private UpdateHmacKeyOption(HmacKeyTargetOpt opt) {
       super(opt);
     }
@@ -841,6 +1162,59 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static UpdateHmacKeyOption userProject(@NonNull String userProject) {
       return new UpdateHmacKeyOption(UnifiedOpts.userProject(userProject));
+    }
+
+    /**
+     * A set of extra headers to be set for all requests performed within the scope of the operation
+     * this option is passed to (a get, read, resumable upload etc).
+     *
+     * <p>If the same header name is specified across multiple options provided to a method, the
+     * first occurrence will be the value included in the request(s).
+     *
+     * <p>The following headers are not allowed to be specified, and will result in an {@link
+     * IllegalArgumentException}.
+     *
+     * <ol>
+     *   <li>{@code Accept-Encoding}
+     *   <li>{@code Cache-Control}
+     *   <li>{@code Connection}
+     *   <li>{@code Content-ID}
+     *   <li>{@code Content-Length}
+     *   <li>{@code Content-Range}
+     *   <li>{@code Content-Transfer-Encoding}
+     *   <li>{@code Content-Type}
+     *   <li>{@code Date}
+     *   <li>{@code ETag}
+     *   <li>{@code If-Match}
+     *   <li>{@code If-None-Match}
+     *   <li>{@code Keep-Alive}
+     *   <li>{@code Range}
+     *   <li>{@code TE}
+     *   <li>{@code Trailer}
+     *   <li>{@code Transfer-Encoding}
+     *   <li>{@code User-Agent}
+     *   <li>{@code X-Goog-Api-Client}
+     *   <li>{@code X-Goog-Content-Length-Range}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Encryption-Key}
+     *   <li>{@code X-Goog-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Gcs-Idempotency-Token}
+     *   <li>{@code X-Goog-Meta-*}
+     *   <li>{@code X-Goog-User-Project}
+     *   <li>{@code X-HTTP-Method-Override}
+     *   <li>{@code X-Upload-Content-Length}
+     *   <li>{@code X-Upload-Content-Type}
+     * </ol>
+     *
+     * @since 2.49.0
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static UpdateHmacKeyOption extraHeaders(
+        @NonNull ImmutableMap<String, String> extraHeaders) {
+      return new UpdateHmacKeyOption(UnifiedOpts.extraHeaders(extraHeaders));
     }
 
     /**
@@ -927,6 +1301,58 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
               .add(fields)
               .build();
       return new BucketGetOption(UnifiedOpts.fields(set));
+    }
+
+    /**
+     * A set of extra headers to be set for all requests performed within the scope of the operation
+     * this option is passed to (a get, read, resumable upload etc).
+     *
+     * <p>If the same header name is specified across multiple options provided to a method, the
+     * first occurrence will be the value included in the request(s).
+     *
+     * <p>The following headers are not allowed to be specified, and will result in an {@link
+     * IllegalArgumentException}.
+     *
+     * <ol>
+     *   <li>{@code Accept-Encoding}
+     *   <li>{@code Cache-Control}
+     *   <li>{@code Connection}
+     *   <li>{@code Content-ID}
+     *   <li>{@code Content-Length}
+     *   <li>{@code Content-Range}
+     *   <li>{@code Content-Transfer-Encoding}
+     *   <li>{@code Content-Type}
+     *   <li>{@code Date}
+     *   <li>{@code ETag}
+     *   <li>{@code If-Match}
+     *   <li>{@code If-None-Match}
+     *   <li>{@code Keep-Alive}
+     *   <li>{@code Range}
+     *   <li>{@code TE}
+     *   <li>{@code Trailer}
+     *   <li>{@code Transfer-Encoding}
+     *   <li>{@code User-Agent}
+     *   <li>{@code X-Goog-Api-Client}
+     *   <li>{@code X-Goog-Content-Length-Range}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Encryption-Key}
+     *   <li>{@code X-Goog-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Gcs-Idempotency-Token}
+     *   <li>{@code X-Goog-Meta-*}
+     *   <li>{@code X-Goog-User-Project}
+     *   <li>{@code X-HTTP-Method-Override}
+     *   <li>{@code X-Upload-Content-Length}
+     *   <li>{@code X-Upload-Content-Type}
+     * </ol>
+     *
+     * @since 2.49.0
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static BucketGetOption extraHeaders(@NonNull ImmutableMap<String, String> extraHeaders) {
+      return new BucketGetOption(UnifiedOpts.extraHeaders(extraHeaders));
     }
 
     /**
@@ -1118,6 +1544,59 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     @TransportCompatibility({Transport.HTTP})
     public static BlobTargetOption overrideUnlockedRetention(boolean overrideUnlockedRetention) {
       return new BlobTargetOption(UnifiedOpts.overrideUnlockedRetention(overrideUnlockedRetention));
+    }
+
+    /**
+     * A set of extra headers to be set for all requests performed within the scope of the operation
+     * this option is passed to (a get, read, resumable upload etc).
+     *
+     * <p>If the same header name is specified across multiple options provided to a method, the
+     * first occurrence will be the value included in the request(s).
+     *
+     * <p>The following headers are not allowed to be specified, and will result in an {@link
+     * IllegalArgumentException}.
+     *
+     * <ol>
+     *   <li>{@code Accept-Encoding}
+     *   <li>{@code Cache-Control}
+     *   <li>{@code Connection}
+     *   <li>{@code Content-ID}
+     *   <li>{@code Content-Length}
+     *   <li>{@code Content-Range}
+     *   <li>{@code Content-Transfer-Encoding}
+     *   <li>{@code Content-Type}
+     *   <li>{@code Date}
+     *   <li>{@code ETag}
+     *   <li>{@code If-Match}
+     *   <li>{@code If-None-Match}
+     *   <li>{@code Keep-Alive}
+     *   <li>{@code Range}
+     *   <li>{@code TE}
+     *   <li>{@code Trailer}
+     *   <li>{@code Transfer-Encoding}
+     *   <li>{@code User-Agent}
+     *   <li>{@code X-Goog-Api-Client}
+     *   <li>{@code X-Goog-Content-Length-Range}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Encryption-Key}
+     *   <li>{@code X-Goog-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Gcs-Idempotency-Token}
+     *   <li>{@code X-Goog-Meta-*}
+     *   <li>{@code X-Goog-User-Project}
+     *   <li>{@code X-HTTP-Method-Override}
+     *   <li>{@code X-Upload-Content-Length}
+     *   <li>{@code X-Upload-Content-Type}
+     * </ol>
+     *
+     * @since 2.49.0
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static BlobTargetOption extraHeaders(
+        @NonNull ImmutableMap<String, String> extraHeaders) {
+      return new BlobTargetOption(UnifiedOpts.extraHeaders(extraHeaders));
     }
 
     /**
@@ -1347,6 +1826,58 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     }
 
     /**
+     * A set of extra headers to be set for all requests performed within the scope of the operation
+     * this option is passed to (a get, read, resumable upload etc).
+     *
+     * <p>If the same header name is specified across multiple options provided to a method, the
+     * first occurrence will be the value included in the request(s).
+     *
+     * <p>The following headers are not allowed to be specified, and will result in an {@link
+     * IllegalArgumentException}.
+     *
+     * <ol>
+     *   <li>{@code Accept-Encoding}
+     *   <li>{@code Cache-Control}
+     *   <li>{@code Connection}
+     *   <li>{@code Content-ID}
+     *   <li>{@code Content-Length}
+     *   <li>{@code Content-Range}
+     *   <li>{@code Content-Transfer-Encoding}
+     *   <li>{@code Content-Type}
+     *   <li>{@code Date}
+     *   <li>{@code ETag}
+     *   <li>{@code If-Match}
+     *   <li>{@code If-None-Match}
+     *   <li>{@code Keep-Alive}
+     *   <li>{@code Range}
+     *   <li>{@code TE}
+     *   <li>{@code Trailer}
+     *   <li>{@code Transfer-Encoding}
+     *   <li>{@code User-Agent}
+     *   <li>{@code X-Goog-Api-Client}
+     *   <li>{@code X-Goog-Content-Length-Range}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Encryption-Key}
+     *   <li>{@code X-Goog-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Gcs-Idempotency-Token}
+     *   <li>{@code X-Goog-Meta-*}
+     *   <li>{@code X-Goog-User-Project}
+     *   <li>{@code X-HTTP-Method-Override}
+     *   <li>{@code X-Upload-Content-Length}
+     *   <li>{@code X-Upload-Content-Type}
+     * </ol>
+     *
+     * @since 2.49.0
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static BlobWriteOption extraHeaders(@NonNull ImmutableMap<String, String> extraHeaders) {
+      return new BlobWriteOption(UnifiedOpts.extraHeaders(extraHeaders));
+    }
+
+    /**
      * Deduplicate any options which are the same parameter. The value which comes last in {@code
      * os} will be the value included in the return.
      */
@@ -1488,6 +2019,59 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobSourceOption shouldReturnRawInputStream(boolean shouldReturnRawInputStream) {
       return new BlobSourceOption(UnifiedOpts.returnRawInputStream(shouldReturnRawInputStream));
+    }
+
+    /**
+     * A set of extra headers to be set for all requests performed within the scope of the operation
+     * this option is passed to (a get, read, resumable upload etc).
+     *
+     * <p>If the same header name is specified across multiple options provided to a method, the
+     * first occurrence will be the value included in the request(s).
+     *
+     * <p>The following headers are not allowed to be specified, and will result in an {@link
+     * IllegalArgumentException}.
+     *
+     * <ol>
+     *   <li>{@code Accept-Encoding}
+     *   <li>{@code Cache-Control}
+     *   <li>{@code Connection}
+     *   <li>{@code Content-ID}
+     *   <li>{@code Content-Length}
+     *   <li>{@code Content-Range}
+     *   <li>{@code Content-Transfer-Encoding}
+     *   <li>{@code Content-Type}
+     *   <li>{@code Date}
+     *   <li>{@code ETag}
+     *   <li>{@code If-Match}
+     *   <li>{@code If-None-Match}
+     *   <li>{@code Keep-Alive}
+     *   <li>{@code Range}
+     *   <li>{@code TE}
+     *   <li>{@code Trailer}
+     *   <li>{@code Transfer-Encoding}
+     *   <li>{@code User-Agent}
+     *   <li>{@code X-Goog-Api-Client}
+     *   <li>{@code X-Goog-Content-Length-Range}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Encryption-Key}
+     *   <li>{@code X-Goog-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Gcs-Idempotency-Token}
+     *   <li>{@code X-Goog-Meta-*}
+     *   <li>{@code X-Goog-User-Project}
+     *   <li>{@code X-HTTP-Method-Override}
+     *   <li>{@code X-Upload-Content-Length}
+     *   <li>{@code X-Upload-Content-Type}
+     * </ol>
+     *
+     * @since 2.49.0
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static BlobSourceOption extraHeaders(
+        @NonNull ImmutableMap<String, String> extraHeaders) {
+      return new BlobSourceOption(UnifiedOpts.extraHeaders(extraHeaders));
     }
 
     /**
@@ -1659,6 +2243,58 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     }
 
     /**
+     * A set of extra headers to be set for all requests performed within the scope of the operation
+     * this option is passed to (a get, read, resumable upload etc).
+     *
+     * <p>If the same header name is specified across multiple options provided to a method, the
+     * first occurrence will be the value included in the request(s).
+     *
+     * <p>The following headers are not allowed to be specified, and will result in an {@link
+     * IllegalArgumentException}.
+     *
+     * <ol>
+     *   <li>{@code Accept-Encoding}
+     *   <li>{@code Cache-Control}
+     *   <li>{@code Connection}
+     *   <li>{@code Content-ID}
+     *   <li>{@code Content-Length}
+     *   <li>{@code Content-Range}
+     *   <li>{@code Content-Transfer-Encoding}
+     *   <li>{@code Content-Type}
+     *   <li>{@code Date}
+     *   <li>{@code ETag}
+     *   <li>{@code If-Match}
+     *   <li>{@code If-None-Match}
+     *   <li>{@code Keep-Alive}
+     *   <li>{@code Range}
+     *   <li>{@code TE}
+     *   <li>{@code Trailer}
+     *   <li>{@code Transfer-Encoding}
+     *   <li>{@code User-Agent}
+     *   <li>{@code X-Goog-Api-Client}
+     *   <li>{@code X-Goog-Content-Length-Range}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Encryption-Key}
+     *   <li>{@code X-Goog-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Gcs-Idempotency-Token}
+     *   <li>{@code X-Goog-Meta-*}
+     *   <li>{@code X-Goog-User-Project}
+     *   <li>{@code X-HTTP-Method-Override}
+     *   <li>{@code X-Upload-Content-Length}
+     *   <li>{@code X-Upload-Content-Type}
+     * </ol>
+     *
+     * @since 2.49.0
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static BlobGetOption extraHeaders(@NonNull ImmutableMap<String, String> extraHeaders) {
+      return new BlobGetOption(UnifiedOpts.extraHeaders(extraHeaders));
+    }
+
+    /**
      * Deduplicate any options which are the same parameter. The value which comes last in {@code
      * os} will be the value included in the return.
      */
@@ -1743,6 +2379,59 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     public static BlobRestoreOption copySourceAcl(boolean copySourceAcl) {
       return new BlobRestoreOption(UnifiedOpts.copySourceAcl(copySourceAcl));
     }
+
+    /**
+     * A set of extra headers to be set for all requests performed within the scope of the operation
+     * this option is passed to (a get, read, resumable upload etc).
+     *
+     * <p>If the same header name is specified across multiple options provided to a method, the
+     * first occurrence will be the value included in the request(s).
+     *
+     * <p>The following headers are not allowed to be specified, and will result in an {@link
+     * IllegalArgumentException}.
+     *
+     * <ol>
+     *   <li>{@code Accept-Encoding}
+     *   <li>{@code Cache-Control}
+     *   <li>{@code Connection}
+     *   <li>{@code Content-ID}
+     *   <li>{@code Content-Length}
+     *   <li>{@code Content-Range}
+     *   <li>{@code Content-Transfer-Encoding}
+     *   <li>{@code Content-Type}
+     *   <li>{@code Date}
+     *   <li>{@code ETag}
+     *   <li>{@code If-Match}
+     *   <li>{@code If-None-Match}
+     *   <li>{@code Keep-Alive}
+     *   <li>{@code Range}
+     *   <li>{@code TE}
+     *   <li>{@code Trailer}
+     *   <li>{@code Transfer-Encoding}
+     *   <li>{@code User-Agent}
+     *   <li>{@code X-Goog-Api-Client}
+     *   <li>{@code X-Goog-Content-Length-Range}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Encryption-Key}
+     *   <li>{@code X-Goog-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Gcs-Idempotency-Token}
+     *   <li>{@code X-Goog-Meta-*}
+     *   <li>{@code X-Goog-User-Project}
+     *   <li>{@code X-HTTP-Method-Override}
+     *   <li>{@code X-Upload-Content-Length}
+     *   <li>{@code X-Upload-Content-Type}
+     * </ol>
+     *
+     * @since 2.49.0
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static BlobRestoreOption extraHeaders(
+        @NonNull ImmutableMap<String, String> extraHeaders) {
+      return new BlobRestoreOption(UnifiedOpts.extraHeaders(extraHeaders));
+    }
   }
 
   /** Class for specifying bucket list options. */
@@ -1800,6 +2489,59 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
                       .map(f -> NamedField.prefixed("items/", f)))
               .collect(ImmutableSet.toImmutableSet());
       return new BucketListOption(UnifiedOpts.fields(set));
+    }
+
+    /**
+     * A set of extra headers to be set for all requests performed within the scope of the operation
+     * this option is passed to (a get, read, resumable upload etc).
+     *
+     * <p>If the same header name is specified across multiple options provided to a method, the
+     * first occurrence will be the value included in the request(s).
+     *
+     * <p>The following headers are not allowed to be specified, and will result in an {@link
+     * IllegalArgumentException}.
+     *
+     * <ol>
+     *   <li>{@code Accept-Encoding}
+     *   <li>{@code Cache-Control}
+     *   <li>{@code Connection}
+     *   <li>{@code Content-ID}
+     *   <li>{@code Content-Length}
+     *   <li>{@code Content-Range}
+     *   <li>{@code Content-Transfer-Encoding}
+     *   <li>{@code Content-Type}
+     *   <li>{@code Date}
+     *   <li>{@code ETag}
+     *   <li>{@code If-Match}
+     *   <li>{@code If-None-Match}
+     *   <li>{@code Keep-Alive}
+     *   <li>{@code Range}
+     *   <li>{@code TE}
+     *   <li>{@code Trailer}
+     *   <li>{@code Transfer-Encoding}
+     *   <li>{@code User-Agent}
+     *   <li>{@code X-Goog-Api-Client}
+     *   <li>{@code X-Goog-Content-Length-Range}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Encryption-Key}
+     *   <li>{@code X-Goog-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Gcs-Idempotency-Token}
+     *   <li>{@code X-Goog-Meta-*}
+     *   <li>{@code X-Goog-User-Project}
+     *   <li>{@code X-HTTP-Method-Override}
+     *   <li>{@code X-Upload-Content-Length}
+     *   <li>{@code X-Upload-Content-Type}
+     * </ol>
+     *
+     * @since 2.49.0
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static BucketListOption extraHeaders(
+        @NonNull ImmutableMap<String, String> extraHeaders) {
+      return new BucketListOption(UnifiedOpts.extraHeaders(extraHeaders));
     }
 
     /**
@@ -1977,6 +2719,58 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
     @TransportCompatibility({Transport.HTTP, Transport.GRPC})
     public static BlobListOption softDeleted(boolean softDeleted) {
       return new BlobListOption(UnifiedOpts.softDeleted(softDeleted));
+    }
+
+    /**
+     * A set of extra headers to be set for all requests performed within the scope of the operation
+     * this option is passed to (a get, read, resumable upload etc).
+     *
+     * <p>If the same header name is specified across multiple options provided to a method, the
+     * first occurrence will be the value included in the request(s).
+     *
+     * <p>The following headers are not allowed to be specified, and will result in an {@link
+     * IllegalArgumentException}.
+     *
+     * <ol>
+     *   <li>{@code Accept-Encoding}
+     *   <li>{@code Cache-Control}
+     *   <li>{@code Connection}
+     *   <li>{@code Content-ID}
+     *   <li>{@code Content-Length}
+     *   <li>{@code Content-Range}
+     *   <li>{@code Content-Transfer-Encoding}
+     *   <li>{@code Content-Type}
+     *   <li>{@code Date}
+     *   <li>{@code ETag}
+     *   <li>{@code If-Match}
+     *   <li>{@code If-None-Match}
+     *   <li>{@code Keep-Alive}
+     *   <li>{@code Range}
+     *   <li>{@code TE}
+     *   <li>{@code Trailer}
+     *   <li>{@code Transfer-Encoding}
+     *   <li>{@code User-Agent}
+     *   <li>{@code X-Goog-Api-Client}
+     *   <li>{@code X-Goog-Content-Length-Range}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key}
+     *   <li>{@code X-Goog-Copy-Source-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Encryption-Algorithm}
+     *   <li>{@code X-Goog-Encryption-Key}
+     *   <li>{@code X-Goog-Encryption-Key-Sha256}
+     *   <li>{@code X-Goog-Gcs-Idempotency-Token}
+     *   <li>{@code X-Goog-Meta-*}
+     *   <li>{@code X-Goog-User-Project}
+     *   <li>{@code X-HTTP-Method-Override}
+     *   <li>{@code X-Upload-Content-Length}
+     *   <li>{@code X-Upload-Content-Type}
+     * </ol>
+     *
+     * @since 2.49.0
+     */
+    @TransportCompatibility({Transport.HTTP, Transport.GRPC})
+    public static BlobListOption extraHeaders(@NonNull ImmutableMap<String, String> extraHeaders) {
+      return new BlobListOption(UnifiedOpts.extraHeaders(extraHeaders));
     }
 
     /**
@@ -5035,8 +5829,6 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
    * <p>This new method is an atomic equivalent of the existing {@link Storage#copy(CopyRequest)} +
    * {@link Storage#delete(BlobId)}, however without the ability to change metadata fields for the
    * target object.
-   *
-   * <p>This feature is currently only supported for HNS (Hierarchical Namespace) buckets.
    *
    * @since 2.48.0
    */

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
@@ -2049,8 +2049,7 @@ final class UnifiedOpts {
           return optionBuilder;
         }
         // not ideal, but ImmutableMap.Builder doesn't have any read methods so we can detect
-        // collision
-        // before build time.
+        // collision before build time.
         ImmutableMap<StorageRpc.Option, Object> builtOptions = Utils.mapBuild(optionBuilder);
         ImmutableMap<String, String> tmp =
             (ImmutableMap<String, String>) builtOptions.get(StorageRpc.Option.EXTRA_HEADERS);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Utils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Utils.java
@@ -40,6 +40,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -318,5 +319,9 @@ final class Utils {
 
   static <K, V> ImmutableMap<K, V> mapBuild(ImmutableMap.Builder<K, V> b) {
     return (ImmutableMap<K, V>) mapBuild.apply(b);
+  }
+
+  static String headerNameToLowerCase(String headerName) {
+    return headerName.toLowerCase(Locale.US);
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/XGoogApiClientHeaderProvider.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/XGoogApiClientHeaderProvider.java
@@ -24,7 +24,6 @@ import com.google.common.collect.MapDifference;
 import com.google.common.collect.MapDifference.ValueDifference;
 import com.google.common.collect.Maps;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collector;
@@ -98,7 +97,7 @@ final class XGoogApiClientHeaderProvider implements HeaderProvider {
     for (Entry<String, String> e : orig.entrySet()) {
       String k = e.getKey();
       String v = e.getValue();
-      tmp.put(k.toLowerCase(Locale.US), v);
+      tmp.put(Utils.headerNameToLowerCase(k), v);
     }
     return tmp;
   }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/StorageRpc.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/StorageRpc.java
@@ -78,7 +78,12 @@ public interface StorageRpc extends ServiceRpc {
     COPY_SOURCE_ACL("copySourceAcl"),
     GENERATION("generation"),
     INCLUDE_FOLDERS_AS_PREFIXES("includeFoldersAsPrefixes"),
-    X_UPLOAD_CONTENT_LENGTH("x-upload-content-length");
+    X_UPLOAD_CONTENT_LENGTH("x-upload-content-length"),
+    /**
+     * An {@link com.google.common.collect.ImmutableMap ImmutableMap&lt;String, String>} of values
+     * which will be set as additional headers on the request.
+     */
+    EXTRA_HEADERS("extra_headers");
 
     private final String value;
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITExtraHeadersOptionTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITExtraHeadersOptionTest.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.cloud.storage.TestUtils.assertAll;
+import static com.google.cloud.storage.TestUtils.xxd;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.gax.grpc.GrpcInterceptorProvider;
+import com.google.api.gax.paging.Page;
+import com.google.cloud.ReadChannel;
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.WriteChannel;
+import com.google.cloud.storage.Storage.BlobGetOption;
+import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.cloud.storage.Storage.BlobSourceOption;
+import com.google.cloud.storage.Storage.BlobTargetOption;
+import com.google.cloud.storage.Storage.BlobWriteOption;
+import com.google.cloud.storage.Storage.BucketGetOption;
+import com.google.cloud.storage.Storage.BucketListOption;
+import com.google.cloud.storage.Storage.ComposeRequest;
+import com.google.cloud.storage.Storage.CopyRequest;
+import com.google.cloud.storage.TransportCompatibility.Transport;
+import com.google.cloud.storage.it.AssertRequestHeaders;
+import com.google.cloud.storage.it.AssertRequestHeaders.FilteringPolicy;
+import com.google.cloud.storage.it.GrpcRequestAuditing;
+import com.google.cloud.storage.it.RequestAuditing;
+import com.google.cloud.storage.it.TemporaryBucket;
+import com.google.cloud.storage.it.runner.StorageITRunner;
+import com.google.cloud.storage.it.runner.annotations.Backend;
+import com.google.cloud.storage.it.runner.annotations.CrossRun;
+import com.google.cloud.storage.it.runner.annotations.Inject;
+import com.google.cloud.storage.it.runner.registry.Generator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.ByteStreams;
+import com.google.common.truth.IterableSubject;
+import io.grpc.ClientInterceptor;
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(StorageITRunner.class)
+@CrossRun(
+    backends = {Backend.PROD},
+    transports = {Transport.HTTP, Transport.GRPC})
+public final class ITExtraHeadersOptionTest {
+
+  private static final String HEADER_NAME = "x-my-header";
+  private static final String HEADER_VALUE = "value";
+  private static final ImmutableMap<String, String> EXTRA_HEADERS =
+      ImmutableMap.of(HEADER_NAME, HEADER_VALUE);
+  @Inject public BucketInfo bucket;
+  @Inject public Generator generator;
+  @Inject public Storage baseStorage;
+  @Inject public Transport transport;
+
+  private Storage storage;
+  private AssertRequestHeaders headers;
+
+  @Before
+  public void setUp() throws Exception {
+    switch (transport) {
+      case HTTP:
+        RequestAuditing requestAuditing = new RequestAuditing();
+        headers = requestAuditing;
+        storage =
+            ((HttpStorageOptions) baseStorage.getOptions())
+                .toBuilder()
+                .setTransportOptions(requestAuditing)
+                // we're counting requests, disable retries so that if a request fails it won't
+                // show up as a bad assertion of the test itself
+                .setRetrySettings(ServiceOptions.getNoRetrySettings())
+                .build()
+                .getService();
+        break;
+      case GRPC:
+        GrpcRequestAuditing grpcRequestAuditing = new GrpcRequestAuditing();
+        headers = grpcRequestAuditing;
+        GrpcStorageOptions grpcStorageOptions = (GrpcStorageOptions) baseStorage.getOptions();
+        GrpcInterceptorProvider grpcInterceptorProvider =
+            grpcStorageOptions.getGrpcInterceptorProvider();
+        storage =
+            grpcStorageOptions
+                .toBuilder()
+                // we're counting requests, disable retries so that if a request fails it won't
+                // show up as a bad assertion of the test itself
+                .setRetrySettings(ServiceOptions.getNoRetrySettings())
+                .setGrpcInterceptorProvider(
+                    () -> {
+                      List<ClientInterceptor> interceptors =
+                          grpcInterceptorProvider.getInterceptors();
+                      return ImmutableList.<ClientInterceptor>builder()
+                          .addAll(interceptors)
+                          .add(grpcRequestAuditing)
+                          .build();
+                    })
+                .build()
+                .getService();
+        break;
+    }
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (storage != null) {
+      storage.close();
+    }
+  }
+
+  @Test
+  public void simpleUnary() throws Exception {
+    Bucket gen1 = storage.get(bucket.getName(), BucketGetOption.extraHeaders(EXTRA_HEADERS));
+
+    IterableSubject subject = headers.assertRequestHeader(HEADER_NAME, FilteringPolicy.NO_FILTER);
+    assertAll(() -> subject.containsExactly(HEADER_VALUE));
+  }
+
+  @Test
+  public void pageObjects() throws Exception {
+    String baseName = generator.randomObjectName();
+    Blob blob1 = storage.create(BlobInfo.newBuilder(bucket, baseName + "1").build());
+    Blob blob2 = storage.create(BlobInfo.newBuilder(bucket, baseName + "2").build());
+
+    headers.clear();
+    ImmutableList<String> expectedNames = ImmutableList.of(blob1.getName(), blob2.getName());
+    Page<Blob> page =
+        storage.list(
+            bucket.getName(),
+            BlobListOption.prefix(baseName),
+            BlobListOption.pageSize(1),
+            BlobListOption.extraHeaders(EXTRA_HEADERS));
+
+    List<String> collect = page.streamAll().map(BlobInfo::getName).collect(Collectors.toList());
+    IterableSubject subject = headers.assertRequestHeader(HEADER_NAME, FilteringPolicy.NO_FILTER);
+    assertAll(
+        () -> assertThat(collect).hasSize(2),
+        () -> assertThat(collect).containsExactlyElementsIn(expectedNames),
+        () -> subject.containsExactly(HEADER_VALUE, HEADER_VALUE));
+  }
+
+  @Test
+  public void pageBucket() throws Exception {
+    String baseName = generator.randomBucketName();
+    BucketInfo info1 = BucketInfo.of(baseName + "1");
+    BucketInfo info2 = BucketInfo.of(baseName + "2");
+    try (TemporaryBucket tmp1 =
+            TemporaryBucket.newBuilder().setBucketInfo(info1).setStorage(storage).build();
+        TemporaryBucket tmp2 =
+            TemporaryBucket.newBuilder().setBucketInfo(info2).setStorage(storage).build()) {
+      headers.clear();
+      Page<Bucket> page =
+          storage.list(
+              BucketListOption.prefix(baseName),
+              BucketListOption.pageSize(1),
+              BucketListOption.extraHeaders(EXTRA_HEADERS));
+
+      List<String> collect = page.streamAll().map(BucketInfo::getName).collect(Collectors.toList());
+      IterableSubject subject = headers.assertRequestHeader(HEADER_NAME, FilteringPolicy.NO_FILTER);
+      assertAll(
+          () -> assertThat(collect).containsExactly(info1.getName(), info2.getName()),
+          () -> subject.containsExactly(HEADER_VALUE, HEADER_VALUE));
+    }
+  }
+
+  @Test
+  public void readAllBytes() throws Exception {
+    byte[] expected = DataGenerator.base64Characters().genBytes(512 * 1024 + 45);
+    String expectedXxd = xxd(expected);
+
+    Blob gen1 =
+        storage.create(
+            BlobInfo.newBuilder(bucket, generator.randomObjectName()).build(),
+            expected,
+            BlobTargetOption.doesNotExist());
+
+    headers.clear();
+    byte[] actual =
+        storage.readAllBytes(
+            gen1.getBlobId(),
+            BlobSourceOption.generationMatch(),
+            BlobSourceOption.extraHeaders(EXTRA_HEADERS));
+    IterableSubject subject = headers.assertRequestHeader(HEADER_NAME, FilteringPolicy.NO_FILTER);
+    String actualXxd = xxd(actual);
+
+    assertAll(
+        () -> subject.containsExactly(HEADER_VALUE),
+        () -> assertThat(actualXxd).isEqualTo(expectedXxd));
+  }
+
+  @Test
+  public void reader() throws Exception {
+    byte[] expected = DataGenerator.base64Characters().genBytes(512 * 1024 + 45);
+    String expectedXxd = xxd(expected);
+
+    Blob gen1 =
+        storage.create(
+            BlobInfo.newBuilder(bucket, generator.randomObjectName()).build(),
+            expected,
+            BlobTargetOption.doesNotExist());
+
+    headers.clear();
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ReadChannel reader =
+        storage.reader(
+            gen1.getBlobId(),
+            BlobSourceOption.generationMatch(),
+            BlobSourceOption.extraHeaders(EXTRA_HEADERS))) {
+      ByteStreams.copy(reader, Channels.newChannel(baos));
+    }
+    byte[] actual = baos.toByteArray();
+    IterableSubject subject = headers.assertRequestHeader(HEADER_NAME, FilteringPolicy.NO_FILTER);
+    String actualXxd = xxd(actual);
+
+    assertAll(
+        () -> subject.containsExactly(HEADER_VALUE),
+        () -> assertThat(actualXxd).isEqualTo(expectedXxd));
+  }
+
+  @Test
+  public void directUpload() throws Exception {
+    byte[] expected = DataGenerator.base64Characters().genBytes(512 * 1024 + 45);
+    String expectedXxd = xxd(expected);
+
+    BlobInfo info = BlobInfo.newBuilder(bucket, generator.randomObjectName()).build();
+    headers.clear();
+    Blob gen1 =
+        storage.create(
+            info,
+            expected,
+            BlobTargetOption.doesNotExist(),
+            BlobTargetOption.extraHeaders(EXTRA_HEADERS));
+    IterableSubject subject = headers.assertRequestHeader(HEADER_NAME, FilteringPolicy.NO_FILTER);
+
+    byte[] actual = storage.readAllBytes(gen1.getBlobId(), BlobSourceOption.generationMatch());
+    String actualXxd = xxd(actual);
+
+    assertAll(
+        () -> subject.containsExactly(HEADER_VALUE),
+        () -> assertThat(actualXxd).isEqualTo(expectedXxd));
+  }
+
+  @Test
+  public void resumableUpload() throws Exception {
+    byte[] expected = DataGenerator.base64Characters().genBytes(512 * 1024 + 45);
+    String expectedXxd = xxd(expected);
+
+    BlobInfo info = BlobInfo.newBuilder(bucket, generator.randomObjectName()).build();
+    try (WriteChannel writer =
+        storage.writer(
+            info, BlobWriteOption.doesNotExist(), BlobWriteOption.extraHeaders(EXTRA_HEADERS))) {
+      writer.setChunkSize(256 * 1024);
+      writer.write(ByteBuffer.wrap(Arrays.copyOfRange(expected, 0, 256 * 1024)));
+      writer.write(ByteBuffer.wrap(Arrays.copyOfRange(expected, 256 * 1024, 512 * 1024)));
+      writer.write(ByteBuffer.wrap(Arrays.copyOfRange(expected, 512 * 1024, expected.length)));
+    }
+    IterableSubject subject = headers.assertRequestHeader(HEADER_NAME, FilteringPolicy.NO_FILTER);
+
+    byte[] actual = storage.readAllBytes(info.getBlobId());
+    String actualXxd = xxd(actual);
+    assertAll(
+        () -> subject.containsExactly(HEADER_VALUE, HEADER_VALUE, HEADER_VALUE, HEADER_VALUE),
+        () -> assertThat(actualXxd).isEqualTo(expectedXxd));
+  }
+
+  @Test
+  @CrossRun.Exclude(transports = Transport.GRPC)
+  public void batch() throws Exception {
+    BlobInfo info1 = BlobInfo.newBuilder(bucket, generator.randomObjectName()).build();
+    BlobInfo info2 = BlobInfo.newBuilder(bucket, generator.randomObjectName()).build();
+    BlobInfo info3 = BlobInfo.newBuilder(bucket, generator.randomObjectName()).build();
+    storage.create(info1, BlobTargetOption.doesNotExist());
+    storage.create(info2, BlobTargetOption.doesNotExist());
+    storage.create(info3, BlobTargetOption.doesNotExist());
+
+    headers.clear();
+    OffsetDateTime now = Clock.systemUTC().instant().atOffset(ZoneOffset.UTC);
+
+    StorageBatch batch = storage.batch();
+    String batchHeaderKey = "x-batch-key";
+    StorageBatchResult<Blob> r1 =
+        batch.get(
+            info1.getBlobId(), BlobGetOption.extraHeaders(ImmutableMap.of(batchHeaderKey, "v1")));
+    StorageBatchResult<Blob> r2 =
+        batch.update(
+            info2.toBuilder().setCustomTimeOffsetDateTime(now).build(),
+            BlobTargetOption.extraHeaders(ImmutableMap.of(batchHeaderKey, "v2")));
+    StorageBatchResult<Boolean> r3 =
+        batch.delete(
+            info3.getBlobId(),
+            BlobSourceOption.extraHeaders(ImmutableMap.of(batchHeaderKey, "v3")));
+
+    batch.submit();
+    assertAll(
+        () -> assertThat(r1).isNotNull(),
+        () -> assertThat(r2.get().getCustomTimeOffsetDateTime()).isEqualTo(now),
+        () -> assertThat(r3.get()).isTrue(),
+        () -> {
+          IterableSubject subject = headers.assertRequestHeader(batchHeaderKey);
+          subject.containsExactly("v1", "v2", "v3");
+        });
+  }
+
+  @Test
+  public void rewrite() throws Exception {
+    BlobInfo info1 = BlobInfo.newBuilder(bucket, generator.randomObjectName()).build();
+    BlobInfo info2 = BlobInfo.newBuilder(bucket, generator.randomObjectName()).build();
+    BlobInfo gen1 = storage.create(info1, BlobTargetOption.doesNotExist());
+
+    CopyRequest copyRequest =
+        CopyRequest.newBuilder()
+            .setSource(gen1.getBlobId())
+            .setSourceOptions(
+                BlobSourceOption.extraHeaders(ImmutableMap.of("x-header-source", HEADER_VALUE)))
+            .setTarget(
+                info2,
+                BlobTargetOption.doesNotExist(),
+                BlobTargetOption.extraHeaders(ImmutableMap.of("x-header-target", HEADER_VALUE)))
+            .build();
+    headers.clear();
+    CopyWriter copyWriter = storage.copy(copyRequest);
+    copyWriter.getResult();
+    assertAll(
+        () -> {
+          IterableSubject subject = headers.assertRequestHeader("x-header-source");
+          subject.containsExactly(HEADER_VALUE);
+        },
+        () -> {
+          IterableSubject subject = headers.assertRequestHeader("x-header-target");
+          subject.containsExactly(HEADER_VALUE);
+        });
+  }
+
+  @Test
+  public void compose() throws Exception {
+    BlobInfo info1 = BlobInfo.newBuilder(bucket, generator.randomObjectName()).build();
+    BlobInfo info2 = BlobInfo.newBuilder(bucket, generator.randomObjectName()).build();
+    BlobInfo gen1 = storage.create(info1, BlobTargetOption.doesNotExist());
+
+    ComposeRequest composeRequest =
+        ComposeRequest.newBuilder()
+            .addSource(gen1.getBlobId().getName())
+            .setTarget(info2)
+            .setTargetOptions(
+                BlobTargetOption.doesNotExist(), BlobTargetOption.extraHeaders(EXTRA_HEADERS))
+            .build();
+    headers.clear();
+    Blob blob2 = storage.compose(composeRequest);
+    assertThat(blob2).isNotNull();
+    IterableSubject subject = headers.assertRequestHeader(HEADER_NAME, FilteringPolicy.NO_FILTER);
+    subject.containsExactly(HEADER_VALUE);
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITJsonResumableSessionPutTaskTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITJsonResumableSessionPutTaskTest.java
@@ -50,6 +50,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.Before;
 import org.junit.Rule;
@@ -99,7 +100,7 @@ public final class ITJsonResumableSessionPutTaskTest {
       JsonResumableSessionPutTask task =
           new JsonResumableSessionPutTask(
               httpClientContext,
-              uploadUrl,
+              jsonResumableWrite(uploadUrl),
               RewindableContent.empty(),
               HttpContentRange.of(ByteRangeSpec.explicitClosed(0L, 0L), 0));
 
@@ -147,7 +148,7 @@ public final class ITJsonResumableSessionPutTaskTest {
       JsonResumableSessionPutTask task =
           new JsonResumableSessionPutTask(
               httpClientContext,
-              uploadUrl,
+              jsonResumableWrite(uploadUrl),
               RewindableContent.empty(),
               HttpContentRange.of(ByteRangeSpec.explicitClosed(0L, 10L)));
 
@@ -228,7 +229,7 @@ public final class ITJsonResumableSessionPutTaskTest {
       JsonResumableSessionPutTask task =
           new JsonResumableSessionPutTask(
               httpClientContext,
-              uploadUrl,
+              jsonResumableWrite(uploadUrl),
               RewindableContent.of(tmpFile.getPath()),
               HttpContentRange.of(ByteRangeSpec.explicit(0L, _256KiBL)));
 
@@ -297,7 +298,7 @@ public final class ITJsonResumableSessionPutTaskTest {
       JsonResumableSessionPutTask task =
           new JsonResumableSessionPutTask(
               httpClientContext,
-              uploadUrl,
+              jsonResumableWrite(uploadUrl),
               RewindableContent.empty(),
               HttpContentRange.of(_256KiBL));
 
@@ -366,7 +367,7 @@ public final class ITJsonResumableSessionPutTaskTest {
       JsonResumableSessionPutTask task =
           new JsonResumableSessionPutTask(
               httpClientContext,
-              uploadUrl,
+              jsonResumableWrite(uploadUrl),
               RewindableContent.empty(),
               HttpContentRange.of(_512KiBL));
 
@@ -444,7 +445,7 @@ public final class ITJsonResumableSessionPutTaskTest {
       JsonResumableSessionPutTask task =
           new JsonResumableSessionPutTask(
               httpClientContext,
-              uploadUrl,
+              jsonResumableWrite(uploadUrl),
               RewindableContent.empty(),
               HttpContentRange.of(_256KiBL));
 
@@ -526,7 +527,7 @@ public final class ITJsonResumableSessionPutTaskTest {
       JsonResumableSessionPutTask task =
           new JsonResumableSessionPutTask(
               httpClientContext,
-              uploadUrl,
+              jsonResumableWrite(uploadUrl),
               RewindableContent.empty(),
               HttpContentRange.of(_512KiBL));
 
@@ -606,7 +607,7 @@ public final class ITJsonResumableSessionPutTaskTest {
       JsonResumableSessionPutTask task =
           new JsonResumableSessionPutTask(
               httpClientContext,
-              uploadUrl,
+              jsonResumableWrite(uploadUrl),
               RewindableContent.empty(),
               HttpContentRange.of(_128KiBL));
 
@@ -684,7 +685,7 @@ public final class ITJsonResumableSessionPutTaskTest {
       JsonResumableSessionPutTask task =
           new JsonResumableSessionPutTask(
               httpClientContext,
-              uploadUrl,
+              jsonResumableWrite(uploadUrl),
               RewindableContent.of(tmpFile.getPath()),
               HttpContentRange.of(ByteRangeSpec.explicit(_512KiBL, _768KiBL)));
 
@@ -716,7 +717,7 @@ public final class ITJsonResumableSessionPutTaskTest {
       JsonResumableSessionPutTask task =
           new JsonResumableSessionPutTask(
               httpClientContext,
-              uploadUrl,
+              jsonResumableWrite(uploadUrl),
               RewindableContent.of(tmpFile.getPath()),
               HttpContentRange.of(ByteRangeSpec.explicit(_512KiBL, _768KiBL)));
 
@@ -756,7 +757,10 @@ public final class ITJsonResumableSessionPutTaskTest {
 
       JsonResumableSessionPutTask task =
           new JsonResumableSessionPutTask(
-              httpClientContext, uploadUrl, RewindableContent.empty(), HttpContentRange.of(0));
+              httpClientContext,
+              jsonResumableWrite(uploadUrl),
+              RewindableContent.empty(),
+              HttpContentRange.of(0));
 
       StorageException se = assertThrows(StorageException.class, task::call);
       // the parse error happens while trying to read the success object, make sure we raise it as
@@ -791,7 +795,10 @@ public final class ITJsonResumableSessionPutTaskTest {
 
       JsonResumableSessionPutTask task =
           new JsonResumableSessionPutTask(
-              httpClientContext, uploadUrl, RewindableContent.empty(), HttpContentRange.of(0));
+              httpClientContext,
+              jsonResumableWrite(uploadUrl),
+              RewindableContent.empty(),
+              HttpContentRange.of(0));
 
       ResumableOperationResult<@Nullable StorageObject> operationResult = task.call();
       StorageObject call = operationResult.getObject();
@@ -856,5 +863,9 @@ public final class ITJsonResumableSessionPutTaskTest {
     task.rewindTo(_256KiBL + 13);
     assertThat(buf1.remaining()).isEqualTo(0);
     assertThat(buf2.position()).isEqualTo(13);
+  }
+
+  static @NonNull JsonResumableWrite jsonResumableWrite(String uploadUrl) {
+    return JsonResumableWrite.of(new StorageObject(), ImmutableMap.of(), uploadUrl, 0);
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITJsonResumableSessionQueryTaskTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITJsonResumableSessionQueryTaskTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.storage;
 
 import static com.google.cloud.storage.ByteSizeConstants._256KiBL;
+import static com.google.cloud.storage.ITJsonResumableSessionPutTaskTest.jsonResumableWrite;
 import static com.google.common.truth.Truth.assertThat;
 import static io.grpc.netty.shaded.io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static io.grpc.netty.shaded.io.netty.handler.codec.http.HttpResponseStatus.OK;
@@ -84,7 +85,7 @@ public final class ITJsonResumableSessionQueryTaskTest {
       String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableSessionQueryTask task =
-          new JsonResumableSessionQueryTask(httpClientContext, uploadUrl);
+          new JsonResumableSessionQueryTask(httpClientContext, jsonResumableWrite(uploadUrl));
 
       ResumableOperationResult<@Nullable StorageObject> result = task.call();
       StorageObject object = result.getObject();
@@ -107,7 +108,7 @@ public final class ITJsonResumableSessionQueryTaskTest {
       String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableSessionQueryTask task =
-          new JsonResumableSessionQueryTask(httpClientContext, uploadUrl);
+          new JsonResumableSessionQueryTask(httpClientContext, jsonResumableWrite(uploadUrl));
 
       ResumableOperationResult<@Nullable StorageObject> result = task.call();
       StorageObject object = result.getObject();
@@ -134,7 +135,7 @@ public final class ITJsonResumableSessionQueryTaskTest {
       String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableSessionQueryTask task =
-          new JsonResumableSessionQueryTask(httpClientContext, uploadUrl);
+          new JsonResumableSessionQueryTask(httpClientContext, jsonResumableWrite(uploadUrl));
 
       ResumableOperationResult<@Nullable StorageObject> result = task.call();
       assertThat(result.getPersistedSize()).isEqualTo(_256KiBL);
@@ -150,7 +151,7 @@ public final class ITJsonResumableSessionQueryTaskTest {
       String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableSessionQueryTask task =
-          new JsonResumableSessionQueryTask(httpClientContext, uploadUrl);
+          new JsonResumableSessionQueryTask(httpClientContext, jsonResumableWrite(uploadUrl));
 
       ResumableOperationResult<@Nullable StorageObject> result = task.call();
       assertThat(result.getPersistedSize()).isEqualTo(0);
@@ -167,7 +168,7 @@ public final class ITJsonResumableSessionQueryTaskTest {
       String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableSessionQueryTask task =
-          new JsonResumableSessionQueryTask(httpClientContext, uploadUrl);
+          new JsonResumableSessionQueryTask(httpClientContext, jsonResumableWrite(uploadUrl));
 
       StorageException se = assertThrows(StorageException.class, task::call);
       assertThat(se.getCode()).isEqualTo(0);
@@ -193,7 +194,7 @@ public final class ITJsonResumableSessionQueryTaskTest {
       String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableSessionQueryTask task =
-          new JsonResumableSessionQueryTask(httpClientContext, uploadUrl);
+          new JsonResumableSessionQueryTask(httpClientContext, jsonResumableWrite(uploadUrl));
 
       StorageException se = assertThrows(StorageException.class, task::call);
       assertThat(se.getCode()).isEqualTo(0);
@@ -221,7 +222,7 @@ public final class ITJsonResumableSessionQueryTaskTest {
       String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableSessionQueryTask task =
-          new JsonResumableSessionQueryTask(httpClientContext, uploadUrl);
+          new JsonResumableSessionQueryTask(httpClientContext, jsonResumableWrite(uploadUrl));
 
       StorageException se = assertThrows(StorageException.class, task::call);
       assertThat(se.getCode()).isEqualTo(0);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/AssertRequestHeaders.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/AssertRequestHeaders.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage.it;
+
+import com.google.common.truth.IterableSubject;
+
+public interface AssertRequestHeaders {
+
+  void clear();
+
+  default IterableSubject assertRequestHeader(String headerName) {
+    return assertRequestHeader(headerName, FilteringPolicy.DISTINCT);
+  }
+
+  IterableSubject assertRequestHeader(String headerName, FilteringPolicy filteringPolicy);
+
+  enum FilteringPolicy {
+    DISTINCT,
+    NO_FILTER
+  }
+}


### PR DESCRIPTION
Add new "Option"s for those methods which already have option types to allow providing an ImmutableMap<String, String> to be applied as extra headers to all requests sent as part of that operation.

If an operation has multiple sources of input Options (rewrite) the "first" (i.e. source option) will be the one added to the request.

The following resources do not have "Option"s and therefor do not have extra headers support at this time:
* Acl
* DefaultAcl
* ServiceAccount
* Notification

### Overview of the changes

This blind number of lines is large, but the number of differences is actually fairly low.

* Add `Headers` Opt` in UnifiedOpts, this is the primary guts of the new feature and is responsible for holding onto the extra header values and validating the provided headers to ensure no collisions with headers otherwise set by our library/restricted by gcs.
* The ~800 lines of change in Storage.java are the same "add new option `extraHeaders`" to each of the 15 option classes along with accompanying javadocs. All javadocs are the exact same, and were copy-pasted for each method.
* Create new utility method `Utils#headerNameToLowerCase` to centralize the logic for transforming header names across all locations
* Add new `StorageRpc.Options#EXTRA_HEADERS` to support extra headers for JSON calls
  * update JSON request building code in `HttpStorageRpc` (433 lines), `ApiaryUnbufferedReadableByteChannel` (13 lines) and `JsonResumable*` (~45 lines + ~50 lines for existing tests) classes to take `EXTRA_HEADERS` into consideration
* test: add new suite of tests `ITExtraHeadersOptionTest` to validate headers are properly added to each request of various operations
* test: introduce new interface `AssertRequestHeaders` which both `GrpcRequestAuditing` and `RequestAuditing` now implement -- this interface makes it easy for each transport to share common methods for asserting request headers
