### PR TITLE
chore: add renovate logging config

### DIFF
--- a/google-cloud-storage/src/test/resources/logback.xml
+++ b/google-cloud-storage/src/test/resources/logback.xml
@@ -78,8 +78,8 @@
   <logger name="jdk.event.security" level="warn"/>
   <!-- http request logging -->
   <logger name="sun.net.www.protocol.http.HttpURLConnection" level="warn"/>
-  <logger name="com.google.api.client.http.HttpTransport" level="debug"/>
-  <logger name="com.google.cloud.storage.it.GrpcPlainRequestLoggingInterceptor" level="trace"/>
+  <logger name="com.google.api.client.http.HttpTransport" level="warn"/>
+  <logger name="com.google.cloud.storage.it.GrpcPlainRequestLoggingInterceptor" level="warn"/>
   <!-- grpc netty traffic logging -->
   <!--<logger name="io.grpc.netty.shaded.io.netty.handler.ssl.SslHandler" level="debug"/>-->
   <!--<logger name="io.grpc.netty.shaded.io.grpc.netty.NettyClientHandler" level="debug"/>-->

--- a/renovate.json
+++ b/renovate.json
@@ -94,7 +94,9 @@
         "^org.mockito:mockito-core",
         "^org.objenesis:objenesis",
         "^com.google.cloud:google-cloud-conformance-tests",
-        "^io.github.classgraph:classgraph"
+        "^io.github.classgraph:classgraph",
+        "^ch.qos.logback:logback-classic",
+        "^org.slf4j:jul-to-slf4j"
       ],
       "semanticCommitType": "test",
       "semanticCommitScope": "deps"
@@ -139,6 +141,12 @@
         "^com.google.cloud:sdk-platform-java-config"
       ],
       "groupName": "sdk-platform-java dependencies"
+    },
+    {
+      "packagePatterns": [
+        "^ch.qos.logback:logback-classic"
+      ],
+      "allowedVersions": "<1.5.0"
     }
   ],
   "semanticCommits": true,


### PR DESCRIPTION
Update default log levels for http and grpc requests

Follow-up for #2948  and #2946 