### PR TITLE
fix: update usages of String.format to explicitly pass Locale.US

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannel.java
@@ -52,6 +52,7 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
@@ -318,7 +319,10 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
     } else {
       throw new IllegalStateException(
           String.format(
-              "Unexpected header type '%s' for header %s", o.getClass().getName(), headerName));
+              Locale.US,
+              "Unexpected header type '%s' for header %s",
+              o.getClass().getName(),
+              headerName));
     }
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobInfo.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobInfo.java
@@ -40,6 +40,7 @@ import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -1441,7 +1442,7 @@ public class BlobInfo implements Serializable {
     byte[] decodedMd5 = BaseEncoding.base64().decode(md5);
     StringBuilder stringBuilder = new StringBuilder();
     for (byte b : decodedMd5) {
-      stringBuilder.append(String.format("%02x", b & 0xff));
+      stringBuilder.append(String.format(Locale.US, "%02x", b & 0xff));
     }
     return stringBuilder.toString();
   }
@@ -1473,7 +1474,7 @@ public class BlobInfo implements Serializable {
     byte[] decodeCrc32c = BaseEncoding.base64().decode(crc32c);
     StringBuilder stringBuilder = new StringBuilder();
     for (byte b : decodeCrc32c) {
-      stringBuilder.append(String.format("%02x", b & 0xff));
+      stringBuilder.append(String.format(Locale.US, "%02x", b & 0xff));
     }
     return stringBuilder.toString();
   }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ByteRangeSpec.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ByteRangeSpec.java
@@ -24,6 +24,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.storage.v2.ReadObjectRequest;
 import java.io.Serializable;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import javax.annotation.concurrent.Immutable;
@@ -239,12 +240,12 @@ abstract class ByteRangeSpec implements Serializable {
 
     @Override
     protected String fmtAsHttpRangeHeader() throws ArithmeticException {
-      return String.format("bytes=%d-%d", beginOffset, endOffsetInclusive());
+      return String.format(Locale.US, "bytes=%d-%d", beginOffset, endOffsetInclusive());
     }
 
     @Override
     protected ToStringHelper append(ToStringHelper tsh) {
-      return tsh.addValue(String.format("%d + %d", beginOffset, length));
+      return tsh.addValue(String.format(Locale.US, "%d + %d", beginOffset, length));
     }
   }
 
@@ -324,12 +325,12 @@ abstract class ByteRangeSpec implements Serializable {
 
     @Override
     protected String fmtAsHttpRangeHeader() throws ArithmeticException {
-      return String.format("bytes=%d-%d", beginOffset, endOffsetInclusive());
+      return String.format(Locale.US, "bytes=%d-%d", beginOffset, endOffsetInclusive());
     }
 
     @Override
     protected ToStringHelper append(ToStringHelper tsh) {
-      return tsh.addValue(String.format("[%d, %d)", beginOffset, endOffsetExclusive));
+      return tsh.addValue(String.format(Locale.US, "[%d, %d)", beginOffset, endOffsetExclusive));
     }
   }
 
@@ -409,12 +410,12 @@ abstract class ByteRangeSpec implements Serializable {
 
     @Override
     protected String fmtAsHttpRangeHeader() throws ArithmeticException {
-      return String.format("bytes=%d-%d", beginOffset, endOffsetInclusive);
+      return String.format(Locale.US, "bytes=%d-%d", beginOffset, endOffsetInclusive);
     }
 
     @Override
     protected ToStringHelper append(ToStringHelper tsh) {
-      return tsh.addValue(String.format("[%d, %d]", beginOffset, endOffsetInclusive));
+      return tsh.addValue(String.format(Locale.US, "[%d, %d]", beginOffset, endOffsetInclusive));
     }
   }
 
@@ -488,9 +489,9 @@ abstract class ByteRangeSpec implements Serializable {
     @Override
     protected String fmtAsHttpRangeHeader() throws ArithmeticException {
       if (beginOffset > 0) {
-        return String.format("bytes=%d-", beginOffset);
+        return String.format(Locale.US, "bytes=%d-", beginOffset);
       } else if (beginOffset < 0) {
-        return String.format("bytes=%d", beginOffset);
+        return String.format(Locale.US, "bytes=%d", beginOffset);
       } else {
         return null;
       }
@@ -498,7 +499,7 @@ abstract class ByteRangeSpec implements Serializable {
 
     @Override
     protected ToStringHelper append(ToStringHelper tsh) {
-      return tsh.addValue(String.format("[%d, +INF)", beginOffset));
+      return tsh.addValue(String.format(Locale.US, "[%d, +INF)", beginOffset));
     }
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Crc32cValue.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Crc32cValue.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.storage;
 
+import java.util.Locale;
 import java.util.Objects;
 
 abstract class Crc32cValue<Res extends Crc32cValue<Res>> {
@@ -64,7 +65,7 @@ abstract class Crc32cValue<Res extends Crc32cValue<Res>> {
   }
 
   static String fmtCrc32cValue(int value1) {
-    return String.format("crc32c{0x%08x}", value1);
+    return String.format(Locale.US, "crc32c{0x%08x}", value1);
   }
 
   static final class Crc32cLengthUnknown extends Crc32cValue<Crc32cLengthUnknown> {
@@ -142,7 +143,7 @@ abstract class Crc32cValue<Res extends Crc32cValue<Res>> {
 
     @Override
     public String toString() {
-      return String.format("crc32c{0x%08x (length = %d)}", value, length);
+      return String.format(Locale.US, "crc32c{0x%08x (length = %d)}", value, length);
     }
 
     @Override

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/CrossTransportUtils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/CrossTransportUtils.java
@@ -18,6 +18,7 @@ package com.google.cloud.storage;
 
 import com.google.cloud.storage.TransportCompatibility.Transport;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 final class CrossTransportUtils {
@@ -49,12 +50,20 @@ final class CrossTransportUtils {
         break;
       default:
         throw new IllegalStateException(
-            String.format("Broken Java Enum: %s received value: '%s'", Transport.class, transport));
+            String.format(
+                Locale.US,
+                "Broken Java Enum: %s received value: '%s'",
+                Transport.class,
+                transport));
     }
     String message =
         String.format(
+            Locale.US,
             "%s#%s is only supported for %s transport. Please use %s to construct a compatible instance.",
-            clazz.getName(), methodName, transport, builder);
+            clazz.getName(),
+            methodName,
+            transport,
+            builder);
     throw new UnsupportedOperationException(message);
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedReadableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedReadableByteChannel.java
@@ -42,6 +42,7 @@ import java.io.InterruptedIOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ScatteringByteChannel;
+import java.util.Locale;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -166,8 +167,10 @@ final class GapicUnbufferedReadableByteChannel
         } else if (metadata.getGeneration() != respMetadata.getGeneration()) {
           throw closeWithError(
               String.format(
+                  Locale.US,
                   "Mismatch Generation between subsequent reads. Expected %d but received %d",
-                  metadata.getGeneration(), respMetadata.getGeneration()));
+                  metadata.getGeneration(),
+                  respMetadata.getGeneration()));
         }
       }
       ChecksummedData checksummedData = resp.getChecksummedData();

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageOptions.java
@@ -96,6 +96,7 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -210,10 +211,10 @@ public final class GrpcStorageOptions extends StorageOptions
     // unless for Direct Google Access try and strip here if we can
     switch (scheme) {
       case "http":
-        endpoint = String.format("%s:%s", uri.getHost(), port > 0 ? port : 80);
+        endpoint = String.format(Locale.US, "%s:%s", uri.getHost(), port > 0 ? port : 80);
         break;
       case "https":
-        endpoint = String.format("%s:%s", uri.getHost(), port > 0 ? port : 443);
+        endpoint = String.format(Locale.US, "%s:%s", uri.getHost(), port > 0 ? port : 443);
         break;
     }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcUtils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcUtils.java
@@ -19,6 +19,7 @@ package com.google.cloud.storage;
 import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.Locale;
 
 final class GrpcUtils {
 
@@ -28,7 +29,8 @@ final class GrpcUtils {
     if (bucketName != null && !bucketName.isEmpty()) {
       return baseContext.withExtraHeaders(
           ImmutableMap.of(
-              "x-goog-request-params", ImmutableList.of(String.format("bucket=%s", bucketName))));
+              "x-goog-request-params",
+              ImmutableList.of(String.format(Locale.US, "bucket=%s", bucketName))));
     }
     return baseContext;
   }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Hasher.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Hasher.java
@@ -21,6 +21,7 @@ import com.google.common.hash.Hashing;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.Immutable;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -98,8 +99,10 @@ interface Hasher {
       if (!actual.eqValue(expected)) {
         throw new IOException(
             String.format(
+                Locale.US,
                 "Mismatch checksum value. Expected %s actual %s",
-                expected.debugString(), actual.debugString()));
+                expected.debugString(),
+                actual.debugString()));
       }
     }
 
@@ -109,8 +112,10 @@ interface Hasher {
       if (!actual.eqValue(expected)) {
         throw new IOException(
             String.format(
+                Locale.US,
                 "Mismatch checksum value. Expected %s actual %s",
-                expected.debugString(), actual.debugString()));
+                expected.debugString(),
+                actual.debugString()));
       }
     }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpContentRange.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpContentRange.java
@@ -19,6 +19,7 @@ package com.google.cloud.storage;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.MoreObjects;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.function.UnaryOperator;
 
@@ -91,7 +92,8 @@ abstract class HttpContentRange {
 
     @Override
     public String getHeaderValue() {
-      return String.format("bytes %d-%d/*", spec.beginOffset(), spec.endOffsetInclusive());
+      return String.format(
+          Locale.US, "bytes %d-%d/*", spec.beginOffset(), spec.endOffsetInclusive());
     }
 
     @Override
@@ -145,7 +147,8 @@ abstract class HttpContentRange {
 
     @Override
     public String getHeaderValue() {
-      return String.format("bytes %d-%d/%d", spec.beginOffset(), spec.endOffsetInclusive(), size);
+      return String.format(
+          Locale.US, "bytes %d-%d/%d", spec.beginOffset(), spec.endOffsetInclusive(), size);
     }
 
     @Override
@@ -202,7 +205,7 @@ abstract class HttpContentRange {
 
     @Override
     public String getHeaderValue() {
-      return String.format("bytes */%d", size);
+      return String.format(Locale.US, "bytes */%d", size);
     }
 
     @Override

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSession.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSession.java
@@ -23,13 +23,14 @@ import com.google.cloud.storage.Retrying.RetryingDependencies;
 import com.google.cloud.storage.spi.v1.HttpRpcContext;
 import com.google.cloud.storage.spi.v1.HttpStorageRpc;
 import io.opencensus.trace.EndSpanOptions;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class JsonResumableSession {
 
   static final String SPAN_NAME_WRITE =
-      String.format("Sent.%s.write", HttpStorageRpc.class.getName());
+      String.format(Locale.US, "Sent.%s.write", HttpStorageRpc.class.getName());
   static final EndSpanOptions END_SPAN_OPTIONS =
       EndSpanOptions.builder().setSampleToLocalSpanStore(true).build();
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/MetadataField.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/MetadataField.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -102,7 +103,7 @@ final class MetadataField<T> {
     }
 
     String encode() {
-      return String.format("%04d-%04d", begin, end);
+      return String.format(Locale.US, "%04d-%04d", begin, end);
     }
 
     static PartRange decode(String s) {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/OtelStorageDecorator.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/OtelStorageDecorator.java
@@ -278,7 +278,7 @@ final class OtelStorageDecorator implements Storage {
     Span span =
         tracer
             .spanBuilder("get")
-            .setAttribute("gsutil.uri", String.format("gs://%s/%s", bucket, blob))
+            .setAttribute("gsutil.uri", String.format(Locale.US, "gs://%s/%s", bucket, blob))
             .startSpan();
     try (Scope ignore = span.makeCurrent()) {
       return delegate.get(bucket, blob, options);
@@ -1477,7 +1477,7 @@ final class OtelStorageDecorator implements Storage {
   }
 
   private static @NonNull String fmtBucket(String bucket) {
-    return String.format("gs://%s/", bucket);
+    return String.format(Locale.US, "gs://%s/", bucket);
   }
 
   private static final class TracerDecorator implements Tracer {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ParallelCompositeUploadWritableByteChannel.java
@@ -63,6 +63,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -245,8 +246,10 @@ final class ParallelCompositeUploadWritableByteChannel implements BufferedWritab
                         buildParallelCompositeUploadException(
                             ApiExceptionFactory.createException(
                                 String.format(
+                                    Locale.US,
                                     "CRC32C Checksum mismatch. expected: [%s] but was: [%s]",
-                                    expectedCrc32c, crc32c),
+                                    expectedCrc32c,
+                                    crc32c),
                                 null,
                                 GrpcStatusCode.of(Code.DATA_LOSS),
                                 false),
@@ -477,6 +480,7 @@ final class ParallelCompositeUploadWritableByteChannel implements BufferedWritab
 
                   String message =
                       String.format(
+                          Locale.US,
                           "Incomplete parallel composite upload cleanup after previous error. Unknown object ids: %s",
                           failedGsUris);
                   StorageException storageException = new StorageException(0, message, null);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/PostPolicyV4.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/PostPolicyV4.java
@@ -24,6 +24,7 @@ import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -416,7 +417,7 @@ public final class PostPolicyV4 {
       for (int i = 0; i < jsonArray.length; i++) {
         char c = jsonArray[i];
         if (c >= 128) { // is a unicode character
-          escapedJson.append(String.format("\\u%04x", (int) c));
+          escapedJson.append(String.format(Locale.US, "\\u%04x", (int) c));
         } else {
           switch (c) {
             case '\\':

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ReadCursor.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ReadCursor.java
@@ -17,6 +17,8 @@ package com.google.cloud.storage;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.util.Locale;
+
 /**
  * Shrink wraps a beginning, offset and limit for tracking state of an individual invocation of
  * {@link #read}
@@ -47,6 +49,7 @@ final class ReadCursor {
 
   @Override
   public String toString() {
-    return String.format("ReadCursor{begin=%d, offset=%d, limit=%d}", beginning, offset, limit);
+    return String.format(
+        Locale.US, "ReadCursor{begin=%d, offset=%d, limit=%d}", beginning, offset, limit);
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableSessionFailureScenario.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ResumableSessionFailureScenario.java
@@ -35,6 +35,7 @@ import io.grpc.StatusRuntimeException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -145,7 +146,10 @@ enum ResumableSessionFailureScenario {
         ResumableSessionFailureScenario.toStorageException(
             cause.getStatusCode(),
             String.format(
-                "%d %s", cause.getStatusCode(), statusMessage == null ? "" : statusMessage),
+                Locale.US,
+                "%d %s",
+                cause.getStatusCode(),
+                statusMessage == null ? "" : statusMessage),
             "",
             uploadId,
             response,
@@ -368,8 +372,10 @@ enum ResumableSessionFailureScenario {
       sb.append("\n").append(prefix).append(t2);
       sb.append(
           String.format(
+              Locale.US,
               "checksummed_data: {range: [%d:%d]",
-              writeOffset, writeOffset + checksummedData.getContent().size()));
+              writeOffset,
+              writeOffset + checksummedData.getContent().size()));
       if (checksummedData.hasCrc32C()) {
         sb.append(", crc32c: ").append(checksummedData.getCrc32C());
       }
@@ -402,8 +408,10 @@ enum ResumableSessionFailureScenario {
       sb.append("\n").append(prefix).append(t2);
       sb.append(
           String.format(
+              Locale.US,
               "checksummed_data: {range: [%d:%d]",
-              writeOffset, writeOffset + checksummedData.getContent().size()));
+              writeOffset,
+              writeOffset + checksummedData.getContent().size()));
       if (checksummedData.hasCrc32C()) {
         sb.append(", crc32c: ").append(checksummedData.getCrc32C());
       }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/RewindableContent.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/RewindableContent.java
@@ -31,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
+import java.util.Locale;
 
 abstract class RewindableContent extends AbstractHttpContent {
 
@@ -65,8 +66,11 @@ abstract class RewindableContent extends AbstractHttpContent {
     if (!(0 <= srcsOffset && srcsOffset <= srcs.length)) {
       throw new ArrayIndexOutOfBoundsException(
           String.format(
+              Locale.US,
               "srcsOffset out of bounds (0 <= %d && %d <= %d)",
-              srcsOffset, srcsOffset, srcs.length));
+              srcsOffset,
+              srcsOffset,
+              srcs.length));
     }
     Preconditions.checkArgument(srcsLength >= 0, "srcsLength >= 0 (%d >= 0)", srcsLength);
     int end = srcsOffset + srcsLength;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageOptions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageOptions.java
@@ -32,6 +32,7 @@ import com.google.cloud.storage.spi.StorageRpcFactory;
 import io.opentelemetry.api.OpenTelemetry;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Locale;
 import java.util.Properties;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -46,7 +47,10 @@ public abstract class StorageOptions extends ServiceOptions<Storage, StorageOpti
     try {
       String resourcePath =
           String.format(
-              "/META-INF/maven/%s/%s/pom.properties", "com.google.cloud", "google-cloud-storage");
+              Locale.US,
+              "/META-INF/maven/%s/%s/pom.properties",
+              "com.google.cloud",
+              "google-cloud-storage");
       InputStream resourceAsStream = StorageOptions.class.getResourceAsStream(resourcePath);
       if (resourceAsStream == null) {
         // some classloaders don't like a leading slash

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ThroughputSink.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ThroughputSink.java
@@ -24,6 +24,7 @@ import java.nio.channels.WritableByteChannel;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Logger;
@@ -163,6 +164,7 @@ interface ThroughputSink {
       LOGGER.info(
           () ->
               String.format(
+                  Locale.US,
                   "{%s} (%01.03f MiB/s) %s",
                   prefix,
                   ((r.numBytes * MiB)

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java
@@ -322,7 +322,7 @@ public class HttpStorageRpc implements StorageRpc {
           // Here we only add a annotation to at least know how much time each batch takes.
           span.addAnnotation("Execute batch request");
           batch.setBatchUrl(
-              new GenericUrl(String.format("%s/batch/storage/v1", options.getHost())));
+              new GenericUrl(String.format(Locale.US, "%s/batch/storage/v1", options.getHost())));
           batch.execute();
         }
       } catch (IOException ex) {
@@ -901,7 +901,7 @@ public class HttpStorageRpc implements StorageRpc {
       }
 
       if (position > 0) {
-        req.getRequestHeaders().setRange(String.format("bytes=%d-", position));
+        req.getRequestHeaders().setRange(String.format(Locale.US, "bytes=%d-", position));
       }
       MediaHttpDownloader mediaHttpDownloader = req.getMediaHttpDownloader();
       mediaHttpDownloader.setDirectDownloadEnabled(true);
@@ -1021,7 +1021,7 @@ public class HttpStorageRpc implements StorageRpc {
     try {
       GenericUrl url = new GenericUrl(uploadId);
       HttpRequest req = storage.getRequestFactory().buildPutRequest(url, new EmptyContent());
-      req.getHeaders().setContentRange(String.format("bytes */%s", totalBytes));
+      req.getHeaders().setContentRange(String.format(Locale.US, "bytes */%s", totalBytes));
       req.setParser(storage.getObjectParser());
       HttpResponse response = req.execute();
       // If the response is 200

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpcSpans.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpcSpans.java
@@ -17,6 +17,7 @@
 package com.google.cloud.storage.spi.v1;
 
 import io.opencensus.trace.EndSpanOptions;
+import java.util.Locale;
 
 /** Helper class for instrumenting {@link HttpStorageRpc} with Open Census APIs. */
 class HttpStorageRpcSpans {
@@ -102,7 +103,11 @@ class HttpStorageRpcSpans {
 
   static String getTraceSpanName(String methodDescriptor) {
     return String.format(
-        "%s.%s.%s", SPAN_NAME_CLIENT_PREFIX, HttpStorageRpc.class.getName(), methodDescriptor);
+        Locale.US,
+        "%s.%s.%s",
+        SPAN_NAME_CLIENT_PREFIX,
+        HttpStorageRpc.class.getName(),
+        methodDescriptor);
   }
 
   private HttpStorageRpcSpans() {}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/BucketNameMismatchException.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/transfermanager/BucketNameMismatchException.java
@@ -16,12 +16,16 @@
 
 package com.google.cloud.storage.transfermanager;
 
+import java.util.Locale;
+
 public final class BucketNameMismatchException extends RuntimeException {
 
   public BucketNameMismatchException(String actual, String expected) {
     super(
         String.format(
+            Locale.US,
             "Bucket name in produced BlobInfo did not match bucket name from config. (%s != %s)",
-            actual, expected));
+            actual,
+            expected));
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ByteRangeSpecTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ByteRangeSpecTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.stream.Stream;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -644,11 +645,11 @@ public final class ByteRangeSpecTest {
   }
 
   private static String headerRangeOpen(long min) {
-    return String.format("bytes=%d-", min);
+    return String.format(Locale.US, "bytes=%d-", min);
   }
 
   private static String headerRangeClosed(long min, long max) {
-    return String.format("bytes=%d-%d", min, max);
+    return String.format(Locale.US, "bytes=%d-%d", min, max);
   }
 
   private static ReadObjectRequest reqOpen(long offset) {
@@ -683,7 +684,7 @@ public final class ByteRangeSpecTest {
     @Override
     public String toString() {
       return String.format(
-          "Expect that %s is applicable to %s", expectations.testNameFormat(), spec);
+          Locale.US, "Expect that %s is applicable to %s", expectations.testNameFormat(), spec);
     }
 
     static ExpectationsBuilder expectThat() {
@@ -769,7 +770,7 @@ public final class ByteRangeSpecTest {
           // to the max value at a glance. In an effort to help this, for any value that is within
           // 20 of Long.MAX_VALUE format it as a difference.
           if (diff <= 20) {
-            return String.format("(Long.MAX_VALUE - %d)", diff);
+            return String.format(Locale.US, "(Long.MAX_VALUE - %d)", diff);
           } else {
             return l.toString();
           }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ChunkSegmenterTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ChunkSegmenterTest.java
@@ -28,6 +28,7 @@ import com.google.protobuf.ByteString;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -253,11 +254,11 @@ final class ChunkSegmenterTest {
     }
 
     static String fmt(int i) {
-      return String.format("0x%08x", i);
+      return String.format(Locale.US, "0x%08x", i);
     }
 
     static String fmt(long i) {
-      return String.format("0x%016x", i);
+      return String.format(Locale.US, "0x%016x", i);
     }
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/DataGenerator.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/DataGenerator.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Path;
+import java.util.Locale;
 import java.util.Random;
 import java.util.stream.IntStream;
 
@@ -84,7 +85,7 @@ public abstract class DataGenerator {
   public final TmpFile tempFile(Path baseDir, long size) throws IOException {
     requireNonNull(baseDir, "baseDir must be non null");
     checkState(size > 0, "size must be > 0");
-    TmpFile bin = TmpFile.of(baseDir, String.format("%015d-", size), ".bin");
+    TmpFile bin = TmpFile.of(baseDir, String.format(Locale.US, "%015d-", size), ".bin");
     ReadableByteChannel src =
         new ReadableByteChannel() {
           long read = 0;

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/DefaultBufferedReadableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/DefaultBufferedReadableByteChannelTest.java
@@ -31,6 +31,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ReadableByteChannel;
+import java.util.Locale;
 import java.util.stream.IntStream;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
@@ -144,11 +145,11 @@ public final class DefaultBufferedReadableByteChannelTest {
 
       if (fullReadCount > 0 && remainingRead > 0) {
         dbgExpectedReadSizes =
-            String.format("[%s * %d, %s]", readSize, fullReadCount, remainingRead);
+            String.format(Locale.US, "[%s * %d, %s]", readSize, fullReadCount, remainingRead);
       } else if (remainingRead > 0) {
-        dbgExpectedReadSizes = String.format("[%s]", remainingRead);
+        dbgExpectedReadSizes = String.format(Locale.US, "[%s]", remainingRead);
       } else {
-        dbgExpectedReadSizes = String.format("[%s * %d]", readSize, fullReadCount);
+        dbgExpectedReadSizes = String.format(Locale.US, "[%s * %d]", readSize, fullReadCount);
       }
     }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/DefaultBufferedWritableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/DefaultBufferedWritableByteChannelTest.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import net.jqwik.api.Arbitraries;
@@ -562,11 +563,16 @@ public final class DefaultBufferedWritableByteChannelTest {
       if (fullWriteCount > 0 && remainingWrite > 0) {
         dbgExpectedWriteSizes =
             String.format(
-                "[%s * %s, %s]", fmt(writeSize), fmt(fullWriteCount), fmt(remainingWrite));
+                Locale.US,
+                "[%s * %s, %s]",
+                fmt(writeSize),
+                fmt(fullWriteCount),
+                fmt(remainingWrite));
       } else if (remainingWrite > 0) {
-        dbgExpectedWriteSizes = String.format("[%s]", fmt(remainingWrite));
+        dbgExpectedWriteSizes = String.format(Locale.US, "[%s]", fmt(remainingWrite));
       } else {
-        dbgExpectedWriteSizes = String.format("[%s * %s]", fmt(writeSize), fmt(fullWriteCount));
+        dbgExpectedWriteSizes =
+            String.format(Locale.US, "[%s * %s]", fmt(writeSize), fmt(fullWriteCount));
       }
       return new WriteOps(
           bytes,

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/DefaultRetryHandlingBehaviorTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/DefaultRetryHandlingBehaviorTest.java
@@ -40,6 +40,7 @@ import java.security.cert.CertificateException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Function;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
@@ -168,8 +169,10 @@ public final class DefaultRetryHandlingBehaviorTest {
    */
   private static String token(ThrowableCategory t, HandlerCategory h) {
     return String.format(
+        Locale.US,
         "new Case(ThrowableCategory.%s, HandlerCategory.%s, /*TODO*/ null, /*TODO*/ null)",
-        t.name(), h.name());
+        t.name(),
+        h.name());
   }
 
   /**
@@ -1093,7 +1096,7 @@ public final class DefaultRetryHandlingBehaviorTest {
     private final boolean isRetryable;
 
     private RetryableException(boolean isRetryable) {
-      super(String.format("RetryableException{isRetryable=%s}", isRetryable));
+      super(String.format(Locale.US, "RetryableException{isRetryable=%s}", isRetryable));
       this.isRetryable = isRetryable;
     }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/FakeServer.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/FakeServer.java
@@ -24,6 +24,7 @@ import io.grpc.Server;
 import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 final class FakeServer implements AutoCloseable {
@@ -53,7 +54,7 @@ final class FakeServer implements AutoCloseable {
     InetSocketAddress address = new InetSocketAddress("localhost", 0);
     Server server = NettyServerBuilder.forAddress(address).addService(service).build();
     server.start();
-    String endpoint = String.format("%s:%d", address.getHostString(), server.getPort());
+    String endpoint = String.format(Locale.US, "%s:%d", address.getHostString(), server.getPort());
     GrpcStorageOptions grpcStorageOptions =
         StorageOptions.grpc()
             .setHost("http://" + endpoint)

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/GenerateGrpcProtobufReflectConfig.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/GenerateGrpcProtobufReflectConfig.java
@@ -27,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -66,6 +67,7 @@ public final class GenerateGrpcProtobufReflectConfig {
                       .map(
                           name ->
                               String.format(
+                                  Locale.US,
                                   "{ \"name\": \"%s\", \"queryAllDeclaredConstructors\": true, \"queryAllPublicConstructors\": true, \"queryAllDeclaredMethods\": true, \"allPublicMethods\": true, \"allDeclaredClasses\": true, \"allPublicClasses\": true }",
                                   name)))
               .flatMap(s -> s)

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/HttpContentRangeTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/HttpContentRangeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.cloud.storage.HttpContentRange.parse;
+import static com.google.cloud.storage.TestUtils.assertAll;
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Locale;
+import java.util.Locale.Category;
+import org.junit.Test;
+
+public final class HttpContentRangeTest {
+
+  @Test
+  public void localeDoesNotImpactThings() throws Exception {
+    // can fail on java11+
+    // https://docs.oracle.com/javase/tutorial/i18n/locale/scope.html
+    Locale before = Locale.getDefault(Category.FORMAT);
+    try {
+      // arabic local, also RTL instead of LTR
+      Locale ar = Locale.forLanguageTag("ar");
+      Locale.setDefault(Category.FORMAT, ar);
+      assertAll(
+          () -> assertThat(parse("bytes 0-9/9").getHeaderValue()).isEqualTo("bytes 0-9/9"),
+          () -> assertThat(parse("bytes 0-9/*").getHeaderValue()).isEqualTo("bytes 0-9/*"),
+          () -> assertThat(parse("bytes */9").getHeaderValue()).isEqualTo("bytes */9"),
+          () -> assertThat(parse("bytes */*").getHeaderValue()).isEqualTo("bytes */*"));
+    } finally {
+      Locale.setDefault(Category.FORMAT, before);
+      assertThat(Locale.getDefault(Category.FORMAT)).isEqualTo(before);
+    }
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicBidiUnbufferedWritableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicBidiUnbufferedWritableByteChannelTest.java
@@ -43,6 +43,7 @@ import io.grpc.stub.CallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -880,6 +881,7 @@ public final class ITGapicBidiUnbufferedWritableByteChannelTest {
       Collector<CharSequence, ?, String> oneLine = Collectors.joining(",", "[", "]");
       String msg =
           String.format(
+              Locale.US,
               "Unexpected Request Chain.%nexpected one of: %s%n        but was: %s",
               writes.stream()
                   .map(l -> l.stream().map(StorageV2ProtoUtils::fmtProto).collect(oneLine))

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicUnbufferedWritableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicUnbufferedWritableByteChannelTest.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -194,9 +195,9 @@ public final class ITGapicUnbufferedWritableByteChannelTest {
       try {
         ImmutableList<ByteBuffer> buffers = TestUtils.subDivide(bytes, 10);
         for (ByteBuffer buf : buffers) {
-          debugMessages.add(String.format("Writing buffer. buf = %s", buf));
+          debugMessages.add(String.format(Locale.US, "Writing buffer. buf = %s", buf));
           int written = c.write(buf);
-          debugMessages.add(String.format("Wrote bytes. written = %2d", written));
+          debugMessages.add(String.format(Locale.US, "Wrote bytes. written = %2d", written));
         }
         // explicitly only close on success so we can trap the original error that maybe have
         // happened before we reach here.
@@ -371,6 +372,7 @@ public final class ITGapicUnbufferedWritableByteChannelTest {
       Collector<CharSequence, ?, String> oneLine = Collectors.joining(",", "[", "]");
       String msg =
           String.format(
+              Locale.US,
               "Unexpected Request Chain.%nexpected one of: %s%n        but was: %s",
               writes.stream()
                   .map(l -> l.stream().map(StorageV2ProtoUtils::fmtProto).collect(oneLine))

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITJsonResumableSessionPutTaskTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITJsonResumableSessionPutTaskTest.java
@@ -48,6 +48,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -95,7 +96,8 @@ public final class ITJsonResumableSessionPutTaskTest {
 
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableSessionPutTask task =
           new JsonResumableSessionPutTask(
@@ -141,7 +143,8 @@ public final class ITJsonResumableSessionPutTaskTest {
 
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       AtomicLong confirmedBytes = new AtomicLong(-1L);
 
@@ -222,7 +225,8 @@ public final class ITJsonResumableSessionPutTaskTest {
         TmpFile tmpFile =
             DataGenerator.base64Characters().tempFile(temp.newFolder().toPath(), _256KiBL)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       AtomicLong confirmedBytes = new AtomicLong(-1L);
 
@@ -291,7 +295,8 @@ public final class ITJsonResumableSessionPutTaskTest {
 
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       AtomicLong confirmedBytes = new AtomicLong(-1L);
 
@@ -360,7 +365,8 @@ public final class ITJsonResumableSessionPutTaskTest {
 
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       AtomicLong confirmedBytes = new AtomicLong(-1L);
 
@@ -440,7 +446,8 @@ public final class ITJsonResumableSessionPutTaskTest {
 
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableSessionPutTask task =
           new JsonResumableSessionPutTask(
@@ -520,7 +527,8 @@ public final class ITJsonResumableSessionPutTaskTest {
 
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       AtomicLong confirmedBytes = new AtomicLong(-1L);
 
@@ -600,7 +608,8 @@ public final class ITJsonResumableSessionPutTaskTest {
 
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       AtomicLong confirmedBytes = new AtomicLong(-1L);
 
@@ -678,7 +687,8 @@ public final class ITJsonResumableSessionPutTaskTest {
         TmpFile tmpFile =
             DataGenerator.base64Characters().tempFile(temp.newFolder().toPath(), _256KiBL)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       AtomicLong confirmedBytes = new AtomicLong(-1L);
 
@@ -710,7 +720,8 @@ public final class ITJsonResumableSessionPutTaskTest {
         TmpFile tmpFile =
             DataGenerator.base64Characters().tempFile(temp.newFolder().toPath(), _256KiBL)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       AtomicLong confirmedBytes = new AtomicLong(-1L);
 
@@ -751,7 +762,8 @@ public final class ITJsonResumableSessionPutTaskTest {
 
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       AtomicLong confirmedBytes = new AtomicLong(-1L);
 
@@ -791,7 +803,8 @@ public final class ITJsonResumableSessionPutTaskTest {
 
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableSessionPutTask task =
           new JsonResumableSessionPutTask(

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITJsonResumableSessionQueryTaskTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITJsonResumableSessionQueryTaskTest.java
@@ -41,6 +41,7 @@ import io.grpc.netty.shaded.io.netty.handler.codec.http.HttpResponseStatus;
 import java.math.BigInteger;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.UUID;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.Before;
@@ -82,7 +83,8 @@ public final class ITJsonResumableSessionQueryTaskTest {
 
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableSessionQueryTask task =
           new JsonResumableSessionQueryTask(httpClientContext, jsonResumableWrite(uploadUrl));
@@ -105,7 +107,8 @@ public final class ITJsonResumableSessionQueryTaskTest {
 
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableSessionQueryTask task =
           new JsonResumableSessionQueryTask(httpClientContext, jsonResumableWrite(uploadUrl));
@@ -132,7 +135,8 @@ public final class ITJsonResumableSessionQueryTaskTest {
         };
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableSessionQueryTask task =
           new JsonResumableSessionQueryTask(httpClientContext, jsonResumableWrite(uploadUrl));
@@ -148,7 +152,8 @@ public final class ITJsonResumableSessionQueryTaskTest {
         req -> new DefaultFullHttpResponse(req.protocolVersion(), RESUME_INCOMPLETE);
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableSessionQueryTask task =
           new JsonResumableSessionQueryTask(httpClientContext, jsonResumableWrite(uploadUrl));
@@ -165,7 +170,8 @@ public final class ITJsonResumableSessionQueryTaskTest {
 
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableSessionQueryTask task =
           new JsonResumableSessionQueryTask(httpClientContext, jsonResumableWrite(uploadUrl));
@@ -191,7 +197,8 @@ public final class ITJsonResumableSessionQueryTaskTest {
 
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableSessionQueryTask task =
           new JsonResumableSessionQueryTask(httpClientContext, jsonResumableWrite(uploadUrl));
@@ -219,7 +226,8 @@ public final class ITJsonResumableSessionQueryTaskTest {
 
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableSessionQueryTask task =
           new JsonResumableSessionQueryTask(httpClientContext, jsonResumableWrite(uploadUrl));

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITJsonResumableSessionTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITJsonResumableSessionTest.java
@@ -46,6 +46,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -111,7 +112,8 @@ public final class ITJsonResumableSessionTest {
         TmpFile tmpFile =
             DataGenerator.base64Characters().tempFile(temp.newFolder().toPath(), _512KiBL)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableWrite resumableWrite =
           JsonResumableWrite.of(null, ImmutableMap.of(), uploadUrl, 0);
@@ -166,7 +168,8 @@ public final class ITJsonResumableSessionTest {
 
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableWrite resumableWrite =
           JsonResumableWrite.of(null, ImmutableMap.of(), uploadUrl, 0);
@@ -234,7 +237,8 @@ public final class ITJsonResumableSessionTest {
 
     try (FakeHttpServer fakeHttpServer = FakeHttpServer.of(handler)) {
       URI endpoint = fakeHttpServer.getEndpoint();
-      String uploadUrl = String.format("%s/upload/%s", endpoint.toString(), UUID.randomUUID());
+      String uploadUrl =
+          String.format(Locale.US, "%s/upload/%s", endpoint.toString(), UUID.randomUUID());
 
       JsonResumableWrite resumableWrite =
           JsonResumableWrite.of(null, ImmutableMap.of(), uploadUrl, 0);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITSyncAndUploadUnbufferedWritableByteChannelPropertyTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITSyncAndUploadUnbufferedWritableByteChannelPropertyTest.java
@@ -64,6 +64,7 @@ import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
@@ -433,7 +434,7 @@ public class ITSyncAndUploadUnbufferedWritableByteChannelPropertyTest {
               int objectSize = t.get3();
               int writeSize = t.get4();
               return Scenario.of(
-                  String.format("object-%d", t.hashCode()),
+                  String.format(Locale.US, "object-%d", t.hashCode()),
                   objectSize,
                   writeSize,
                   segmentSize,
@@ -456,7 +457,7 @@ public class ITSyncAndUploadUnbufferedWritableByteChannelPropertyTest {
   }
 
   private static String fmt(int i) {
-    return String.format("% 10d (0x%08x)", i, i);
+    return String.format(Locale.US, "% 10d (0x%08x)", i, i);
   }
 
   private static final class Scenario {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITSyncingFileChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITSyncingFileChannelTest.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import net.jqwik.api.Arbitraries;
@@ -150,7 +151,10 @@ public final class ITSyncingFileChannelTest {
           .add(
               "\nwrites",
               Arrays.stream(writes)
-                  .map(b -> String.format("%s \n %s", b.toString(), xxd(false, b.duplicate())))
+                  .map(
+                      b ->
+                          String.format(
+                              Locale.US, "%s \n %s", b.toString(), xxd(false, b.duplicate())))
                   .collect(DEBUG_JOINER))
           .add(
               "\nexpectedCumulativeContents",

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/LazyReadChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/LazyReadChannelTest.java
@@ -25,6 +25,7 @@ import com.google.common.base.MoreObjects;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 
@@ -76,7 +77,7 @@ public final class LazyReadChannelTest {
   }
 
   private TestSession newTestSession() {
-    return new TestSession(String.format("test-%02d", counter.getAndIncrement()));
+    return new TestSession(String.format(Locale.US, "test-%02d", counter.getAndIncrement()));
   }
 
   private static final class TestSession implements BufferedReadableByteChannelSession<String> {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfigTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ParallelCompositeUploadBlobWriteSessionConfigTest.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.util.Locale;
 import org.junit.Test;
 
 public final class ParallelCompositeUploadBlobWriteSessionConfigTest {
@@ -107,7 +108,8 @@ public final class ParallelCompositeUploadBlobWriteSessionConfigTest {
   private static StringSubject assertField(String fmt, int idx) {
     String[] split = fmt.split(";");
     String s = split[idx];
-    return assertWithMessage(String.format("Formatted name '%s', field[%d] = %s", fmt, idx, s))
+    return assertWithMessage(
+            String.format(Locale.US, "Formatted name '%s', field[%d] = %s", fmt, idx, s))
         .that(s);
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ParallelCompositeUploadWritableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ParallelCompositeUploadWritableByteChannelTest.java
@@ -62,6 +62,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
@@ -949,7 +950,8 @@ public final class ParallelCompositeUploadWritableByteChannelTest {
 
     @Override
     String fmtName(String ultimateObjectName, PartRange partRange) {
-      return String.format("%s/%s/%s.part", prefix, ultimateObjectName, partRange.encode());
+      return String.format(
+          Locale.US, "%s/%s/%s.part", prefix, ultimateObjectName, partRange.encode());
     }
 
     @Override

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ThroughputMovingWindowPropertyTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ThroughputMovingWindowPropertyTest.java
@@ -29,6 +29,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
@@ -190,7 +191,9 @@ final class ThroughputMovingWindowPropertyTest {
       return MoreObjects.toStringHelper(this)
           .add("i", i)
           .add("t", t)
-          .add("tenSecMovingAvg", String.format("%,.03f", expectedMovingAvgBytesPerSecond))
+          .add(
+              "tenSecMovingAvg",
+              String.format(Locale.US, "%,.03f", expectedMovingAvgBytesPerSecond))
           .toString();
     }
   }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/UnifiedOptsTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/UnifiedOptsTest.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Modifier;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.crypto.SecretKey;
@@ -194,7 +195,8 @@ public final class UnifiedOptsTest {
                 m -> {
                   try {
                     String msg =
-                        String.format("Method %s did not throw expected NullPointerException", m);
+                        String.format(
+                            Locale.US, "Method %s did not throw expected NullPointerException", m);
                     try {
                       m.invoke(null, new Object[] {null});
                       return new AssertionError(msg);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/V4PostPolicyTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/V4PostPolicyTest.java
@@ -37,6 +37,7 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -163,7 +164,7 @@ public class V4PostPolicyTest {
     for (int i = 0; i < expectedPolicyArray.length; i++) {
       char c = expectedPolicyArray[i];
       if (c >= 128) {
-        escapedPolicy.append(String.format("\\u%04x", (int) c));
+        escapedPolicy.append(String.format(Locale.US, "\\u%04x", (int) c));
       } else {
         switch (c) {
           case '\\':
@@ -218,12 +219,14 @@ public class V4PostPolicyTest {
 
     InputStream credentialsStream = cl.getResourceAsStream(SERVICE_ACCOUNT_JSON_RESOURCE);
     assertNotNull(
-        String.format("Unable to load service account json: %s", SERVICE_ACCOUNT_JSON_RESOURCE),
+        String.format(
+            Locale.US, "Unable to load service account json: %s", SERVICE_ACCOUNT_JSON_RESOURCE),
         credentialsStream);
 
     InputStream dataJson = cl.getResourceAsStream(TEST_DATA_JSON_RESOURCE);
     assertNotNull(
-        String.format("Unable to load test definition: %s", TEST_DATA_JSON_RESOURCE), dataJson);
+        String.format(Locale.US, "Unable to load test definition: %s", TEST_DATA_JSON_RESOURCE),
+        dataJson);
 
     ServiceAccountCredentials serviceAccountCredentials =
         ServiceAccountCredentials.fromStream(credentialsStream);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/V4SigningTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/V4SigningTest.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -152,12 +153,14 @@ public class V4SigningTest {
 
     InputStream credentialsStream = cl.getResourceAsStream(SERVICE_ACCOUNT_JSON_RESOURCE);
     assertNotNull(
-        String.format("Unable to load service account json: %s", SERVICE_ACCOUNT_JSON_RESOURCE),
+        String.format(
+            Locale.US, "Unable to load service account json: %s", SERVICE_ACCOUNT_JSON_RESOURCE),
         credentialsStream);
 
     InputStream dataJson = cl.getResourceAsStream(TEST_DATA_JSON_RESOURCE);
     assertNotNull(
-        String.format("Unable to load test definition: %s", TEST_DATA_JSON_RESOURCE), dataJson);
+        String.format(Locale.US, "Unable to load test definition: %s", TEST_DATA_JSON_RESOURCE),
+        dataJson);
 
     ServiceAccountCredentials serviceAccountCredentials =
         ServiceAccountCredentials.fromStream(credentialsStream);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/CtxFunctions.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/CtxFunctions.java
@@ -42,6 +42,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.pubsub.v1.TopicName;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -230,7 +231,8 @@ final class CtxFunctions {
 
           if (!resources.isEmpty()) {
             throw new IllegalStateException(
-                String.format("Unhandled Method Resource [%s]", Joiner.on(", ").join(resources)));
+                String.format(
+                    Locale.US, "Unhandled Method Resource [%s]", Joiner.on(", ").join(resources)));
           }
 
           return f.apply(ctx, c);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
@@ -58,6 +58,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.BiPredicate;
@@ -268,7 +269,8 @@ public class ITRetryConformanceTest {
 
       InputStream dataJson = cl.getResourceAsStream(retryTestsJsonResourcePath);
       assertNotNull(
-          String.format("Unable to load test definition: %s", retryTestsJsonResourcePath),
+          String.format(
+              Locale.US, "Unable to load test definition: %s", retryTestsJsonResourcePath),
           dataJson);
 
       InputStreamReader reader = new InputStreamReader(dataJson, Charsets.UTF_8);
@@ -290,7 +292,9 @@ public class ITRetryConformanceTest {
               String methodName = method.getName();
               RpcMethod key = RpcMethod.storage.lookup.get(methodName);
               assertNotNull(
-                  String.format("Unable to resolve RpcMethod for value '%s'", methodName), key);
+                  String.format(
+                      Locale.US, "Unable to resolve RpcMethod for value '%s'", methodName),
+                  key);
               // get all RpcMethodMappings which are defined for key
               List<RpcMethodMapping> mappings =
                   rpcMethodMappings.get(key).stream()
@@ -373,6 +377,7 @@ public class ITRetryConformanceTest {
       if (!unusedMappings.isEmpty()) {
         LOGGER.warning(
             String.format(
+                Locale.US,
                 "Declared but unused mappings with ids: [%s]",
                 Joiner.on(", ").join(unusedMappings)));
       }
@@ -498,7 +503,8 @@ public class ITRetryConformanceTest {
                           throw new IllegalStateException("Unable to generate seed");
                         });
             String msg =
-                String.format("Shuffling test order using Random with seed: 0x%016X", seed);
+                String.format(
+                    Locale.US, "Shuffling test order using Random with seed: 0x%016X", seed);
             LOGGER.info(msg);
           }
           return new Random(seed);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RetryTestFixture.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RetryTestFixture.java
@@ -28,6 +28,7 @@ import com.google.cloud.storage.it.runner.registry.TestBench;
 import com.google.cloud.storage.it.runner.registry.TestBench.RetryTestResource;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.util.Locale;
 import java.util.logging.Logger;
 import org.junit.AssumptionViolatedException;
 import org.junit.rules.TestRule;
@@ -192,6 +193,9 @@ final class RetryTestFixture extends TestWatcher {
 
   private String fmtUserAgent(String testDescriptor) {
     return String.format(
-        "%s/ (%s) java-conformance-tests/", testDescriptor, testRetryConformance.getTestName());
+        Locale.US,
+        "%s/ (%s) java-conformance-tests/",
+        testDescriptor,
+        testRetryConformance.getTestName());
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethod.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethod.java
@@ -17,6 +17,7 @@
 package com.google.cloud.storage.conformance.retry;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -34,7 +35,7 @@ interface RpcMethod {
    */
   final class storage {
     private static String getFullQualifiedMethodName(Enum<?> e) {
-      return String.format("storage.%s.%s", e.getClass().getSimpleName(), e.name());
+      return String.format(Locale.US, "storage.%s.%s", e.getClass().getSimpleName(), e.name());
     }
 
     enum bucket_acl implements RpcMethod {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
@@ -99,6 +99,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.OptionalInt;
@@ -231,6 +232,7 @@ final class RpcMethodMappings {
                   RpcMethod rpcMethod = e.getKey();
                   Collection<RpcMethodMapping> mappings = e.getValue();
                   return String.format(
+                      Locale.US,
                       "\t%s.%s: %d",
                       rpcMethod
                           .getClass()
@@ -246,7 +248,7 @@ final class RpcMethodMappings {
     OptionalInt max =
         funcMap.values().stream().map(RpcMethodMapping::getMappingId).mapToInt(i -> i).max();
     if (max.isPresent()) {
-      LOGGER.info(String.format("Current max mapping index is: %d%n", max.getAsInt()));
+      LOGGER.info(String.format(Locale.US, "Current max mapping index is: %d%n", max.getAsInt()));
     } else {
       throw new IllegalStateException("No mappings defined");
     }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/State.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/State.java
@@ -37,6 +37,7 @@ import com.google.errorprone.annotations.Immutable;
 import com.google.pubsub.v1.TopicName;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -345,7 +346,7 @@ final class State {
 
   private <T> T getValue(Key<T> key) {
     Object o = data.get(key);
-    requireNonNull(o, () -> String.format("%s was not found in state", key.name));
+    requireNonNull(o, () -> String.format(Locale.US, "%s was not found in state", key.name));
     return key.cast(o);
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestRetryConformance.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/TestRetryConformance.java
@@ -42,6 +42,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -136,24 +137,49 @@ final class TestRetryConformance {
     char transportTag = transport.name().toLowerCase().charAt(0);
     this.bucketName =
         String.format(
+            Locale.US,
             "%s_s%03d-%s-m%03d_bkt1_%s",
-            BASE_ID, scenarioId, instructionsString.toLowerCase(), mappingId, transportTag);
+            BASE_ID,
+            scenarioId,
+            instructionsString.toLowerCase(),
+            mappingId,
+            transportTag);
     this.bucketName2 =
         String.format(
+            Locale.US,
             "%s_s%03d-%s-m%03d_bkt2_%s",
-            BASE_ID, scenarioId, instructionsString.toLowerCase(), mappingId, transportTag);
+            BASE_ID,
+            scenarioId,
+            instructionsString.toLowerCase(),
+            mappingId,
+            transportTag);
     this.userProject =
         String.format(
+            Locale.US,
             "%s_s%03d-%s-m%03d_prj1_%s",
-            BASE_ID, scenarioId, instructionsString.toLowerCase(), mappingId, transportTag);
+            BASE_ID,
+            scenarioId,
+            instructionsString.toLowerCase(),
+            mappingId,
+            transportTag);
     this.objectName =
         String.format(
+            Locale.US,
             "%s_s%03d-%s-m%03d_obj1_%s",
-            BASE_ID, scenarioId, instructionsString.toLowerCase(), mappingId, transportTag);
+            BASE_ID,
+            scenarioId,
+            instructionsString.toLowerCase(),
+            mappingId,
+            transportTag);
     this.topicName =
         String.format(
+            Locale.US,
             "%s_s%03d-%s-m%03d_top1_%s",
-            BASE_ID, scenarioId, instructionsString.toLowerCase(), mappingId, transportTag);
+            BASE_ID,
+            scenarioId,
+            instructionsString.toLowerCase(),
+            mappingId,
+            transportTag);
     // define a lazy supplier for bytes.
     this.lazyHelloWorldUtf8Bytes =
         () -> genBytes(this.method, this.instruction.getInstructionsList());
@@ -225,8 +251,13 @@ final class TestRetryConformance {
   public String getTestName() {
     String instructionsDesc = Joiner.on("_").join(instruction.getInstructionsList());
     return String.format(
+        Locale.US,
         "TestRetryConformance/%s-%d-[%s]-%s-%d",
-        transport.name().toLowerCase(), scenarioId, instructionsDesc, method.getName(), mappingId);
+        transport.name().toLowerCase(),
+        scenarioId,
+        instructionsDesc,
+        method.getName(),
+        mappingId);
   }
 
   public Transport getTransport() {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/BucketCleaner.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/BucketCleaner.java
@@ -41,6 +41,7 @@ import com.google.storage.control.v2.StorageLayoutName;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -137,7 +138,8 @@ public final class BucketCleaner {
                   .sorted(Collections.reverseOrder(Comparator.comparing(Folder::getName)))
                   .map(
                       folder -> {
-                        String formatted = String.format("folder = %s", folder.getName());
+                        String formatted =
+                            String.format(Locale.US, "folder = %s", folder.getName());
                         LOGGER.warning(formatted);
                         boolean success = true;
                         try {
@@ -173,7 +175,7 @@ public final class BucketCleaner {
                   .map(
                       managedFolder -> {
                         String formatted =
-                            String.format("managedFolder = %s", managedFolder.getName());
+                            String.format(Locale.US, "managedFolder = %s", managedFolder.getName());
                         LOGGER.warning(formatted);
                         boolean success = true;
                         try {
@@ -214,8 +216,10 @@ public final class BucketCleaner {
       } else {
         LOGGER.warning(
             String.format(
+                Locale.US,
                 "Unable to delete bucket %s due to previous failed %s deletes",
-                bucketName, failed));
+                bucketName,
+                failed));
       }
 
       LOGGER.warning("Bucket cleanup complete: " + bucketName);
@@ -231,7 +235,8 @@ public final class BucketCleaner {
     failedDeletes.forEach(
         r ->
             LOGGER.warning(
-                String.format("Failed to delete %s %s/%s", resourceType, bucketName, r.name)));
+                String.format(
+                    Locale.US, "Failed to delete %s %s/%s", resourceType, bucketName, r.name)));
     return !failedDeletes.isEmpty();
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/GrpcPlainRequestLoggingInterceptor.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/GrpcPlainRequestLoggingInterceptor.java
@@ -33,6 +33,7 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -77,7 +78,10 @@ public final class GrpcPlainRequestLoggingInterceptor implements ClientIntercept
                     Level.CONFIG,
                     () ->
                         String.format(
-                            "<<< %s{%n%s}", message.getClass().getSimpleName(), fmtProto(message)));
+                            Locale.US,
+                            "<<< %s{%n%s}",
+                            message.getClass().getSimpleName(),
+                            fmtProto(message)));
                 super.onMessage(message);
               }
 
@@ -87,8 +91,10 @@ public final class GrpcPlainRequestLoggingInterceptor implements ClientIntercept
                     Level.CONFIG,
                     () ->
                         String.format(
+                            Locale.US,
                             "<<< status = %s, trailers = %s",
-                            status.toString(), trailers.toString()));
+                            status.toString(),
+                            trailers.toString()));
                 super.onClose(status, trailers);
               }
             };
@@ -101,7 +107,10 @@ public final class GrpcPlainRequestLoggingInterceptor implements ClientIntercept
             Level.CONFIG,
             () ->
                 String.format(
-                    ">>> %s{%n%s}", message.getClass().getSimpleName(), fmtProto(message)));
+                    Locale.US,
+                    ">>> %s{%n%s}",
+                    message.getClass().getSimpleName(),
+                    fmtProto(message)));
         super.sendMessage(message);
       }
     };
@@ -133,7 +142,8 @@ public final class GrpcPlainRequestLoggingInterceptor implements ClientIntercept
       ByteString content = msg.getChecksummedData().getContent();
       if (content.size() > 20) {
         WriteObjectRequest.Builder b = msg.toBuilder();
-        ByteString snip = ByteString.copyFromUtf8(String.format("<snip (%d)>", content.size()));
+        ByteString snip =
+            ByteString.copyFromUtf8(String.format(Locale.US, "<snip (%d)>", content.size()));
         ByteString trim = content.substring(0, 20).concat(snip);
         b.getChecksummedDataBuilder().setContent(trim);
 
@@ -149,7 +159,8 @@ public final class GrpcPlainRequestLoggingInterceptor implements ClientIntercept
       ByteString content = msg.getChecksummedData().getContent();
       if (content.size() > 20) {
         BidiWriteObjectRequest.Builder b = msg.toBuilder();
-        ByteString snip = ByteString.copyFromUtf8(String.format("<snip (%d)>", content.size()));
+        ByteString snip =
+            ByteString.copyFromUtf8(String.format(Locale.US, "<snip (%d)>", content.size()));
         ByteString trim = content.substring(0, 20).concat(snip);
         b.getChecksummedDataBuilder().setContent(trim);
 
@@ -165,7 +176,8 @@ public final class GrpcPlainRequestLoggingInterceptor implements ClientIntercept
       ByteString content = msg.getChecksummedData().getContent();
       if (content.size() > 20) {
         ReadObjectResponse.Builder b = msg.toBuilder();
-        ByteString snip = ByteString.copyFromUtf8(String.format("<snip (%d)>", content.size()));
+        ByteString snip =
+            ByteString.copyFromUtf8(String.format(Locale.US, "<snip (%d)>", content.size()));
         ByteString trim = content.substring(0, 20).concat(snip);
         b.getChecksummedDataBuilder().setContent(trim);
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/GrpcRequestAuditing.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/GrpcRequestAuditing.java
@@ -32,6 +32,7 @@ import io.grpc.MethodDescriptor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -81,7 +82,7 @@ public final class GrpcRequestAuditing implements ClientInterceptor, AssertReque
       Metadata.Key<T> key, Function<Stream<T>, Stream<T>> f) {
     Stream<T> stream = requestHeaders.stream().map(m -> m.get(key)).filter(Objects::nonNull);
     ImmutableList<Object> actual = f.apply(stream).collect(ImmutableList.toImmutableList());
-    return assertWithMessage(String.format("Headers %s", key.name())).that(actual);
+    return assertWithMessage(String.format(Locale.US, "Headers %s", key.name())).that(actual);
   }
 
   private final class Factory extends ClientStreamTracer.Factory {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobReadChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobReadChannelTest.java
@@ -62,6 +62,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.zip.GZIPInputStream;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.Rule;
@@ -137,7 +138,7 @@ public final class ITBlobReadChannelTest {
 
   @Test
   public void testLimit_downloadToFile() throws IOException {
-    String blobName = String.format("%s/src", generator.randomObjectName());
+    String blobName = String.format(Locale.US, "%s/src", generator.randomObjectName());
     BlobId blobId = BlobId.of(bucket.getName(), blobName);
     ByteBuffer content = DataGenerator.base64Characters().genByteBuffer(108);
     try (WriteChannel writer = storage.writer(BlobInfo.newBuilder(blobId).build())) {
@@ -596,7 +597,7 @@ public final class ITBlobReadChannelTest {
 
   private void doLimitTest(int srcContentSize, int rangeBegin, int rangeEnd, int chunkSize)
       throws IOException {
-    String blobName = String.format("%s/src", generator.randomObjectName());
+    String blobName = String.format(Locale.US, "%s/src", generator.randomObjectName());
     BlobInfo src = BlobInfo.newBuilder(bucket, blobName).build();
     ByteBuffer content = DataGenerator.base64Characters().genByteBuffer(srcContentSize);
     ByteBuffer dup = content.duplicate();

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobReadChannelV2RetryTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobReadChannelV2RetryTest.java
@@ -53,6 +53,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.Random;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -195,7 +196,7 @@ public final class ITBlobReadChannelV2RetryTest {
           () -> assertThat(requests.get(0).getHeaders().get("range")).isNull(),
           () ->
               assertThat(requests.get(1).getHeaders().get("range"))
-                  .isEqualTo(ImmutableList.of(String.format("bytes=%d-", 256 * 1024))));
+                  .isEqualTo(ImmutableList.of(String.format(Locale.US, "bytes=%d-", 256 * 1024))));
     }
   }
 
@@ -248,7 +249,7 @@ public final class ITBlobReadChannelV2RetryTest {
           () -> assertThat(requests.get(0).getHeaders().get("range")).isNull(),
           () ->
               assertThat(requests.get(1).getHeaders().get("range"))
-                  .isEqualTo(ImmutableList.of(String.format("bytes=%d-", 256 * 1024))));
+                  .isEqualTo(ImmutableList.of(String.format(Locale.US, "bytes=%d-", 256 * 1024))));
     }
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobWriteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobWriteChannelTest.java
@@ -61,6 +61,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.logging.Logger;
 import org.junit.Test;
@@ -128,7 +129,8 @@ public final class ITBlobWriteChannelTest {
         DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.from(ZoneOffset.UTC));
     String nowString = formatter.format(now);
     BucketInfo bucketInfo = BucketInfo.of(generator.randomBucketName());
-    String blobPath = String.format("%s/%s/blob", generator.randomObjectName(), nowString);
+    String blobPath =
+        String.format(Locale.US, "%s/%s/blob", generator.randomObjectName(), nowString);
     BlobId blobId = BlobId.of(bucketInfo.getName(), blobPath);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
     storage.create(bucketInfo);
@@ -189,7 +191,8 @@ public final class ITBlobWriteChannelTest {
   }
 
   private void doJsonUnexpectedEOFTest(int contentSize, int cappedByteCount) throws IOException {
-    String blobPath = String.format("%s/%s/blob", generator.randomObjectName(), NOW_STRING);
+    String blobPath =
+        String.format(Locale.US, "%s/%s/blob", generator.randomObjectName(), NOW_STRING);
 
     BucketInfo bucketInfo = BucketInfo.of(generator.randomBucketName());
     BlobInfo blobInfoGen0 = BlobInfo.newBuilder(bucketInfo, blobPath, 0L).build();
@@ -199,7 +202,8 @@ public final class ITBlobWriteChannelTest {
             Method.newBuilder().setName("storage.objects.insert").build(),
             InstructionList.newBuilder()
                 .addInstructions(
-                    String.format("return-broken-stream-final-chunk-after-%dB", cappedByteCount))
+                    String.format(
+                        Locale.US, "return-broken-stream-final-chunk-after-%dB", cappedByteCount))
                 .build(),
             Transport.HTTP.name());
     RetryTestResource retryTest = testBench.createRetryTest(retryTestResource);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcInterceptorTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcInterceptorTest.java
@@ -44,6 +44,7 @@ import io.grpc.MethodDescriptor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -83,8 +84,9 @@ public class ITGrpcInterceptorTest {
             .map(m -> m.get(X_GOOG_REQUEST_PARAMS))
             .collect(Collectors.toList());
 
-    String expected = String.format("project=projects/%s", options.getProjectId());
-    String expectedEncoded = String.format("project=projects%%2F%s", options.getProjectId());
+    String expected = String.format(Locale.US, "project=projects/%s", options.getProjectId());
+    String expectedEncoded =
+        String.format(Locale.US, "project=projects%%2F%s", options.getProjectId());
     assertThat(requestParams).containsAnyOf(expected, expectedEncoded);
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITGrpcTest.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 import org.junit.Test;
@@ -76,7 +77,7 @@ public final class ITGrpcTest {
     String prefix = generator.randomObjectName();
     List<Blob> blobs =
         IntStream.rangeClosed(1, 10)
-            .mapToObj(i -> String.format("%s/%02d", prefix, i))
+            .mapToObj(i -> String.format(Locale.US, "%s/%02d", prefix, i))
             .map(n -> BlobInfo.newBuilder(bucketInfo, n).build())
             .map(info -> storage.create(info, content, BlobTargetOption.doesNotExist()))
             .collect(ImmutableList.toImmutableList());

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITNotificationTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITNotificationTest.java
@@ -37,6 +37,7 @@ import com.google.iam.v1.GetIamPolicyRequest;
 import com.google.iam.v1.SetIamPolicyRequest;
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -71,7 +72,7 @@ public class ITNotificationTest {
     // square brackets are not acceptable characters for topic names, replace them with dash
     // https://cloud.google.com/pubsub/docs/admin#resource_names
     String name = generator.randomObjectName().replaceAll("[\\[\\]]", "-");
-    topic = String.format("projects/%s/topics/%s", projectId, name).trim();
+    topic = String.format(Locale.US, "projects/%s/topics/%s", projectId, name).trim();
     notificationInfo =
         NotificationInfo.newBuilder(topic)
             .setCustomAttributes(CUSTOM_ATTRIBUTES)

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectTest.java
@@ -87,6 +87,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
@@ -564,9 +565,12 @@ public class ITObjectTest {
     String directoryName = generator.randomObjectName();
     String subdirectoryName = "subdirectory";
 
-    String uriSubDir = String.format("gs://%s/%s/%s/", bucketName, directoryName, subdirectoryName);
-    String uri1 = String.format("gs://%s/%s/%s/blob1", bucketName, directoryName, subdirectoryName);
-    String uri2 = String.format("gs://%s/%s/blob2", bucketName, directoryName);
+    String uriSubDir =
+        String.format(Locale.US, "gs://%s/%s/%s/", bucketName, directoryName, subdirectoryName);
+    String uri1 =
+        String.format(
+            Locale.US, "gs://%s/%s/%s/blob1", bucketName, directoryName, subdirectoryName);
+    String uri2 = String.format(Locale.US, "gs://%s/%s/blob2", bucketName, directoryName);
 
     BlobId id1 = BlobId.fromGsUtilUri(uri1);
     BlobId id2 = BlobId.fromGsUtilUri(uri2);
@@ -654,7 +658,7 @@ public class ITObjectTest {
 
     ImmutableList<BlobInfo> expected =
         IntStream.rangeClosed(1, 10)
-            .mapToObj(i -> String.format("%s/%2d", basePath, i))
+            .mapToObj(i -> String.format(Locale.US, "%s/%2d", basePath, i))
             .map(name -> BlobInfo.newBuilder(bucket, name).build())
             .map(info -> storage.create(info, BlobTargetOption.doesNotExist()))
             .map(PackagePrivateMethodWorkarounds::noAcl)
@@ -1182,7 +1186,7 @@ public class ITObjectTest {
   }
 
   private void doTestReadAndWriteChannelsWithSize(int blobSize) throws IOException {
-    String blobName = String.format("%s-%d", generator.randomObjectName(), blobSize);
+    String blobName = String.format(Locale.US, "%s-%d", generator.randomObjectName(), blobSize);
     BlobInfo blob = BlobInfo.newBuilder(bucket, blobName).build();
     Random rnd = new Random();
     byte[] bytes = new byte[blobSize];

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITOptionRegressionTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITOptionRegressionTest.java
@@ -59,6 +59,7 @@ import com.google.cloud.storage.it.runner.annotations.SingleBackend;
 import com.google.cloud.storage.it.runner.annotations.StorageFixture;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.util.Locale;
 import java.util.Set;
 import java.util.function.Function;
 import org.junit.Before;
@@ -1189,11 +1190,11 @@ public final class ITOptionRegressionTest {
   }
 
   private static String bucketName() {
-    return String.format("bucket-%03d", bucketCounter++);
+    return String.format(Locale.US, "bucket-%03d", bucketCounter++);
   }
 
   private static String objectName() {
-    return String.format("object-%03d", objectCounter++);
+    return String.format(Locale.US, "object-%03d", objectCounter++);
   }
 
   private static Function<String, Set<String>> splitOnCommaToSet() {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITTransferManagerTest.java
@@ -59,6 +59,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -98,15 +99,21 @@ public class ITTransferManagerTest {
     baseDir = tmpDir.getRoot().toPath();
     BlobInfo blobInfo1 =
         BlobInfo.newBuilder(
-                BlobId.of(bucket.getName(), String.format("%s/src", generator.randomObjectName())))
+                BlobId.of(
+                    bucket.getName(),
+                    String.format(Locale.US, "%s/src", generator.randomObjectName())))
             .build();
     BlobInfo blobInfo2 =
         BlobInfo.newBuilder(
-                BlobId.of(bucket.getName(), String.format("%s/src", generator.randomObjectName())))
+                BlobId.of(
+                    bucket.getName(),
+                    String.format(Locale.US, "%s/src", generator.randomObjectName())))
             .build();
     BlobInfo blobInfoChunking =
         BlobInfo.newBuilder(
-                BlobId.of(bucket.getName(), String.format("%s/src", generator.randomObjectName())))
+                BlobId.of(
+                    bucket.getName(),
+                    String.format(Locale.US, "%s/src", generator.randomObjectName())))
             .build();
     Collections.addAll(blobs, blobInfo1, blobInfo2);
     ByteBuffer content = DataGenerator.base64Characters().genByteBuffer(108);
@@ -510,7 +517,8 @@ public class ITTransferManagerTest {
       BlobInfo nonexistentBlob =
           BlobInfo.newBuilder(
                   BlobId.of(
-                      bucket.getName(), String.format("%s/src", generator.randomObjectName())))
+                      bucket.getName(),
+                      String.format(Locale.US, "%s/src", generator.randomObjectName())))
               .build();
       downloadBlobs.add(nonexistentBlob);
       DownloadJob job = transferManager.downloadBlobs(blobs, parallelDownloadConfig);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/RequestAuditing.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/RequestAuditing.java
@@ -35,6 +35,7 @@ import com.google.common.truth.IterableSubject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -220,6 +221,6 @@ public final class RequestAuditing extends HttpTransportOptions implements Asser
             .filter(Objects::nonNull);
     List<Object> actual = filter.apply(stream).collect(Collectors.toList());
 
-    return assertWithMessage(String.format("Headers %s", headerName)).that(actual);
+    return assertWithMessage(String.format(Locale.US, "Headers %s", headerName)).that(actual);
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/CrossRunIntersection.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/CrossRunIntersection.java
@@ -23,6 +23,7 @@ import com.google.cloud.storage.it.runner.annotations.Backend;
 import com.google.cloud.storage.it.runner.annotations.CrossRun;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
+import java.util.Locale;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -118,7 +119,7 @@ public final class CrossRunIntersection {
   public String fmtSuiteName() {
     String t = transport != null ? transport.toString() : "NULL_TRANSPORT";
     String b = backend != null ? backend.toString() : "NULL_BACKEND";
-    return String.format("[%s][%s]", t, b);
+    return String.format(Locale.US, "[%s][%s]", t, b);
   }
 
   @Override

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/StorageITLeafRunner.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/StorageITLeafRunner.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -74,11 +75,14 @@ final class StorageITLeafRunner extends BlockJUnit4ClassRunner {
                   } else {
                     return new Exception(
                         String.format(
+                            Locale.US,
                             "@Inject field '%s' must have a type compatible with one of [%s]",
-                            f, registry.injectableTypesString()));
+                            f,
+                            registry.injectableTypesString()));
                   }
                 } else {
-                  return new Exception(String.format("The @Inject field '%s' must be public", f));
+                  return new Exception(
+                      String.format(Locale.US, "The @Inject field '%s' must be public", f));
                 }
               })
           .filter(Objects::nonNull)

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/StorageITRunner.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/StorageITRunner.java
@@ -28,6 +28,7 @@ import com.google.cloud.storage.it.runner.registry.Registry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
@@ -202,7 +203,7 @@ public final class StorageITRunner extends Suite {
   }
 
   private static String fmtParam(Object param) {
-    return String.format("[%s]", param.toString());
+    return String.format(Locale.US, "[%s]", param.toString());
   }
 
   private static String fmtParam(CrossRunIntersection c, Object param) {
@@ -224,13 +225,17 @@ public final class StorageITRunner extends Suite {
     if (crossRun != null && singleBackend != null) {
       throw new InitializationError(
           String.format(
+              Locale.US,
               "Class annotated with both @%s and @%s. Pick only one.",
-              CrossRun.class.getSimpleName(), SingleBackend.class.getSimpleName()));
+              CrossRun.class.getSimpleName(),
+              SingleBackend.class.getSimpleName()));
     } else if (crossRun == null && singleBackend == null) {
       throw new InitializationError(
           String.format(
+              Locale.US,
               "Missing either of @%s and @%s.",
-              CrossRun.class.getSimpleName(), SingleBackend.class.getSimpleName()));
+              CrossRun.class.getSimpleName(),
+              SingleBackend.class.getSimpleName()));
     }
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/BackendResources.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/BackendResources.java
@@ -41,6 +41,7 @@ import com.google.storage.control.v2.StorageControlSettings;
 import com.google.storage.control.v2.stub.StorageControlStubSettings;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Locale;
 import java.util.UUID;
 
 /** The set of resources which are defined for a single backend. */
@@ -147,7 +148,7 @@ final class BackendResources implements ManagedLifecycle {
                 case TEST_BENCH:
                   String baseUri = Registry.getInstance().testBench().getBaseUri();
                   URI uri = URI.create(baseUri);
-                  String endpoint = String.format("%s:%d", uri.getHost(), uri.getPort());
+                  String endpoint = String.format(Locale.US, "%s:%d", uri.getHost(), uri.getPort());
                   builder =
                       StorageControlSettings.newBuilder()
                           .setCredentialsProvider(NoCredentialsProvider.create())
@@ -181,7 +182,8 @@ final class BackendResources implements ManagedLifecycle {
         TestRunScopedInstance.of(
             "fixture/BUCKET/[" + backend.name() + "]",
             () -> {
-              String bucketName = String.format("java-storage-grpc-%s", UUID.randomUUID());
+              String bucketName =
+                  String.format(Locale.US, "java-storage-grpc-%s", UUID.randomUUID());
               protectedBucketNames.add(bucketName);
               return new BucketInfoShim(
                   BucketInfo.newBuilder(bucketName)
@@ -194,7 +196,8 @@ final class BackendResources implements ManagedLifecycle {
         TestRunScopedInstance.of(
             "fixture/BUCKET/[" + backend.name() + "]/REQUESTER_PAYS",
             () -> {
-              String bucketName = String.format("java-storage-grpc-rp-%s", UUID.randomUUID());
+              String bucketName =
+                  String.format(Locale.US, "java-storage-grpc-rp-%s", UUID.randomUUID());
               protectedBucketNames.add(bucketName);
               return new BucketInfoShim(
                   BucketInfo.newBuilder(bucketName)
@@ -208,7 +211,8 @@ final class BackendResources implements ManagedLifecycle {
         TestRunScopedInstance.of(
             "fixture/BUCKET/[" + backend.name() + "]/VERSIONED",
             () -> {
-              String bucketName = String.format("java-storage-grpc-v-%s", UUID.randomUUID());
+              String bucketName =
+                  String.format(Locale.US, "java-storage-grpc-v-%s", UUID.randomUUID());
               protectedBucketNames.add(bucketName);
               return new BucketInfoShim(
                   BucketInfo.newBuilder(bucketName)
@@ -222,7 +226,8 @@ final class BackendResources implements ManagedLifecycle {
         TestRunScopedInstance.of(
             "fixture/BUCKET/[" + backend.name() + "]/HNS",
             () -> {
-              String bucketName = String.format("java-storage-grpc-hns-%s", UUID.randomUUID());
+              String bucketName =
+                  String.format(Locale.US, "java-storage-grpc-hns-%s", UUID.randomUUID());
               protectedBucketNames.add(bucketName);
               return new BucketInfoShim(
                   BucketInfo.newBuilder(bucketName)

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/Generator.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/Generator.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.storage.it.runner.registry;
 
+import java.util.Locale;
 import java.util.UUID;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -46,8 +47,11 @@ public final class Generator implements ManagedLifecycle {
     }
     AtomicInteger counter = counters.computeIfAbsent(currentTest, (d) -> new AtomicInteger(1));
     return String.format(
+        Locale.US,
         "%s.%s-%04d",
-        currentTest.getClassName(), currentTest.getMethodName(), counter.getAndIncrement());
+        currentTest.getClassName(),
+        currentTest.getMethodName(),
+        counter.getAndIncrement());
   }
 
   @Override

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/ObjectsFixture.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/ObjectsFixture.java
@@ -28,6 +28,7 @@ import com.google.cloud.storage.Storage.ComposeRequest;
 import com.google.cloud.storage.it.ChecksummedTestContent;
 import com.google.common.collect.ImmutableMap;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 
 /** Globally scoped objects correlated with a specific backend and bucket */
 public final class ObjectsFixture implements ManagedLifecycle {
@@ -137,7 +138,7 @@ public final class ObjectsFixture implements ManagedLifecycle {
   public void stop() {}
 
   private static String objName(String name) {
-    return String.format("%s/%s", ObjectsFixture.class.getSimpleName(), name);
+    return String.format(Locale.US, "%s/%s", ObjectsFixture.class.getSimpleName(), name);
   }
 
   public static final class ObjectAndContent {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/Registry.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/Registry.java
@@ -37,6 +37,7 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
@@ -174,7 +175,8 @@ public final class Registry extends RunListener {
     Span span =
         tracer
             .spanBuilder(
-                String.format("%s/%s", description.getClassName(), description.getMethodName()))
+                String.format(
+                    Locale.US, "%s/%s", description.getClassName(), description.getMethodName()))
             .setAttribute("service.name", "test")
             .startSpan();
     Scope scope = span.makeCurrent();
@@ -234,7 +236,8 @@ public final class Registry extends RunListener {
       }
     } else {
       throw new IllegalArgumentException(
-          String.format("Invalid: ff: %s, crossRunIntersection: %s", ff, crossRunIntersection));
+          String.format(
+              Locale.US, "Invalid: ff: %s, crossRunIntersection: %s", ff, crossRunIntersection));
     }
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestBench.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestBench.java
@@ -55,6 +55,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -128,7 +129,8 @@ public final class TestBench implements ManagedLifecycle {
                   request.getHeaders().setAccept("application/json");
                   request
                       .getHeaders()
-                      .setUserAgent(String.format("%s/ test-bench/", this.containerName));
+                      .setUserAgent(
+                          String.format(Locale.US, "%s/ test-bench/", this.containerName));
                 });
   }
 
@@ -206,7 +208,7 @@ public final class TestBench implements ManagedLifecycle {
       File errFile = errPath.toFile();
       LOGGER.info("Redirecting server stdout to: " + outFile.getAbsolutePath());
       LOGGER.info("Redirecting server stderr to: " + errFile.getAbsolutePath());
-      String dockerImage = String.format("%s:%s", dockerImageName, dockerImageTag);
+      String dockerImage = String.format(Locale.US, "%s:%s", dockerImageName, dockerImageTag);
       // First try and pull the docker image, this validates docker is available and running
       // on the host, as well as gives time for the image to be downloaded independently of
       // trying to start the container. (Below, when we first start the container we then attempt
@@ -223,12 +225,15 @@ public final class TestBench implements ManagedLifecycle {
           dumpServerLogs(outPath, errPath);
           throw new IllegalStateException(
               String.format(
-                  "Non-zero status while attempting to pull docker image '%s'", dockerImage));
+                  Locale.US,
+                  "Non-zero status while attempting to pull docker image '%s'",
+                  dockerImage));
         }
       } catch (InterruptedException | IllegalThreadStateException e) {
         dumpServerLogs(outPath, errPath);
         throw new IllegalStateException(
-            String.format("Timeout while attempting to pull docker image '%s'", dockerImage));
+            String.format(
+                Locale.US, "Timeout while attempting to pull docker image '%s'", dockerImage));
       }
 
       int port = URI.create(baseUri).getPort();
@@ -243,7 +248,7 @@ public final class TestBench implements ManagedLifecycle {
               port + ":9000",
               "--publish",
               gRPCPort + ":9090",
-              String.format("--name=%s", containerName),
+              String.format(Locale.US, "--name=%s", containerName),
               dockerImage);
       process =
           new ProcessBuilder()
@@ -533,7 +538,7 @@ public final class TestBench implements ManagedLifecycle {
           gRPCBaseUri,
           requireNonNull(dockerImageName, "dockerImageName must be non null"),
           requireNonNull(dockerImageTag, "dockerImageTag must be non null"),
-          String.format("storage-testbench_%s", containerName));
+          String.format(Locale.US, "storage-testbench_%s", containerName));
     }
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/jqwik/IamPolicyArbitraryProvider.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/jqwik/IamPolicyArbitraryProvider.java
@@ -23,6 +23,7 @@ import com.google.iam.v1.Policy;
 import com.google.protobuf.ByteString;
 import com.google.type.Expr;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Set;
 import javax.annotation.ParametersAreNonnullByDefault;
 import net.jqwik.api.Arbitraries;
@@ -83,10 +84,10 @@ public final class IamPolicyArbitraryProvider implements ArbitraryProvider {
     return Arbitraries.oneOf(
         Arbitraries.of("allUsers"),
         Arbitraries.of("allAuthenticatedUsers"),
-        Web.emails().map(e -> String.format("user:%s", e)),
-        Web.emails().map(e -> String.format("serviceAccount:%s", e)),
-        Web.emails().map(e -> String.format("group:%s", e)),
-        Web.webDomains().map(d -> String.format("domain:%s", d)));
+        Web.emails().map(e -> String.format(Locale.US, "user:%s", e)),
+        Web.emails().map(e -> String.format(Locale.US, "serviceAccount:%s", e)),
+        Web.emails().map(e -> String.format(Locale.US, "group:%s", e)),
+        Web.webDomains().map(d -> String.format(Locale.US, "domain:%s", d)));
   }
 
   static Arbitrary<Expr> condition() {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/jqwik/StorageArbitraries.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/jqwik/StorageArbitraries.java
@@ -44,6 +44,7 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.Locale;
 import java.util.Map;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
@@ -549,11 +550,12 @@ public final class StorageArbitraries {
                 } else {
                   //noinspection ConstantConditions
                   if (maxAge != null) {
-                    return String.format("%s, max-age=%d", visibility, maxAge);
+                    return String.format(Locale.US, "%s, max-age=%d", visibility, maxAge);
                   } else if (transform != null) {
-                    return String.format("%s, %s", visibility, transform);
+                    return String.format(Locale.US, "%s, %s", visibility, transform);
                   } else {
-                    return String.format("%s, max-age=%d, %s", visibility, maxAge, transform);
+                    return String.format(
+                        Locale.US, "%s, max-age=%d, %s", visibility, maxAge, transform);
                   }
                 }
               });
@@ -642,7 +644,7 @@ public final class StorageArbitraries {
       }
 
       static EntityWithoutId user(String email) {
-        return new EntityWithoutId(String.format("user-%s", email));
+        return new EntityWithoutId(String.format(Locale.US, "user-%s", email));
       }
 
       static EntityWithId groupId(String id) {
@@ -650,16 +652,17 @@ public final class StorageArbitraries {
       }
 
       static EntityWithoutId group(String email) {
-        return new EntityWithoutId(String.format("group-%s", email));
+        return new EntityWithoutId(String.format(Locale.US, "group-%s", email));
       }
 
       static EntityWithoutId domain(String email) {
-        return new EntityWithoutId(String.format("domain-%s", email));
+        return new EntityWithoutId(String.format(Locale.US, "domain-%s", email));
       }
 
       static EntityWithoutId project(ProjectTeam projectTeam) {
         return new EntityWithoutId(
-            String.format("project-%s-%s", projectTeam.getTeam(), projectTeam.getProjectNumber()));
+            String.format(
+                Locale.US, "project-%s-%s", projectTeam.getTeam(), projectTeam.getProjectNumber()));
       }
     }
 


### PR DESCRIPTION
Usage of `Storage#format(String, Object...)` will use the default locale for it's formatting. This can lead to unexpected formatting if a right-to-left language such as Arabic is the default locale.

Update all usages to use `String.format(Locale.US, pattern, Object...)` so we ensure things like headers or error messages are formatted according to the US conventions which match `en_US` and ascii byte conventions.

Incidentally, things like right-to-left formatting seem to only apply to java11+ not java8.

Fixes #2972