### PR TITLE
fix: improve 503 handling for json resumable queries

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionQueryTask.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionQueryTask.java
@@ -113,6 +113,7 @@ final class JsonResumableSessionQueryTask
       } else {
         HttpResponseException cause = new HttpResponseException(response);
         String contentType = response.getHeaders().getContentType();
+        Long contentLength = response.getHeaders().getContentLength();
         // If the content-range header value has run ahead of the backend, it will respond with
         // a 503 with plain text content
         // Attempt to detect this very loosely as to minimize impact of modified error message
@@ -120,7 +121,9 @@ final class JsonResumableSessionQueryTask
         if ((!ResumableSessionFailureScenario.isOk(code)
                 && !ResumableSessionFailureScenario.isContinue(code))
             && contentType != null
-            && contentType.startsWith("text/plain")) {
+            && contentType.startsWith("text/plain")
+            && contentLength != null
+            && contentLength > 0) {
           String errorMessage = cause.getContent().toLowerCase(Locale.US);
           if (errorMessage.contains("content-range")) {
             throw ResumableSessionFailureScenario.SCENARIO_5.toStorageException(


### PR DESCRIPTION
This is exactly the same as https://github.com/googleapis/java-storage/pull/2289 - seem like a duplicated code that diverged.

Fixes a rare 503 handling issue
```
...
caused by NullPointerException: Cannot invoke "String.toLowerCase(java.util.Locale)" because the return value of "com.google.api.client.http.HttpResponseException.getContent()" is null
...
com.google.cloud.storage.JsonResumableSessionQueryTask.call(JsonResumableSessionQueryTask.java:117)
com.google.cloud.storage.JsonResumableSession.query(JsonResumableSession.java:57)
```


```
caused by StorageException: Unknown Error
	|> PUT https://storage.googleapis.com/upload/storage/v1/b/gcpeuropewest4-gcpeuropewest3-e942/o?name=<...>
	|> content-range: bytes */*
	|> x-goog-gcs-idempotency-token: <...>
	|  
	|< HTTP/1.1 503 Service Unavailable
	|< content-length: 0
	|< content-type: text/plain; charset=utf-8
	|< x-guploader-uploadid: <...>
	|  
```

cc @BenWhitehead 