### PR TITLE
fix: improve 503 handling for json resumable uploads

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionQueryTask.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionQueryTask.java
@@ -113,6 +113,7 @@ final class JsonResumableSessionQueryTask
       } else {
         HttpResponseException cause = new HttpResponseException(response);
         String contentType = response.getHeaders().getContentType();
+        Long contentLength = response.getHeaders().getContentLength();
         // If the content-range header value has run ahead of the backend, it will respond with
         // a 503 with plain text content
         // Attempt to detect this very loosely as to minimize impact of modified error message
@@ -120,7 +121,9 @@ final class JsonResumableSessionQueryTask
         if ((!ResumableSessionFailureScenario.isOk(code)
                 && !ResumableSessionFailureScenario.isContinue(code))
             && contentType != null
-            && contentType.startsWith("text/plain")) {
+            && contentType.startsWith("text/plain")
+            && contentLength != null
+            && contentLength > 0) {
           String errorMessage = cause.getContent().toLowerCase(Locale.US);
           if (errorMessage.contains("content-range")) {
             throw ResumableSessionFailureScenario.SCENARIO_5.toStorageException(


### PR DESCRIPTION
Port `NullPointerException` fix of `JsonResumableSessionPutTask` in 9b4bb8221294bcd94037b69281a37f33b364b174 to `JsonResumableSessionQueryTask`, which has similar code.
