### PR TITLE
chore: running integration test with Protobuf 4.30.1 [no need to review]

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -66,13 +66,14 @@ javadoc)
     ;;
 integration)
     mvn -B ${INTEGRATION_TEST_ARGS} \
+      -Dprotobuf.version=4.30.1 \
       -ntp \
       -Penable-integration-tests \
       -DtrimStackTrace=false \
       -Dclirr.skip=true \
       -Denforcer.skip=true \
       -fae \
-      verify
+      dependency:tree verify
     RETURN_CODE=$?
     ;;
 graalvm)


### PR DESCRIPTION
Not for merge. It's a preparation of how we can test integration
tests with a specific version of the Protobuf library.
