### PR TITLE
fix: ensure object generation is sent for Storage#update(BlobInfo) using HTTP Transport

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
@@ -564,7 +564,11 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage, 
     } else {
       StorageObject tmp = codecs.blobInfo().encode(updated);
       StorageObject pb = new StorageObject();
-      Stream.concat(modifiedFields.stream(), BlobField.REQUIRED_FIELDS.stream())
+      Stream.of(
+              modifiedFields.stream(),
+              BlobField.REQUIRED_FIELDS.stream(),
+              Stream.of(BlobField.GENERATION))
+          .flatMap(s -> s) // .flatten()
           .map(
               f -> {
                 if (f instanceof NestedNamedField) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectTest.java
@@ -98,6 +98,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import javax.crypto.spec.SecretKeySpec;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -1581,5 +1582,29 @@ public class ITObjectTest {
     gen1 = storage.get(gen1.getBlobId());
     Blob gen2 = storage.update(gen1);
     assertThat(gen2).isEqualTo(gen1);
+  }
+
+  @Test
+  public void blob_update() throws Exception {
+    ImmutableMap<@NonNull String, @NonNull String> meta1 = ImmutableMap.of("k1", "v1");
+    ImmutableMap<@NonNull String, @NonNull String> meta2 = ImmutableMap.of("k1", "v2");
+    ImmutableMap<@NonNull String, @NonNull String> meta3 = ImmutableMap.of("k1", "v1", "k2", "n1");
+
+    String randomObjectName = generator.randomObjectName();
+    BlobInfo info1 =
+        BlobInfo.newBuilder(versionedBucket, randomObjectName).setMetadata(meta1).build();
+    BlobInfo info2 =
+        BlobInfo.newBuilder(versionedBucket, randomObjectName).setMetadata(meta2).build();
+
+    BlobInfo gen1 = storage.create(info1);
+    BlobInfo gen2 = storage.create(info2);
+
+    BlobInfo update1 = gen1.toBuilder().setMetadata(meta3).build();
+
+    BlobInfo gen1_2 = storage.update(update1);
+
+    assertAll(
+        () -> assertThat(gen1_2.getMetadata()).isEqualTo(meta3),
+        () -> assertThat(gen1_2.getGeneration()).isEqualTo(gen1.getGeneration()));
   }
 }


### PR DESCRIPTION
If a generation is present in the provided BlobInfo ensure it is sent to GCS. This is a hard requirement when using versioned buckets and trying to update a non-current object version.

Effects all version 2.42.0 through 2.50.0

Regression introduced in #2664

Fixes #2980
