### PR TITLE
fix: update 416 & OUT_OF_RANGE handling for ReadChannel

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannel.java
@@ -222,6 +222,8 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
         if (statusCode == 404) {
           throw new StorageException(404, "Failure while trying to resume download", e);
         }
+      } else if (e.getStatusCode() == 416) {
+        returnEOF = true;
       }
       throw StorageException.translate(e);
     } catch (IOException e) {


### PR DESCRIPTION
If a 416 or OUT_OF_RANGE error are encountered the channel will always return -1, even if a new generation of object is created.
