### PR TITLE
chore: improve read object range error handling and retry robustness

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ObjectReadSessionStream.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ObjectReadSessionStream.java
@@ -378,37 +378,52 @@ final class ObjectReadSessionStream
     @Override
     public void onError(Throwable t) {
       requestStream = null;
-      try {
-        BidiReadObjectError error = GrpcUtils.getBidiReadObjectError(t);
-        if (error == null) {
-          return;
-        }
-
-        List<ReadRangeError> rangeErrors = error.getReadRangeErrorsList();
-        if (rangeErrors.isEmpty()) {
-          return;
-        }
-        for (ReadRangeError rangeError : rangeErrors) {
-          Status status = rangeError.getStatus();
-          long id = rangeError.getReadId();
-          ObjectReadSessionStreamRead<?> read = state.getOutstandingRead(id);
-          if (read == null) {
-            continue;
-          }
-          // mark read as failed, but don't resolve its future now. Schedule the delivery of the
-          // failure in executor to ensure any downstream future doesn't block this IO thread.
-          read.preFail();
-          executor.execute(
-              StorageException.liftToRunnable(
-                  () ->
-                      state
-                          .removeOutstandingReadOnFailure(id, read::fail)
-                          .onFailure(GrpcUtils.statusToApiException(status))));
-        }
-      } finally {
+      BidiReadObjectError error = GrpcUtils.getBidiReadObjectError(t);
+      if (error == null) {
+        // if there isn't a BidiReadObjectError that may contain more narrow failures, propagate
+        // the failure as is to the stream.
         streamRetryContext.recordError(
             t, ObjectReadSessionStream.this::restart, ObjectReadSessionStream.this::failAll);
+        return;
       }
+
+      List<ReadRangeError> rangeErrors = error.getReadRangeErrorsList();
+      if (rangeErrors.isEmpty()) {
+        // if there aren't any specific read id's that contain errors, propagate the error as is to
+        // the stream.
+        streamRetryContext.recordError(
+            t, ObjectReadSessionStream.this::restart, ObjectReadSessionStream.this::failAll);
+        return;
+      }
+      for (ReadRangeError rangeError : rangeErrors) {
+        Status status = rangeError.getStatus();
+        long id = rangeError.getReadId();
+        ObjectReadSessionStreamRead<?> read = state.getOutstandingRead(id);
+        if (read == null) {
+          continue;
+        }
+        // mark read as failed, but don't resolve its future now. Schedule the delivery of the
+        // failure in executor to ensure any downstream future doesn't block this IO thread.
+        read.preFail();
+        executor.execute(
+            StorageException.liftToRunnable(
+                () ->
+                    state
+                        .removeOutstandingReadOnFailure(id, read::fail)
+                        .onFailure(GrpcUtils.statusToApiException(status))));
+      }
+      // now that we've failed specific reads, raise a retryable ABORTED error to the stream to
+      // cause it to retry and pending remaining reads.
+      ApiException apiException =
+          ApiExceptionFactory.createException(
+              "Stream error, reclassifying as ABORTED for reads not specified in BidiReadObjectError",
+              t,
+              GrpcStatusCode.of(Code.ABORTED),
+              true);
+      streamRetryContext.recordError(
+          apiException,
+          ObjectReadSessionStream.this::restart,
+          ObjectReadSessionStream.this::failAll);
     }
 
     private OnSuccess restartReadFromCurrentOffset(long id) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITObjectReadSessionFakeTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITObjectReadSessionFakeTest.java
@@ -53,9 +53,11 @@ import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
 import com.google.common.io.ByteStreams;
 import com.google.common.truth.Correspondence;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.TextFormat;
+import com.google.rpc.DebugInfo;
 import com.google.storage.v2.BidiReadHandle;
 import com.google.storage.v2.BidiReadObjectError;
 import com.google.storage.v2.BidiReadObjectRedirectedError;
@@ -77,6 +79,7 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.ProtoUtils;
 import io.grpc.stub.StreamObserver;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousCloseException;
 import java.nio.channels.Channels;
@@ -87,13 +90,20 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -1375,9 +1385,6 @@ public final class ITObjectReadSessionFakeTest {
                     .build())
             .build();
 
-    System.out.println("req1 = " + TextFormat.printer().shortDebugString(req1));
-    System.out.println("req2 = " + TextFormat.printer().shortDebugString(req2));
-    System.out.println("req3 = " + TextFormat.printer().shortDebugString(req3));
     ImmutableMap<BidiReadObjectRequest, BidiReadObjectResponse> db =
         ImmutableMap.<BidiReadObjectRequest, BidiReadObjectResponse>builder()
             .put(req1, res1)
@@ -1533,6 +1540,196 @@ public final class ITObjectReadSessionFakeTest {
             () -> assertThat(actual).hasLength(expectedBytes.length),
             () -> assertThat(xxd(actual)).isEqualTo(xxd(expectedBytes)),
             () -> assertThat(actualCrc32c).isEqualTo(expectedCrc32c));
+      }
+    }
+  }
+
+  /**
+   * Define a test where multiple reads for the same session will be performed, and some of those
+   * reads cause OUT_OF_RANGE errors.
+   *
+   * <p>An OUT_OF_RANGE error is delivered as a stream level status, which means any reads which
+   * share a stream must be restarted while the read that caused the OUT_OF_RANGE should be failed.
+   *
+   * <p>Verify this behavior for both channel based and future byte[] based.
+   */
+  @Test
+  public void serverOutOfRangeIsNotRetried() throws Exception {
+    ChecksummedTestContent expected = ChecksummedTestContent.of(ALL_OBJECT_BYTES, 10, 20);
+    Semaphore sem = new Semaphore(1);
+
+    BidiReadObjectResponse dataResp =
+        BidiReadObjectResponse.newBuilder()
+            .addObjectDataRanges(
+                ObjectRangeData.newBuilder()
+                    .setChecksummedData(expected.asChecksummedData())
+                    .setReadRange(getReadRange(0, 10, 20))
+                    .setRangeEnd(true)
+                    .build())
+            .build();
+
+    AtomicInteger bidiReadObjectCount = new AtomicInteger();
+    ExecutorService exec =
+        Executors.newCachedThreadPool(
+            new ThreadFactoryBuilder().setDaemon(true).setNameFormat("test-server-%d").build());
+
+    StorageImplBase fakeStorage =
+        new StorageImplBase() {
+          @Override
+          public StreamObserver<BidiReadObjectRequest> bidiReadObject(
+              StreamObserver<BidiReadObjectResponse> respond) {
+            bidiReadObjectCount.getAndIncrement();
+            return new StreamObserver<BidiReadObjectRequest>() {
+              @Override
+              public void onNext(BidiReadObjectRequest request) {
+                if (request.equals(REQ_OPEN)) {
+                  respond.onNext(RES_OPEN);
+                } else if (request.getReadRangesList().get(0).getReadOffset() == 10) {
+                  exec.submit(
+                      () -> {
+                        try {
+                          sem.acquire();
+                          BidiReadObjectResponse.Builder b = dataResp.toBuilder();
+                          ReadRange readRange = request.getReadRangesList().get(0);
+                          ObjectRangeData.Builder bb = dataResp.getObjectDataRanges(0).toBuilder();
+                          bb.getReadRangeBuilder().setReadId(readRange.getReadId());
+                          b.setObjectDataRanges(0, bb.build());
+                          respond.onNext(b.build());
+                        } catch (InterruptedException e) {
+                          respond.onError(
+                              TestUtils.apiException(Code.UNIMPLEMENTED, e.getMessage()));
+                        }
+                      });
+                } else if (bidiReadObjectCount.getAndIncrement() >= 1) {
+                  Optional<ReadRange> readRange = request.getReadRangesList().stream().findFirst();
+                  String message =
+                      String.format(
+                          Locale.US,
+                          "OUT_OF_RANGE read_offset = %d",
+                          readRange.map(ReadRange::getReadOffset).orElse(0L));
+                  long readId = readRange.map(ReadRange::getReadId).orElse(0L);
+
+                  BidiReadObjectError err2 =
+                      BidiReadObjectError.newBuilder()
+                          .addReadRangeErrors(
+                              ReadRangeError.newBuilder()
+                                  .setReadId(readId)
+                                  .setStatus(
+                                      com.google.rpc.Status.newBuilder()
+                                          .setCode(com.google.rpc.Code.OUT_OF_RANGE_VALUE)
+                                          .build())
+                                  .build())
+                          .build();
+
+                  com.google.rpc.Status grpcStatusDetails =
+                      com.google.rpc.Status.newBuilder()
+                          .setCode(com.google.rpc.Code.UNAVAILABLE_VALUE)
+                          .setMessage("fail read_id: " + readId)
+                          .addDetails(Any.pack(err2))
+                          .addDetails(
+                              Any.pack(
+                                  DebugInfo.newBuilder()
+                                      .setDetail(message)
+                                      .addStackEntries(
+                                          TextFormat.printer().shortDebugString(request))
+                                      .build()))
+                          .build();
+
+                  Metadata trailers = new Metadata();
+                  trailers.put(GRPC_STATUS_DETAILS_KEY, grpcStatusDetails);
+                  StatusRuntimeException statusRuntimeException =
+                      Status.OUT_OF_RANGE.withDescription(message).asRuntimeException(trailers);
+                  respond.onError(statusRuntimeException);
+                } else {
+                  respond.onError(
+                      apiException(
+                          Code.UNIMPLEMENTED,
+                          "Unexpected request { "
+                              + TextFormat.printer().shortDebugString(request)
+                              + " }"));
+                }
+              }
+
+              @Override
+              public void onError(Throwable t) {
+                respond.onError(t);
+              }
+
+              @Override
+              public void onCompleted() {
+                respond.onCompleted();
+              }
+            };
+          }
+        };
+    try (FakeServer fakeServer = FakeServer.of(fakeStorage);
+        Storage storage = fakeServer.getGrpcStorageOptions().getService()) {
+
+      BlobId id = BlobId.of("b", "o");
+
+      try (BlobReadSession session = storage.blobReadSession(id).get(5, TimeUnit.SECONDS)) {
+
+        ApiFuture<byte[]> shouldSucceedFuture =
+            session.readAs(
+                ReadProjectionConfigs.asFutureBytes().withRangeSpec(RangeSpec.of(10, 20)));
+
+        ApiFuture<byte[]> shouldFailFuture =
+            session.readAs(
+                ReadProjectionConfigs.asFutureBytes().withRangeSpec(RangeSpec.beginAt(37)));
+        ExecutionException exceptionFromFuture =
+            assertThrows(
+                ExecutionException.class, () -> shouldFailFuture.get(30, TimeUnit.SECONDS));
+        sem.release();
+
+        Exception exceptionFromChannel;
+        byte[] bytesFromFuture = shouldSucceedFuture.get(30, TimeUnit.SECONDS);
+
+        AtomicReference<byte[]> bytesFromChannel = new AtomicReference<>();
+        Future<Long> asyncShouldSucceedChannel =
+            exec.submit(
+                () -> {
+                  try (ScatteringByteChannel succeed =
+                      session.readAs(
+                          ReadProjectionConfigs.asChannel().withRangeSpec(RangeSpec.of(10, 20)))) {
+                    sem.acquire();
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                    long copy = ByteStreams.copy(succeed, Channels.newChannel(baos));
+                    bytesFromChannel.set(baos.toByteArray());
+                    return copy;
+                  } catch (IOException e) {
+                    throw new RuntimeException(e);
+                  }
+                });
+
+        try (ScatteringByteChannel fail =
+            session.readAs(
+                ReadProjectionConfigs.asChannel().withRangeSpec(RangeSpec.beginAt(39)))) {
+          exceptionFromChannel =
+              assertThrows(
+                  IOException.class,
+                  () -> {
+                    int read = 0;
+                    do {
+                      read = fail.read(ByteBuffer.allocate(1));
+                    } while (read == 0);
+                  });
+          sem.release();
+        }
+        asyncShouldSucceedChannel.get(30, TimeUnit.SECONDS);
+        Exception finalExceptionFromChannel = exceptionFromChannel;
+        assertAll(
+            () ->
+                assertThat(exceptionFromFuture)
+                    .hasCauseThat()
+                    .hasCauseThat()
+                    .isInstanceOf(OutOfRangeException.class),
+            () ->
+                assertThat(finalExceptionFromChannel)
+                    .hasCauseThat()
+                    .hasCauseThat()
+                    .isInstanceOf(OutOfRangeException.class),
+            () -> assertThat(xxd(bytesFromFuture)).isEqualTo(xxd(expected.getBytes())),
+            () -> assertThat(xxd(bytesFromChannel.get())).isEqualTo(xxd(expected.getBytes())));
       }
     }
   }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITObjectReadSessionTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITObjectReadSessionTest.java
@@ -25,8 +25,10 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
+import com.google.api.gax.rpc.OutOfRangeException;
 import com.google.cloud.storage.Crc32cValue.Crc32cLengthKnown;
 import com.google.cloud.storage.Storage.BlobTargetOption;
+import com.google.cloud.storage.Storage.BlobWriteOption;
 import com.google.cloud.storage.TransportCompatibility.Transport;
 import com.google.cloud.storage.ZeroCopySupport.DisposableByteString;
 import com.google.cloud.storage.it.ChecksummedTestContent;
@@ -297,6 +299,37 @@ public final class ITObjectReadSessionTest {
             () -> assertThat(finalCopy2).isEqualTo(8 * _1MiB),
             () -> assertThat(finalCopy3).isEqualTo(16 * _1MiB));
       }
+    }
+  }
+
+  @Test
+  public void outOfRange()
+      throws ExecutionException, InterruptedException, TimeoutException, IOException {
+    BlobId blobId;
+    BlobWriteSession session =
+        storage.blobWriteSession(
+            BlobInfo.newBuilder(bucket, generator.randomObjectName()).build(),
+            BlobWriteOption.doesNotExist());
+    try (WritableByteChannel upload = session.open()) {
+      upload.write(DataGenerator.base64Characters().genByteBuffer(4));
+    }
+    blobId = session.getResult().get(5, TimeUnit.SECONDS).getBlobId();
+    try (BlobReadSession blobReadSession =
+        storage.blobReadSession(blobId).get(30, TimeUnit.SECONDS)) {
+
+      BlobInfo info1 = blobReadSession.getBlobInfo();
+      assertThat(info1).isNotNull();
+
+      ReadAsFutureBytes cfg = ReadProjectionConfigs.asFutureBytes();
+
+      ApiFuture<byte[]> f2 = blobReadSession.readAs(cfg.withRangeSpec(RangeSpec.beginAt(5)));
+      ExecutionException ee =
+          assertThrows(ExecutionException.class, () -> f2.get(30, TimeUnit.SECONDS));
+      assertThat(ee).hasCauseThat().hasCauseThat().isInstanceOf(OutOfRangeException.class);
+
+      ApiFuture<byte[]> f1 = blobReadSession.readAs(cfg.withRangeSpec(RangeSpec.all()));
+      byte[] bytes1 = f1.get(30, TimeUnit.SECONDS);
+      assertThat(bytes1.length).isEqualTo(4);
     }
   }
 


### PR DESCRIPTION
When a read causes an error it is delivered as a stream error. Depending on the kind of error (DATA_LOSS OUT_OF_RANGE) this could lead to a terminal state for the stream. If the error is for a specific range(s) mark those individual reads as terminally failed, but do not fail any others. Instead, raise a client side retryable ABORTED to restart the stream and any remaining reads for it.

