### PR TITLE
chore: refactor BlobAppendableUpload, so it follows the lifecycle of BlobWriteSession

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobAppendableUploadConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobAppendableUploadConfig.java
@@ -19,10 +19,21 @@ package com.google.cloud.storage;
 import static com.google.cloud.storage.ByteSizeConstants._256KiB;
 import static java.util.Objects.requireNonNull;
 
+import com.google.api.core.ApiFutures;
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
+import com.google.api.gax.retrying.BasicResultRetryAlgorithm;
+import com.google.api.gax.rpc.AbortedException;
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.storage.BlobAppendableUpload.AppendableUploadWriteableByteChannel;
+import com.google.cloud.storage.BlobAppendableUploadImpl.AppendableObjectBufferedWritableByteChannel;
 import com.google.cloud.storage.Storage.BlobWriteOption;
 import com.google.cloud.storage.TransportCompatibility.Transport;
+import com.google.cloud.storage.UnifiedOpts.ObjectTargetOpt;
+import com.google.cloud.storage.UnifiedOpts.Opts;
+import com.google.storage.v2.BidiWriteObjectRequest;
+import com.google.storage.v2.BidiWriteObjectResponse;
+import com.google.storage.v2.Object;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -39,14 +50,20 @@ import javax.annotation.concurrent.Immutable;
 public final class BlobAppendableUploadConfig {
 
   private static final BlobAppendableUploadConfig INSTANCE =
-      new BlobAppendableUploadConfig(FlushPolicy.minFlushSize(_256KiB), Hasher.enabled());
+      new BlobAppendableUploadConfig(
+          FlushPolicy.minFlushSize(_256KiB),
+          Hasher.enabled(),
+          CloseAction.CLOSE_WITHOUT_FINALIZING);
 
   private final FlushPolicy flushPolicy;
   private final Hasher hasher;
+  private final CloseAction closeAction;
 
-  private BlobAppendableUploadConfig(FlushPolicy flushPolicy, Hasher hasher) {
+  private BlobAppendableUploadConfig(
+      FlushPolicy flushPolicy, Hasher hasher, CloseAction closeAction) {
     this.flushPolicy = flushPolicy;
     this.hasher = hasher;
+    this.closeAction = closeAction;
   }
 
   /**
@@ -77,7 +94,37 @@ public final class BlobAppendableUploadConfig {
     if (this.flushPolicy.equals(flushPolicy)) {
       return this;
     }
-    return new BlobAppendableUploadConfig(flushPolicy, hasher);
+    return new BlobAppendableUploadConfig(flushPolicy, hasher, closeAction);
+  }
+
+  /**
+   * The {@link CloseAction} which will dictate the behavior of {@link
+   * AppendableUploadWriteableByteChannel#close()}.
+   *
+   * <p><i>Default:</i> {@link CloseAction#CLOSE_WITHOUT_FINALIZING}
+   *
+   * @see #withCloseAction(CloseAction)
+   * @since 2.51.0 This new api is in preview and is subject to breaking changes.
+   */
+  @BetaApi
+  public CloseAction getCloseAction() {
+    return closeAction;
+  }
+
+  /**
+   * Return an instance with the {@code CloseAction} set to be the specified value. <i>Default:</i>
+   * {@link CloseAction#CLOSE_WITHOUT_FINALIZING}
+   *
+   * @see #getCloseAction()
+   * @since 2.51.0 This new api is in preview and is subject to breaking changes.
+   */
+  @BetaApi
+  public BlobAppendableUploadConfig withCloseAction(CloseAction closeAction) {
+    requireNonNull(closeAction, "closeAction must be non null");
+    if (this.closeAction == closeAction) {
+      return this;
+    }
+    return new BlobAppendableUploadConfig(flushPolicy, hasher, closeAction);
   }
 
   /**
@@ -108,7 +155,8 @@ public final class BlobAppendableUploadConfig {
     } else if (!enabled && Hasher.noop().equals(hasher)) {
       return this;
     }
-    return new BlobAppendableUploadConfig(flushPolicy, enabled ? Hasher.enabled() : Hasher.noop());
+    return new BlobAppendableUploadConfig(
+        flushPolicy, enabled ? Hasher.enabled() : Hasher.noop(), closeAction);
   }
 
   /** Never to be made public until {@link Hasher} is public */
@@ -125,6 +173,7 @@ public final class BlobAppendableUploadConfig {
    * <pre>{@code
    * BlobAppendableUploadConfig.of()
    *   .withFlushPolicy(FlushPolicy.minFlushSize(256 * 1024))
+   *   .withCloseAction(CloseAction.CLOSE_WITHOUT_FINALIZING)
    * }</pre>
    *
    * @since 2.51.0 This new api is in preview and is subject to breaking changes.
@@ -133,5 +182,90 @@ public final class BlobAppendableUploadConfig {
   @BetaApi
   public static BlobAppendableUploadConfig of() {
     return INSTANCE;
+  }
+
+  /**
+   * Enum providing the possible actions which can be taken during the {@link
+   * AppendableUploadWriteableByteChannel#close()} call.
+   *
+   * @see AppendableUploadWriteableByteChannel#close()
+   * @see BlobAppendableUploadConfig#withCloseAction(CloseAction)
+   * @see BlobAppendableUploadConfig#getCloseAction()
+   * @since 2.51.0 This new api is in preview and is subject to breaking changes.
+   */
+  @BetaApi
+  public enum CloseAction {
+    /**
+     * Designate that when {@link AppendableUploadWriteableByteChannel#close()} is called, the
+     * appendable upload should be finalized.
+     *
+     * @since 2.51.0 This new api is in preview and is subject to breaking changes.
+     * @see AppendableUploadWriteableByteChannel#finalizeAndClose()
+     */
+    @BetaApi
+    FINALIZE_WHEN_CLOSING,
+    /**
+     * Designate that when {@link AppendableUploadWriteableByteChannel#close()} is called, the
+     * appendable upload should NOT be finalized, allowing for takeover by another session or
+     * client.
+     *
+     * @since 2.51.0 This new api is in preview and is subject to breaking changes.
+     * @see AppendableUploadWriteableByteChannel#closeWithoutFinalizing()
+     */
+    @BetaApi
+    CLOSE_WITHOUT_FINALIZING
+  }
+
+  BlobAppendableUpload create(GrpcStorageImpl storage, BlobInfo info, Opts<ObjectTargetOpt> opts) {
+    boolean takeOver = info.getGeneration() != null;
+    BidiWriteObjectRequest req =
+        takeOver
+            ? storage.getBidiWriteObjectRequestForTakeover(info, opts)
+            : storage.getBidiWriteObjectRequest(info, opts);
+
+    BidiAppendableWrite baw = new BidiAppendableWrite(req, takeOver);
+
+    WritableByteChannelSession<AppendableObjectBufferedWritableByteChannel, BidiWriteObjectResponse>
+        build =
+            ResumableMedia.gapic()
+                .write()
+                .bidiByteChannel(storage.storageClient.bidiWriteObjectCallable())
+                .setHasher(this.getHasher())
+                .setByteStringStrategy(ByteStringStrategy.copy())
+                .appendable()
+                .withRetryConfig(
+                    storage.retrier.withAlg(
+                        new BasicResultRetryAlgorithm<Object>() {
+                          @Override
+                          public boolean shouldRetry(
+                              Throwable previousThrowable, Object previousResponse) {
+                            // TODO: remove this later once the redirects are not handled by the
+                            // retry loop
+                            ApiException apiEx = null;
+                            if (previousThrowable instanceof StorageException) {
+                              StorageException se = (StorageException) previousThrowable;
+                              Throwable cause = se.getCause();
+                              if (cause instanceof ApiException) {
+                                apiEx = (ApiException) cause;
+                              }
+                            }
+                            if (apiEx instanceof AbortedException) {
+                              return true;
+                            }
+                            return storage
+                                .retryAlgorithmManager
+                                .idempotent()
+                                .shouldRetry(previousThrowable, null);
+                          }
+                        }))
+                .buffered(this.getFlushPolicy())
+                .setStartAsync(ApiFutures.immediateFuture(baw))
+                .setGetCallable(storage.storageClient.getObjectCallable())
+                .setFinalizeOnClose(this.closeAction == CloseAction.FINALIZE_WHEN_CLOSING)
+                .build();
+
+    return new BlobAppendableUploadImpl(
+        new DefaultBlobWriteSessionConfig.DecoratedWritableByteChannelSession<>(
+            build, BidiBlobWriteSessionConfig.Factory.WRITE_OBJECT_RESPONSE_BLOB_INFO_DECODER));
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ChannelSession.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ChannelSession.java
@@ -37,7 +37,7 @@ class ChannelSession<StartT, ResultT, ChannelT> {
 
   private volatile ApiFuture<ChannelT> channelFuture;
 
-  private ChannelSession(
+  ChannelSession(
       ApiFuture<StartT> startFuture, BiFunction<StartT, SettableApiFuture<ResultT>, ChannelT> f) {
     this.startFuture = startFuture;
     this.resultFuture = SettableApiFuture.create();

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
@@ -5901,21 +5901,21 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
    * BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
    * ReadableByteChannel readableByteChannel = ...;
    *
-   * try (
-   *   BlobAppendableUpload blobAppendableUpload = storage.blobAppendableUpload(
+   * BlobAppendableUpload uploadSession = storage.blobAppendableUpload(
    *     blobInfo,
    *     BlobAppendableUploadConfig.of()
-   *   )
-   * ) {
-   * // copy all bytes
-   * ByteStreams.copy(readableByteChannel, blobAppendableUpload);
-   * // get the resulting object metadata
-   * ApiFuture<BlobInfo> resultFuture = blobAppendableUpload.finalizeUpload();
-   * BlobInfo gen1 = resultFuture.get();
-   *
-   * } catch (IOException e) {
-   * // handle IOException
+   * );
+   * try (AppendableUploadWriteableByteChannel channel = uploadSession.open()) {
+   *   // copy all bytes
+   *   ByteStreams.copy(readableByteChannel, channel);
+   *   channel.finalizeAndClose();
+   * } catch (IOException ex) {
+   *   // handle IOException
    * }
+   *
+   * // get the resulting object metadata
+   * ApiFuture<BlobInfo> resultFuture = uploadSession.getResult();
+   * BlobInfo gen1 = resultFuture.get();
    * }</pre>
    *
    * @param blobInfo blobInfo to create
@@ -5927,8 +5927,7 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
   @BetaApi
   @TransportCompatibility({Transport.GRPC})
   default BlobAppendableUpload blobAppendableUpload(
-      BlobInfo blobInfo, BlobAppendableUploadConfig uploadConfig, BlobWriteOption... options)
-      throws IOException {
+      BlobInfo blobInfo, BlobAppendableUploadConfig uploadConfig, BlobWriteOption... options) {
     return throwGrpcOnly(
         fmtMethodName("appendableBlobUpload", BlobId.class, BlobWriteOption.class));
   }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/AbstractStorageProxy.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/AbstractStorageProxy.java
@@ -500,8 +500,7 @@ abstract class AbstractStorageProxy implements Storage {
 
   @Override
   public BlobAppendableUpload blobAppendableUpload(
-      BlobInfo blobInfo, BlobAppendableUploadConfig uploadConfig, BlobWriteOption... options)
-      throws IOException {
+      BlobInfo blobInfo, BlobAppendableUploadConfig uploadConfig, BlobWriteOption... options) {
     return delegate.blobAppendableUpload(blobInfo, uploadConfig, options);
   }
 


### PR DESCRIPTION
This allows access to the resulting BlobInfo, even if not finalized. The returned BlobInfo will have generation and a client side updated `size` matching the number of persisted bytes the client knows has been ack'd by GCS.

Add closeAction option to BlobAppendableUploadConfig allowing configuration of finalization on close behavior.
