### PR TITLE
feat: update generation config manually

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -15,8 +15,9 @@ branchProtectionRules:
       - units (11)
       - 'Kokoro - Test: Integration'
       - cla/google
-      - 'Kokoro - Test: Java GraalVM Native Image'
-      - 'Kokoro - Test: Java 17 GraalVM Native Image'
+      - 'Kokoro - Test: Java GraalVM Native Image A'
+      - 'Kokoro - Test: Java GraalVM Native Image B'
+      - 'Kokoro - Test: Java GraalVM Native Image C'
       - javadoc
       - unmanaged_dependency_check
   - pattern: 1.113.14-sp

--- a/.kokoro/presubmit/graalvm-native-a.cfg
+++ b/.kokoro/presubmit/graalvm-native-a.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.46.1"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_a:3.46.2" # {x-version-update:google-cloud-shared-dependencies:current}
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native-b.cfg
+++ b/.kokoro/presubmit/graalvm-native-b.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.46.1"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_b:3.46.2" # {x-version-update:google-cloud-shared-dependencies:current}
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native-c.cfg
+++ b/.kokoro/presubmit/graalvm-native-c.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_c:3.46.1"
+  value: "gcr.io/cloud-devrel-public-resources/graalvm_sdk_platform_c:3.46.2" # {x-version-update:google-cloud-shared-dependencies:current}
 }
 
 env_vars: {

--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -1,5 +1,5 @@
-gapic_generator_version: 2.56.0
-googleapis_commitish: c8f09eb3362651a47b5c4adef1cb2bbdc652eeb4
+gapic_generator_version: 2.56.2
+googleapis_commitish: 03baf05e13d9241ec8c19bdedb1d991b6ed7e115
 libraries_bom_version: 26.59.0
 libraries:
   - api_shortname: storage


### PR DESCRIPTION
This pull request is generated with proto changes between [googleapis/googleapis@c8f09eb](https://github.com/googleapis/googleapis/commit/c8f09eb3362651a47b5c4adef1cb2bbdc652eeb4) (exclusive) and [googleapis/googleapis@03baf05](https://github.com/googleapis/googleapis/commit/03baf05e13d9241ec8c19bdedb1d991b6ed7e115) (inclusive).

BEGIN_COMMIT_OVERRIDE
BEGIN_NESTED_COMMIT
fix(deps): update the Java code generator (gapic-generator-java) to 2.56.2
END_NESTED_COMMIT
END_COMMIT_OVERRIDE