### PR TITLE
test: switch all test logging to slf4j instead of j.u.l

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicBidiUnbufferedWritableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicBidiUnbufferedWritableByteChannelTest.java
@@ -48,11 +48,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
-import java.util.logging.Logger;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class ITGapicBidiUnbufferedWritableByteChannelTest {
 
@@ -830,7 +831,7 @@ public final class ITGapicBidiUnbufferedWritableByteChannelTest {
   }
 
   static class BidiWriteService extends StorageImplBase {
-    private static final Logger LOGGER = Logger.getLogger(BidiWriteService.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(BidiWriteService.class);
     private final BiConsumer<StreamObserver<BidiWriteObjectResponse>, List<BidiWriteObjectRequest>>
         c;
 
@@ -878,7 +879,7 @@ public final class ITGapicBidiUnbufferedWritableByteChannelTest {
                   .map(l -> l.stream().map(StorageV2ProtoUtils::fmtProto).collect(oneLine))
                   .collect(joining),
               build.stream().map(StorageV2ProtoUtils::fmtProto).collect(oneLine));
-      LOGGER.warning(msg);
+      LOGGER.warn(msg);
     }
 
     @Override

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicUnbufferedWritableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicUnbufferedWritableByteChannelTest.java
@@ -51,14 +51,15 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
-import java.util.logging.Logger;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class ITGapicUnbufferedWritableByteChannelTest {
   private static final Logger LOGGER =
-      Logger.getLogger(ITGapicUnbufferedWritableByteChannelTest.class.getName());
+      LoggerFactory.getLogger(ITGapicUnbufferedWritableByteChannelTest.class);
 
   private static final Hasher HASHER = Hasher.enabled();
   private static final ChunkSegmenter segmenter =
@@ -202,7 +203,7 @@ public final class ITGapicUnbufferedWritableByteChannelTest {
         c.close();
       } catch (PermissionDeniedException ignore) {
         for (String debugMessage : debugMessages) {
-          LOGGER.warning(debugMessage);
+          LOGGER.warn(debugMessage);
         }
       }
       assertThat(result.get()).isEqualTo(resp5);
@@ -331,7 +332,7 @@ public final class ITGapicUnbufferedWritableByteChannelTest {
   }
 
   static class DirectWriteService extends StorageImplBase {
-    private static final Logger LOGGER = Logger.getLogger(DirectWriteService.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(DirectWriteService.class);
     private final BiConsumer<StreamObserver<WriteObjectResponse>, List<WriteObjectRequest>> c;
 
     private ImmutableList.Builder<WriteObjectRequest> requests;
@@ -368,7 +369,7 @@ public final class ITGapicUnbufferedWritableByteChannelTest {
                   .map(l -> l.stream().map(StorageV2ProtoUtils::fmtProto).collect(oneLine))
                   .collect(joining),
               build.stream().map(StorageV2ProtoUtils::fmtProto).collect(oneLine));
-      LOGGER.warning(msg);
+      LOGGER.warn(msg);
     }
 
     @Override

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/ITRetryConformanceTest.java
@@ -63,7 +63,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.After;
@@ -71,6 +70,8 @@ import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Load and dynamically generate a series of test cases to verify if the {@link Storage} and
@@ -86,7 +87,7 @@ import org.junit.runner.RunWith;
 @Parameterized(RetryConformanceParameterProvider.class)
 @ParallelFriendly
 public class ITRetryConformanceTest {
-  private static final Logger LOGGER = Logger.getLogger(ITRetryConformanceTest.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(ITRetryConformanceTest.class);
 
   private RetryTestFixture retryTestFixture;
 
@@ -100,7 +101,7 @@ public class ITRetryConformanceTest {
 
   @Before
   public void setUp() throws Throwable {
-    LOGGER.fine("Running setup...");
+    LOGGER.trace("Running setup...");
     retryTestFixture = retryParameter.retryTestFixture;
     testRetryConformance = retryParameter.testRetryConformance;
     mapping = retryParameter.rpcMethodMapping;
@@ -111,12 +112,12 @@ public class ITRetryConformanceTest {
     // the case setup fails for some reason
     ctx = ctx(nonTestStorage, empty());
     ctx = mapping.getSetup().apply(ctx, testRetryConformance).leftMap(s -> testStorage);
-    LOGGER.fine("Running setup complete");
+    LOGGER.trace("Running setup complete");
   }
 
   @After
   public void tearDown() throws Throwable {
-    LOGGER.fine("Running teardown...");
+    LOGGER.trace("Running teardown...");
     if (ctx != null) {
       ctx = ctx.leftMap(s -> nonTestStorage);
       getReplaceStorageInObjectsFromCtx()
@@ -124,7 +125,7 @@ public class ITRetryConformanceTest {
           .apply(ctx, testRetryConformance);
     }
     retryTestFixture.finished(null);
-    LOGGER.fine("Running teardown complete");
+    LOGGER.trace("Running teardown complete");
   }
 
   /**
@@ -133,7 +134,7 @@ public class ITRetryConformanceTest {
    */
   @Test
   public void test() throws Throwable {
-    LOGGER.fine("Running test...");
+    LOGGER.trace("Running test...");
     assertThat(ctx).isNotNull();
     try {
       ctx =
@@ -146,7 +147,7 @@ public class ITRetryConformanceTest {
       retryTestFixture.failed(e, null);
       throw e;
     }
-    LOGGER.fine("Running test complete");
+    LOGGER.trace("Running test complete");
   }
 
   /**
@@ -374,7 +375,7 @@ public class ITRetryConformanceTest {
                   .collect(Collectors.toSet()));
 
       if (!unusedMappings.isEmpty()) {
-        LOGGER.warning(
+        LOGGER.warn(
             String.format(
                 Locale.US,
                 "Declared but unused mappings with ids: [%s]",

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/conformance/retry/RpcMethodMappings.java
@@ -105,8 +105,9 @@ import java.util.Map.Entry;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A class which serves to try and organize all of the {@link RpcMethodMapping} for the retry
@@ -120,7 +121,7 @@ import java.util.stream.Collectors;
 @Immutable
 @SuppressWarnings("Guava")
 final class RpcMethodMappings {
-  private static final Logger LOGGER = Logger.getLogger(RpcMethodMappings.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(RpcMethodMappings.class);
 
   private static final Predicate<TestRetryConformance> groupIsDownload =
       methodGroupIs("storage.objects.download");
@@ -224,7 +225,7 @@ final class RpcMethodMappings {
 
   private void reportMappingSummary() {
     int mappingCount = funcMap.values().stream().mapToInt(m -> 1).sum();
-    LOGGER.info("Current total number of mappings defined: " + mappingCount);
+    LOGGER.info("Current total number of mappings defined: {}", mappingCount);
     String counts =
         funcMap.asMap().entrySet().stream()
             .map(
@@ -244,7 +245,7 @@ final class RpcMethodMappings {
                 })
             .sorted()
             .collect(Collectors.joining("\n", "\n", ""));
-    LOGGER.info("Current number of mappings per rpc method: " + counts);
+    LOGGER.info("Current number of mappings per rpc method: {}", counts);
     OptionalInt max =
         funcMap.values().stream().map(RpcMethodMapping::getMappingId).mapToInt(i -> i).max();
     if (max.isPresent()) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/BucketCleaner.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/BucketCleaner.java
@@ -42,18 +42,18 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class BucketCleaner {
 
-  private static final Logger LOGGER = Logger.getLogger(BucketCleaner.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(BucketCleaner.class);
 
   public static void doCleanup(String bucketName, Storage s) {
-    LOGGER.fine("Starting bucket cleanup...");
+    LOGGER.trace("Starting bucket cleanup...");
     String projectId = s.getOptions().getProjectId();
     try {
       // TODO: probe bucket existence, a bad test could have deleted the bucket
@@ -73,16 +73,16 @@ public final class BucketCleaner {
       if (!anyFailedObjectDeletes) {
         s.delete(bucketName, BucketSourceOption.userProject(projectId));
       } else {
-        LOGGER.warning("Unable to delete bucket due to previous failed object deletes");
+        LOGGER.warn("Unable to delete bucket due to previous failed object deletes");
       }
-      LOGGER.fine("Bucket cleanup complete");
+      LOGGER.trace("Bucket cleanup complete");
     } catch (Exception e) {
-      LOGGER.log(Level.SEVERE, e, () -> "Error during bucket cleanup.");
+      LOGGER.error("Error during bucket cleanup.");
     }
   }
 
   public static void doCleanup(String bucketName, Storage s, StorageControlClient ctrl) {
-    LOGGER.warning("Starting bucket cleanup: " + bucketName);
+    LOGGER.warn("Starting bucket cleanup: {}", bucketName);
     String projectId = s.getOptions().getProjectId();
     try {
       // TODO: probe bucket existence, a bad test could have deleted the bucket
@@ -140,7 +140,7 @@ public final class BucketCleaner {
                       folder -> {
                         String formatted =
                             String.format(Locale.US, "folder = %s", folder.getName());
-                        LOGGER.warning(formatted);
+                        LOGGER.warn(formatted);
                         boolean success = true;
                         try {
                           ctrl.deleteFolderCallable()
@@ -176,7 +176,7 @@ public final class BucketCleaner {
                       managedFolder -> {
                         String formatted =
                             String.format(Locale.US, "managedFolder = %s", managedFolder.getName());
-                        LOGGER.warning(formatted);
+                        LOGGER.warn(formatted);
                         boolean success = true;
                         try {
                           ctrl.deleteManagedFolderCallable()
@@ -214,7 +214,7 @@ public final class BucketCleaner {
       if (!anyFailedObjectDelete && !anyFailedFolderDelete && !anyFailedManagedFolderDelete) {
         s.delete(bucketName, BucketSourceOption.userProject(projectId));
       } else {
-        LOGGER.warning(
+        LOGGER.warn(
             String.format(
                 Locale.US,
                 "Unable to delete bucket %s due to previous failed %s deletes",
@@ -222,9 +222,9 @@ public final class BucketCleaner {
                 failed));
       }
 
-      LOGGER.warning("Bucket cleanup complete: " + bucketName);
+      LOGGER.warn("Bucket cleanup complete: {}", bucketName);
     } catch (Exception e) {
-      LOGGER.log(Level.SEVERE, e, () -> "Error during bucket cleanup.");
+      LOGGER.error("Error during bucket cleanup.");
     }
   }
 
@@ -234,7 +234,7 @@ public final class BucketCleaner {
         deleteResults.stream().filter(r -> !r.success).collect(Collectors.toList());
     failedDeletes.forEach(
         r ->
-            LOGGER.warning(
+            LOGGER.warn(
                 String.format(
                     Locale.US, "Failed to delete %s %s/%s", resourceType, bucketName, r.name)));
     return !failedDeletes.isEmpty();

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/GrpcPlainRequestLoggingInterceptor.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/GrpcPlainRequestLoggingInterceptor.java
@@ -50,11 +50,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Client side interceptor which will log gRPC request, headers, response, status and trailers in
@@ -67,7 +67,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 public final class GrpcPlainRequestLoggingInterceptor implements ClientInterceptor {
 
   private static final Logger LOGGER =
-      Logger.getLogger(GrpcPlainRequestLoggingInterceptor.class.getName());
+      LoggerFactory.getLogger(GrpcPlainRequestLoggingInterceptor.class);
 
   private static final GrpcPlainRequestLoggingInterceptor INSTANCE =
       new GrpcPlainRequestLoggingInterceptor();
@@ -117,14 +117,13 @@ public final class GrpcPlainRequestLoggingInterceptor implements ClientIntercept
       @Override
       public void start(Listener<RespT> responseListener, Metadata headers) {
         if (headers.containsKey(X_GOOG_REQUEST_PARAMS)) {
-          LOGGER.log(Level.CONFIG, () -> String.format(">>> headers = %s", headers));
+          LOGGER.atDebug().log(() -> String.format(">>> headers = %s", headers));
         }
         SimpleForwardingClientCallListener<RespT> listener =
             new SimpleForwardingClientCallListener<RespT>(responseListener) {
               @Override
               public void onMessage(RespT message) {
-                LOGGER.log(
-                    Level.CONFIG,
+                LOGGER.atDebug().log(
                     () ->
                         String.format(
                             Locale.US,
@@ -136,7 +135,7 @@ public final class GrpcPlainRequestLoggingInterceptor implements ClientIntercept
 
               @Override
               public void onClose(Status status, Metadata trailers) {
-                LOGGER.log(Level.CONFIG, lazyOnCloseLogString(status, trailers));
+                LOGGER.atDebug().log(lazyOnCloseLogString(status, trailers));
                 super.onClose(status, trailers);
               }
             };
@@ -145,8 +144,7 @@ public final class GrpcPlainRequestLoggingInterceptor implements ClientIntercept
 
       @Override
       public void sendMessage(ReqT message) {
-        LOGGER.log(
-            Level.CONFIG,
+        LOGGER.atDebug().log(
             () ->
                 String.format(
                     Locale.US,

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobWriteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITBlobWriteChannelTest.java
@@ -63,7 +63,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.logging.Logger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -71,7 +70,6 @@ import org.junit.runner.RunWith;
 @SingleBackend(Backend.TEST_BENCH)
 public final class ITBlobWriteChannelTest {
 
-  private static final Logger LOGGER = Logger.getLogger(ITBlobWriteChannelTest.class.getName());
   private static final String NOW_STRING;
   private static final String BLOB_STRING_CONTENT = "Hello Google Cloud Storage!";
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITNotificationTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITNotificationTest.java
@@ -39,12 +39,12 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @RunWith(StorageITRunner.class)
 @CrossRun(
@@ -53,7 +53,7 @@ import org.junit.runner.RunWith;
 public class ITNotificationTest {
   private static final Notification.PayloadFormat PAYLOAD_FORMAT = PayloadFormat.JSON_API_V1;
   private static final Map<String, String> CUSTOM_ATTRIBUTES = ImmutableMap.of("label1", "value1");
-  private static final Logger log = Logger.getLogger(ITNotificationTest.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(ITNotificationTest.class);
   private static final String DOES_NOT_EXIST_ID = "something-that-does-not-exist-probably";
 
   @Inject public Backend backend;
@@ -110,7 +110,7 @@ public class ITNotificationTest {
         topicAdminClient.deleteTopic(topic);
         topicAdminClient.close();
       } catch (Exception e) {
-        log.log(Level.WARNING, "Error while trying to delete topic and shutdown topic client", e);
+        LOGGER.warn("Error while trying to delete topic and shutdown topic client", e);
       }
       topicAdminClient = null;
     }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/StorageITLeafRunner.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/StorageITLeafRunner.java
@@ -26,7 +26,6 @@ import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -36,6 +35,7 @@ import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.TestClass;
+import org.slf4j.LoggerFactory;
 
 final class StorageITLeafRunner extends BlockJUnit4ClassRunner {
   private final CrossRunIntersection crossRunIntersection;
@@ -111,7 +111,7 @@ final class StorageITLeafRunner extends BlockJUnit4ClassRunner {
             "Using @Test(timeout = 1), @Rule Timeout or @ClassRule Timeout can break multi-thread"
                 + " and Fixture support of StorageITRunner. Please refactor your test to detect a"
                 + " timeout in the test itself.";
-        Logger.getLogger(StorageITRunner.class.getName()).warning(msg);
+        LoggerFactory.getLogger(StorageITRunner.class).warn(msg);
       }
     }
     super.validateTestMethods(errors);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestBench.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestBench.java
@@ -58,10 +58,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link ManagedLifecycle} which integrates with the <a target="_blank"
@@ -89,7 +89,7 @@ import java.util.regex.Pattern;
  */
 public final class TestBench implements ManagedLifecycle {
 
-  private static final Logger LOGGER = Logger.getLogger(TestBench.class.getName());
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestBench.class);
 
   private final boolean ignorePullError;
   private final String baseUri;
@@ -206,8 +206,8 @@ public final class TestBench implements ManagedLifecycle {
 
       File outFile = outPath.toFile();
       File errFile = errPath.toFile();
-      LOGGER.info("Redirecting server stdout to: " + outFile.getAbsolutePath());
-      LOGGER.info("Redirecting server stderr to: " + errFile.getAbsolutePath());
+      LOGGER.info("Redirecting server stdout to: {}", outFile.getAbsolutePath());
+      LOGGER.info("Redirecting server stderr to: {}", errFile.getAbsolutePath());
       String dockerImage = String.format(Locale.US, "%s:%s", dockerImageName, dockerImageTag);
       // First try and pull the docker image, this validates docker is available and running
       // on the host, as well as gives time for the image to be downloaded independently of
@@ -263,7 +263,7 @@ public final class TestBench implements ManagedLifecycle {
               .redirectOutput(outFile)
               .redirectError(errFile)
               .start();
-      LOGGER.log(Level.INFO, command.toString());
+      LOGGER.info(command.toString());
       try {
         // wait a small amount of time for the server to come up before probing
         Thread.sleep(500);
@@ -317,22 +317,19 @@ public final class TestBench implements ManagedLifecycle {
         if (processExitValue != 0) {
           attemptForceStopContainer = true;
         }
-        System.out.println("processExitValue = " + processExitValue);
-        LOGGER.warning("Container exit value = " + processExitValue);
+        LOGGER.warn("Container exit value = {}", processExitValue);
       } catch (IllegalThreadStateException e) {
         attemptForceStopContainer = true;
       }
 
       if (attemptForceStopContainer) {
-        LOGGER.warning("Container did not gracefully exit, attempting to explicitly stop it.");
-        System.out.println("Container did not gracefully exit, attempting to explicitly stop it.");
+        LOGGER.warn("Container did not gracefully exit, attempting to explicitly stop it.");
         ImmutableList<String> command = ImmutableList.of("docker", "kill", containerName);
-        System.out.println("command = " + command);
-        LOGGER.log(Level.WARNING, command.toString());
+        LOGGER.warn(command.toString());
         Process shutdownProcess = new ProcessBuilder(command).start();
         shutdownProcess.waitFor(5, TimeUnit.SECONDS);
         int shutdownProcessExitValue = shutdownProcess.exitValue();
-        LOGGER.warning("Container exit value = " + shutdownProcessExitValue);
+        LOGGER.warn("Container exit value = {}", shutdownProcessExitValue);
       }
 
       // wait for the server to shutdown
@@ -373,10 +370,10 @@ public final class TestBench implements ManagedLifecycle {
 
   private void dumpServerLogs(Path outFile, Path errFile) throws IOException {
     try {
-      LOGGER.warning("Dumping contents of stdout");
+      LOGGER.warn("Dumping contents of stdout");
       dumpServerLog("stdout", outFile.toFile());
     } finally {
-      LOGGER.warning("Dumping contents of stderr");
+      LOGGER.warn("Dumping contents of stderr");
       dumpServerLog("stderr", errFile.toFile());
     }
   }
@@ -385,7 +382,7 @@ public final class TestBench implements ManagedLifecycle {
     try (BufferedReader reader = new BufferedReader(new FileReader(out))) {
       String line;
       while ((line = reader.readLine()) != null) {
-        LOGGER.warning("<" + prefix + "> " + line);
+        LOGGER.warn("<{}> {}", prefix, line);
       }
     }
   }


### PR DESCRIPTION
OpenTelemetry brought with it slf4j and we already have logback configured for tests. Update our tests to use slf4j directly instead of java.util.logging.

This avoids the need for the j.u.l messages to be redirected through an slf4j adapter before making it to logback.