### PR TITLE
feat: add post-upload crc32c validation for most uploads

### DIFF
--- a/google-cloud-storage/pom.xml
+++ b/google-cloud-storage/pom.xml
@@ -65,6 +65,10 @@
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
+      <artifactId>gax-httpjson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
     </dependency>
     <dependency>

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannel.java
@@ -300,13 +300,13 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
   }
 
   @SuppressWarnings("unchecked")
-  private static <T> T cast(Object o) {
+  static <T> T cast(Object o) {
     return (T) o;
   }
 
   @Nullable
   @SuppressWarnings("unchecked")
-  private static String getHeaderValue(@NonNull HttpHeaders headers, @NonNull String headerName) {
+  static String getHeaderValue(@NonNull HttpHeaders headers, @NonNull String headerName) {
     Object o = headers.get(headerName);
     if (o == null) {
       return null;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Buffers.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Buffers.java
@@ -194,4 +194,13 @@ final class Buffers {
     }
     return total;
   }
+
+  static ByteBuffer[] duplicate(ByteBuffer[] buffers, int offset, int length) {
+    ByteBuffer[] returnValue = new ByteBuffer[length - offset];
+    for (int i = offset; i < length; i++) {
+      ByteBuffer buffer = buffers[i];
+      returnValue[i] = buffer.duplicate();
+    }
+    return returnValue;
+  }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ClientDetectedDataLossException.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ClientDetectedDataLossException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import com.google.api.gax.httpjson.HttpJsonStatusCode;
+import com.google.api.gax.rpc.DataLossException;
+import com.google.api.gax.rpc.StatusCode.Code;
+import java.util.Locale;
+
+final class ClientDetectedDataLossException extends DataLossException {
+
+  public ClientDetectedDataLossException(Crc32cValue<?> actual, Crc32cValue<?> expected) {
+    super(
+        String.format(Locale.US, "actual: %s, expected: %s", actual, expected),
+        null,
+        HttpJsonStatusCode.of(Code.DATA_LOSS),
+        false);
+  }
+}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GzipReadableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GzipReadableByteChannel.java
@@ -91,6 +91,7 @@ final class GzipReadableByteChannel implements UnbufferedReadableByteChannel {
           delegate = source;
         }
       } catch (InterruptedException | ExecutionException e) {
+        Thread.currentThread().interrupt();
         throw new IOException(e);
       }
     } else if (leftovers != null && leftovers.hasRemaining()) {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionPutTask.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionPutTask.java
@@ -148,7 +148,7 @@ final class JsonResumableSessionPutTask
           response.ignore();
           actualSize = new BigInteger(storedContentLength, 10);
           success = true;
-          storageObject = null;
+          storageObject = jsonResumableWrite.storageObjectFromResponseHeaders(response);
         } else {
           response.ignore();
           StorageException se =

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionQueryTask.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSessionQueryTask.java
@@ -78,18 +78,14 @@ final class JsonResumableSessionQueryTask
           // when a signed url is used, the finalize response is empty
           response.ignore();
           actualSize = new BigInteger(storedContentLength, 10);
-          storageObject = null;
+          storageObject = jsonResumableWrite.storageObjectFromResponseHeaders(response);
         } else {
           response.ignore();
           throw ResumableSessionFailureScenario.SCENARIO_0_1.toStorageException(
               uploadId, response, null, () -> null);
         }
         if (actualSize != null) {
-          if (storageObject != null) {
-            return ResumableOperationResult.complete(storageObject, actualSize.longValue());
-          } else {
-            return ResumableOperationResult.incremental(actualSize.longValue());
-          }
+          return ResumableOperationResult.complete(storageObject, actualSize.longValue());
         } else {
           throw ResumableSessionFailureScenario.SCENARIO_0.toStorageException(
               uploadId,

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ChecksumValidatingBufferedWritableByteChannel.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ChecksumValidatingBufferedWritableByteChannel.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.api.core.SettableApiFuture;
+import com.google.cloud.storage.Crc32cValue.Crc32cLengthKnown;
+import com.google.cloud.storage.UnbufferedWritableByteChannelSession.UnbufferedWritableByteChannel;
+import com.google.cloud.storage.it.ChecksummedTestContent;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Test;
+
+public final class ChecksumValidatingBufferedWritableByteChannel {
+
+  private static final ChecksummedTestContent ALL_CONTENT =
+      ChecksummedTestContent.of(DataGenerator.base64Characters().genBytes(64));
+  private static final List<ChecksummedTestContent> CHUNKS = ALL_CONTENT.chunkup(8);
+
+  static {
+    assertThat(CHUNKS).hasSize(8);
+  }
+
+  @Test
+  public void dataLossErrorRaised() throws IOException {
+    SettableApiFuture<Crc32cLengthKnown> crc32cGetter = SettableApiFuture.create();
+    UnbufferedWritableByteChannel channel =
+        StorageByteChannels.writable()
+            .validateUploadCrc32c(
+                new UnbufferedWritableByteChannel() {
+                  long totalBytes = 0;
+
+                  @Override
+                  public long write(ByteBuffer[] srcs, int offset, int length) {
+                    long total = 0;
+                    for (ByteBuffer buffer : srcs) {
+                      int remaining = buffer.remaining();
+                      total += remaining;
+                      buffer.position(buffer.position() + remaining);
+                    }
+                    totalBytes += total;
+                    return total;
+                  }
+
+                  @Override
+                  public boolean isOpen() {
+                    return true;
+                  }
+
+                  @Override
+                  public void close() {
+                    crc32cGetter.set(Crc32cValue.of(373, totalBytes));
+                  }
+                },
+                crc32cGetter);
+
+    ChecksummedTestContent allContent =
+        ChecksummedTestContent.of(DataGenerator.base64Characters().genBytes(64));
+    List<ChecksummedTestContent> chunks = allContent.chunkup(8);
+    assertThat(chunks).hasSize(8);
+    channel.write(ByteBuffer.wrap(chunks.get(0).getBytes()));
+    channel.write(
+        new ByteBuffer[] {
+          ByteBuffer.wrap(chunks.get(1).getBytes()), ByteBuffer.wrap(chunks.get(2).getBytes()),
+        });
+
+    ClientDetectedDataLossException error =
+        assertThrows(
+            ClientDetectedDataLossException.class,
+            () ->
+                channel.writeAndClose(
+                    new ByteBuffer[] {
+                      ByteBuffer.wrap(chunks.get(3).getBytes()),
+                      ByteBuffer.wrap(chunks.get(4).getBytes()),
+                    }));
+
+    assertThat(error).hasMessageThat().contains("expected");
+    assertThat(error).hasMessageThat().contains("actual");
+  }
+
+  @Test
+  @SuppressWarnings("UnstableApiUsage")
+  public void validChecksumClosesCleanly()
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    SettableApiFuture<Crc32cLengthKnown> crc32cGetter = SettableApiFuture.create();
+    UnbufferedWritableByteChannel channel =
+        StorageByteChannels.writable()
+            .validateUploadCrc32c(
+                new UnbufferedWritableByteChannel() {
+                  long totalBytes = 0;
+                  final Hasher crc32c = Hashing.crc32c().newHasher();
+
+                  @Override
+                  public long write(ByteBuffer[] srcs, int offset, int length) {
+                    long total = 0;
+                    for (ByteBuffer buffer : srcs) {
+                      int remaining = buffer.remaining();
+                      total += remaining;
+                      crc32c.putBytes(buffer);
+                    }
+                    totalBytes += total;
+                    return total;
+                  }
+
+                  @Override
+                  public boolean isOpen() {
+                    return true;
+                  }
+
+                  @Override
+                  public void close() {
+                    crc32cGetter.set(Crc32cValue.of(crc32c.hash().asInt(), totalBytes));
+                  }
+                },
+                crc32cGetter);
+
+    channel.write(ByteBuffer.wrap(CHUNKS.get(0).getBytes()));
+    channel.write(
+        new ByteBuffer[] {
+          ByteBuffer.wrap(CHUNKS.get(1).getBytes()),
+          ByteBuffer.wrap(CHUNKS.get(2).getBytes()),
+          ByteBuffer.wrap(CHUNKS.get(3).getBytes()),
+          ByteBuffer.wrap(CHUNKS.get(4).getBytes()),
+          ByteBuffer.wrap(CHUNKS.get(5).getBytes()),
+          ByteBuffer.wrap(CHUNKS.get(6).getBytes()),
+        });
+
+    channel.writeAndClose(ByteBuffer.wrap(CHUNKS.get(7).getBytes()));
+
+    Crc32cLengthKnown actual = crc32cGetter.get(2, TimeUnit.SECONDS);
+    Crc32cLengthKnown expected =
+        Crc32cValue.of(ALL_CONTENT.getCrc32c(), ALL_CONTENT.getBytes().length);
+    assertThat(actual).isEqualTo(expected);
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ChecksumValidatingUnbufferedWritableByteChannel.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ChecksumValidatingUnbufferedWritableByteChannel.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.junit.Test;
 
-public final class ChecksumValidatingBufferedWritableByteChannel {
+public final class ChecksumValidatingUnbufferedWritableByteChannel {
 
   private static final ChecksummedTestContent ALL_CONTENT =
       ChecksummedTestContent.of(DataGenerator.base64Characters().genBytes(64));
@@ -153,5 +153,92 @@ public final class ChecksumValidatingBufferedWritableByteChannel {
     Crc32cLengthKnown expected =
         Crc32cValue.of(ALL_CONTENT.getCrc32c(), ALL_CONTENT.getBytes().length);
     assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void partiallyConsumedBufferIsAccurate_write_thenClose()
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    doTestPartialConsume(
+        (buffer, channel) -> {
+          int written = channel.write(buffer);
+          assertThat(written).isEqualTo(3);
+          channel.close();
+        });
+  }
+
+  @Test
+  public void partiallyConsumedBufferIsAccurate_writeAndClose()
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    doTestPartialConsume(
+        (buffer, channel) -> {
+          int written = channel.writeAndClose(buffer);
+          assertThat(written).isEqualTo(3);
+        });
+  }
+
+  @Test
+  public void partiallyConsumedBufferIsAccurate_writeArrayAndClose()
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    doTestPartialConsume(
+        (buffer, channel) -> {
+          long written = channel.writeAndClose(new ByteBuffer[] {buffer});
+          assertThat(written).isEqualTo(3);
+        });
+  }
+
+  @Test
+  public void partiallyConsumedBufferIsAccurate_writeArray_thenClose()
+      throws IOException, ExecutionException, InterruptedException, TimeoutException {
+    doTestPartialConsume(
+        (buffer, channel) -> {
+          long written = channel.write(new ByteBuffer[] {buffer});
+          assertThat(written).isEqualTo(3);
+          channel.close();
+        });
+  }
+
+  private static void doTestPartialConsume(IOConsumer<UnbufferedWritableByteChannel> c)
+      throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    SettableApiFuture<Crc32cLengthKnown> crc32cGetter = SettableApiFuture.create();
+    UnbufferedWritableByteChannel channel =
+        StorageByteChannels.writable()
+            .validateUploadCrc32c(
+                new UnbufferedWritableByteChannel() {
+                  Hasher crc32c = Hashing.crc32c().newHasher();
+
+                  @Override
+                  public long write(ByteBuffer[] srcs, int offset, int length) {
+                    ByteBuffer buffer = srcs[0];
+                    ByteBuffer slice = buffer.slice();
+                    slice.limit(3);
+                    crc32c.putBytes(slice);
+                    buffer.position(3);
+                    return 3;
+                  }
+
+                  @Override
+                  public boolean isOpen() {
+                    return true;
+                  }
+
+                  @Override
+                  public void close() {
+                    crc32cGetter.set(Crc32cValue.of(crc32c.hash().asInt(), 3));
+                  }
+                },
+                crc32cGetter);
+
+    c.accept(ByteBuffer.wrap(CHUNKS.get(0).getBytes()), channel);
+
+    Crc32cLengthKnown actual = crc32cGetter.get(2, TimeUnit.SECONDS);
+    ChecksummedTestContent testContent = ALL_CONTENT.slice(0, 3);
+    Crc32cLengthKnown expected =
+        Crc32cValue.of(testContent.getCrc32c(), testContent.getBytes().length);
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @FunctionalInterface
+  interface IOConsumer<T> {
+    void accept(ByteBuffer buffer, T t) throws IOException;
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ChecksummedTestContent.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ChecksummedTestContent.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkPositionIndexes;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
 import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
 import com.google.common.primitives.Ints;
@@ -28,8 +29,10 @@ import com.google.protobuf.UnsafeByteOperations;
 import com.google.storage.v2.ChecksummedData;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.List;
 
 public final class ChecksummedTestContent {
 
@@ -94,6 +97,18 @@ public final class ChecksummedTestContent {
         .setContent(ByteString.copyFrom(bytes))
         .setCrc32C(crc32c)
         .build();
+  }
+
+  public ChecksummedTestContent slice(int begin, int length) {
+    return of(bytes, begin, length);
+  }
+
+  public List<ChecksummedTestContent> chunkup(int chunkSize) {
+    List<ChecksummedTestContent> elements = new ArrayList<>();
+    for (int i = 0; i < bytes.length; i += chunkSize) {
+      elements.add(slice(i, chunkSize));
+    }
+    return ImmutableList.copyOf(elements);
   }
 
   @Override


### PR DESCRIPTION
* Resumable Uploads (JSON & gRPC)
* BlobWriteSessionConfigs.getDefault() (JSON & gRPC)
* BlobWriteSessionConfigs.bufferToTempDirThenUpload() (JSON & gRPC)
* BlobWriteSessionConfigs.bufferToDiskThenUpload() (JSON & gRPC)
* BlobWriteSessionConfigs.journaling() (gRPC)

BlobWriteSessionConfigs.parallelCompositeUpload() already performs crc32c checksum validation. Storage.create(BlobInfo, byte[]) already performs crc32c checksum validation

BlobAppendableUpload already performes crc32c checksum validation

BlobWriteSessionConfigs.bidiWrite() will be addressed in the future


# Pending
* [ ] tests
* [ ] exception wrapping