### PR TITLE
test: disable rapid bucket tests in PROD

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITAppendableUploadTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITAppendableUploadTest.java
@@ -45,7 +45,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(StorageITRunner.class)
 @CrossRun(
-    backends = {Backend.PROD, Backend.TEST_BENCH},
+    backends = {Backend.TEST_BENCH},
     transports = Transport.GRPC)
 public final class ITAppendableUploadTest {
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITObjectReadSessionTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITObjectReadSessionTest.java
@@ -63,7 +63,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(StorageITRunner.class)
 @CrossRun(
-    backends = {Backend.PROD, Backend.TEST_BENCH},
+    backends = {Backend.TEST_BENCH},
     transports = Transport.GRPC)
 public final class ITObjectReadSessionTest {
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/Zone.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/Zone.java
@@ -19,8 +19,11 @@ package com.google.cloud.storage.it.runner.registry;
 import com.google.common.base.MoreObjects;
 import java.io.IOException;
 import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class Zone {
+  private static final Logger LOGGER = LoggerFactory.getLogger(Zone.class);
 
   private final String region;
   private final String zone;
@@ -87,6 +90,7 @@ public final class Zone {
     public void start() {
       try {
         zone = MetadataService.zone().orElseGet(() -> parse("us-east1-c"));
+        LOGGER.info("Resolved zone = {}", zone);
       } catch (IOException e) {
         throw new RuntimeException(e);
       }

--- a/google-cloud-storage/src/test/resources/logback.xml
+++ b/google-cloud-storage/src/test/resources/logback.xml
@@ -86,6 +86,7 @@
 
   <logger name="com.google.cloud.storage" level="info"/>
   <logger name="com.google.cloud.storage.it" level="warn"/>
+  <logger name="com.google.cloud.storage.it.runner.registry.Zone" level="info"/>
 
   <root level="info">
     <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
Persistent 503 errors are happening for RAPID buckets in `us-west1-a`. Exclude running in PROD for the time being, instead running only against testbench.

