### PR TITLE
fix: fix Journaling BlobWriteSessionConfig to properly handle multiple consecutive retries

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ChecksummedTestContent.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ChecksummedTestContent.java
@@ -96,6 +96,10 @@ public final class ChecksummedTestContent {
         .build();
   }
 
+  public ChecksummedTestContent slice(int begin, int length) {
+    return of(bytes, begin, Math.min(length, bytes.length - begin));
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)


### PR DESCRIPTION
* Clear copy buffer used to load bytes from the recovery file so, we don't have dangling bytes from a previous retry
* Do not add to the cumulative crc32c when retrying. The bytes have already been added in the first attempt.
