### PR TITLE
deps: manage hermetic_library_generation action version via Hermetic Build only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,16 +20,6 @@
       "matchStrings": ["uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@google-cloud-shared-dependencies/v(?<currentValue>.+?)\\n"],
       "depNameTemplate": "com.google.cloud:sdk-platform-java-config",
       "datasourceTemplate": "maven"
-    },
-    {
-      "fileMatch": [
-        ".github/workflows/hermetic_library_generation.yaml"
-      ],
-      "matchStrings": [
-        "uses: googleapis/sdk-platform-java/.github/scripts@v(?<currentValue>.+?)\\n"
-      ],
-      "depNameTemplate": "com.google.api:gapic-generator-java",
-      "datasourceTemplate": "maven"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
The fix https://github.com/googleapis/sdk-platform-java/pull/3800 was meant for GraalVM image versions.

The regression in #3169, however, affects the hermetic_library_generation GH action instead, which is not in [the sdk-platform-java template](https://github.com/googleapis/sdk-platform-java/blob/844af0f51b016dd03870d36a80bf04f7521dc6e8/hermetic_build/library_generation/owlbot/templates/java_library/renovate.json), but java-storage does not consume the renovate.json template [as per its owlbot.py](https://github.com/googleapis/java-storage/blob/b956eb9b03831405f05691d50ae2de6bf422f73e/owlbot.py#L43).

This PR removes the action yaml from renovate.json, so it's only managed by Hermetic Build
