### PR TITLE
feat: add default end-to-end crc32c checksumming for several upload methods via grpc transport

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultBlobWriteSessionConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultBlobWriteSessionConfig.java
@@ -163,7 +163,7 @@ public final class DefaultBlobWriteSessionConfig extends BlobWriteSessionConfig
                               grpc.storageClient
                                   .writeObjectCallable()
                                   .withDefaultCallContext(grpcCallContext))
-                          .setHasher(Hasher.noop())
+                          .setHasher(opts.getHasher())
                           .setByteStringStrategy(ByteStringStrategy.copy())
                           .resumable()
                           .withRetryConfig(

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GrpcStorageImpl.java
@@ -263,7 +263,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
       GrpcCallContext grpcCallContext =
           optsWithDefaults.grpcMetadataMapper().apply(GrpcCallContext.createDefault());
       WriteObjectRequest req = getWriteObjectRequest(blobInfo, optsWithDefaults);
-      Hasher hasher = Hasher.enabled();
+      Hasher hasher = optsWithDefaults.getHasher();
       GrpcCallContext merge = Utils.merge(grpcCallContext, Retrying.newCallContext());
       UnbufferedWritableByteChannelSession<WriteObjectResponse> session =
           ResumableMedia.gapic()
@@ -324,7 +324,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
                     write,
                     storageClient.queryWriteStatusCallable(),
                     rw,
-                    Hasher.noop()),
+                    opts.getHasher()),
             MoreExecutors.directExecutor());
     try {
       GrpcResumableSession got = session2.get();
@@ -365,7 +365,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
             .write()
             .byteChannel(
                 storageClient.writeObjectCallable().withDefaultCallContext(grpcCallContext))
-            .setHasher(Hasher.noop())
+            .setHasher(opts.getHasher())
             .setByteStringStrategy(ByteStringStrategy.noCopy())
             .resumable()
             .withRetryConfig(retrier.withAlg(retryAlgorithmManager.idempotent()))
@@ -779,7 +779,7 @@ final class GrpcStorageImpl extends BaseService<StorageOptions>
     GrpcCallContext grpcCallContext =
         opts.grpcMetadataMapper().apply(GrpcCallContext.createDefault());
     WriteObjectRequest req = getWriteObjectRequest(blobInfo, opts);
-    Hasher hasher = Hasher.noop();
+    Hasher hasher = opts.getHasher();
     // in JSON, the starting of the resumable session happens before the invocation of write can
     // happen. Emulate the same thing here.
     //  1. create the future

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Hasher.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Hasher.java
@@ -76,6 +76,15 @@ interface Hasher {
   @Nullable Crc32cLengthKnown nullSafeConcat(
       @Nullable Crc32cLengthKnown r1, @NonNull Crc32cLengthKnown r2);
 
+  /**
+   * The initial value to use for this hasher.
+   *
+   * <p>Not ideal, really we should always start with {@link Crc32cValue#zero()} but this saves us
+   * from having to plumb the initial value along with the actual hasher to the constructor of the
+   * WriteCtx when hashing is disabled because of user provided crc32c/md5 preconditions.
+   */
+  @Nullable Crc32cLengthKnown initialValue();
+
   static NoOpHasher noop() {
     return NoOpHasher.INSTANCE;
   }
@@ -116,6 +125,11 @@ interface Hasher {
     @Override
     public @Nullable Crc32cLengthKnown nullSafeConcat(
         @Nullable Crc32cLengthKnown r1, @NonNull Crc32cLengthKnown r2) {
+      return null;
+    }
+
+    @Override
+    public @Nullable Crc32cLengthKnown initialValue() {
       return null;
     }
   }
@@ -184,6 +198,11 @@ interface Hasher {
       } else {
         return r1.concat(r2);
       }
+    }
+
+    @Override
+    public @NonNull Crc32cLengthKnown initialValue() {
+      return Crc32cValue.zero();
     }
   }
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JournalingBlobWriteSessionConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JournalingBlobWriteSessionConfig.java
@@ -192,7 +192,8 @@ public final class JournalingBlobWriteSessionConfig extends BlobWriteSessionConf
             grpcStorage.startResumableWrite(
                 grpcCallContext, grpcStorage.getWriteObjectRequest(info, opts), opts);
         ApiFuture<WriteCtx<ResumableWrite>> start =
-            ApiFutures.transform(f, WriteCtx::new, MoreExecutors.directExecutor());
+            ApiFutures.transform(
+                f, s -> WriteCtx.of(s, opts.getHasher()), MoreExecutors.directExecutor());
 
         ClientStreamingCallable<WriteObjectRequest, WriteObjectResponse> write =
             grpcStorage.storageClient.writeObjectCallable().withDefaultCallContext(grpcCallContext);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/WriteCtx.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/WriteCtx.java
@@ -23,6 +23,7 @@ import com.google.cloud.storage.WriteCtx.WriteObjectRequestBuilderFactory;
 import com.google.storage.v2.WriteObjectRequest;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class WriteCtx<RequestFactoryT extends WriteObjectRequestBuilderFactory> {
@@ -33,20 +34,16 @@ final class WriteCtx<RequestFactoryT extends WriteObjectRequestBuilderFactory> {
   private final AtomicLong confirmedBytes;
   private final AtomicReference<@Nullable Crc32cLengthKnown> cumulativeCrc32c;
 
-  WriteCtx(RequestFactoryT requestFactory) {
-    this(requestFactory, null);
-  }
-
-  /**
-   * TODO: Remove initialValue and replace with Crc32cValue.zero() once all uploads have been
-   * updated to do e2e checksumming by default.
-   */
-  @Deprecated
-  WriteCtx(RequestFactoryT requestFactory, @Nullable Crc32cLengthKnown initialValue) {
+  private WriteCtx(RequestFactoryT requestFactory, @Nullable Crc32cLengthKnown initialValue) {
     this.requestFactory = requestFactory;
     this.totalSentBytes = new AtomicLong(0);
     this.confirmedBytes = new AtomicLong(0);
     this.cumulativeCrc32c = new AtomicReference<>(initialValue);
+  }
+
+  static <RFT extends WriteObjectRequestBuilderFactory> WriteCtx<RFT> of(
+      RFT rft, @NonNull Hasher hasher) {
+    return new WriteCtx<>(rft, hasher.initialValue());
   }
 
   public RequestFactoryT getRequestFactory() {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicUnbufferedWritableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITGapicUnbufferedWritableByteChannelTest.java
@@ -159,10 +159,7 @@ public final class ITGapicUnbufferedWritableByteChannelTest {
       SettableApiFuture<WriteObjectResponse> result = SettableApiFuture.create();
       try (GapicUnbufferedDirectWritableByteChannel c =
           new GapicUnbufferedDirectWritableByteChannel(
-              result,
-              segmenter,
-              sc.writeObjectCallable(),
-              new WriteCtx<>(reqFactory, Crc32cValue.zero()))) {
+              result, segmenter, sc.writeObjectCallable(), WriteCtx.of(reqFactory, HASHER))) {
         c.write(ByteBuffer.wrap(bytes));
       }
       assertThat(result.get()).isEqualTo(resp);
@@ -188,7 +185,7 @@ public final class ITGapicUnbufferedWritableByteChannelTest {
               result,
               segmenter,
               sc.writeObjectCallable(),
-              new WriteCtx<>(reqFactory, Crc32cValue.zero()),
+              WriteCtx.of(reqFactory, HASHER),
               RetrierWithAlg.attemptOnce(),
               Retrying::newCallContext);
       ArrayList<String> debugMessages = new ArrayList<>();
@@ -270,7 +267,7 @@ public final class ITGapicUnbufferedWritableByteChannelTest {
               result,
               segmenter,
               sc.writeObjectCallable(),
-              new WriteCtx<>(reqFactory, Crc32cValue.zero()),
+              WriteCtx.of(reqFactory, HASHER),
               TestUtils.retrierFromStorageOptions(fake.getGrpcStorageOptions())
                   .withAlg(Retrying.alwaysRetry()),
               Retrying::newCallContext)) {
@@ -322,7 +319,7 @@ public final class ITGapicUnbufferedWritableByteChannelTest {
               result,
               segmenter,
               sc.writeObjectCallable(),
-              new WriteCtx<>(reqFactory, Crc32cValue.zero()),
+              WriteCtx.of(reqFactory, HASHER),
               RetrierWithAlg.attemptOnce(),
               Retrying::newCallContext);
       try {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectChecksumSupportTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITObjectChecksumSupportTest.java
@@ -85,6 +85,8 @@ public final class ITObjectChecksumSupportTest {
       int _24MiB = 24 * 1024 * 1024;
 
       return ImmutableList.of(
+          // empty object content
+          ChecksummedTestContent.of(new byte[0]),
           // small, single message single stream when resumable
           ChecksummedTestContent.of(gen.genBytes(15)),
           // med, multiple messages single stream when resumable


### PR DESCRIPTION
* Storage#blobWriteSession for BlobWriteSessionConfigs.getDefault()
* Storage#blobWriteSession for BlobWriteSessionConfigs.bufferToTempDirThenUpload()
* Storage#blobWriteSession for BlobWriteSessionConfigs.bufferToDiskThenUpload(*)
* Storage#create(BlobInfo, InputStream)
* Storage#createFrom(BlobInfo, InputStream)
* Storage#createFrom(BlobInfo, Path)
* Storage#writer