### PR TITLE
feat: add default end-to-end checksumming for JournalingBlobWriteSessionConfig

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JournalingBlobWriteSessionConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JournalingBlobWriteSessionConfig.java
@@ -201,7 +201,7 @@ public final class JournalingBlobWriteSessionConfig extends BlobWriteSessionConf
             ResumableMedia.gapic()
                 .write()
                 .byteChannel(write)
-                .setHasher(Hasher.noop())
+                .setHasher(opts.getHasher())
                 .setByteStringStrategy(ByteStringStrategy.copy())
                 .journaling()
                 .withRetryConfig(

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITSyncAndUploadUnbufferedWritableByteChannelPropertyTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITSyncAndUploadUnbufferedWritableByteChannelPropertyTest.java
@@ -47,6 +47,7 @@ import com.google.common.primitives.Ints;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;
 import com.google.protobuf.TextFormat;
+import com.google.storage.v2.ChecksummedData;
 import com.google.storage.v2.Object;
 import com.google.storage.v2.ObjectChecksums;
 import com.google.storage.v2.QueryWriteStatusRequest;
@@ -63,11 +64,8 @@ import io.grpc.Status.Code;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -124,23 +122,7 @@ public class ITSyncAndUploadUnbufferedWritableByteChannelPropertyTest {
   @AfterContainer
   static void afterContainer() throws IOException {
     if (tmpFolder != null) {
-      Files.walkFileTree(
-          tmpFolder,
-          new SimpleFileVisitor<Path>() {
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                throws IOException {
-              Files.deleteIfExists(file);
-              return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult postVisitDirectory(Path dir, IOException exc)
-                throws IOException {
-              Files.deleteIfExists(dir);
-              return FileVisitResult.CONTINUE;
-            }
-          });
+      TestUtils.rmDashRf(tmpFolder);
     }
   }
 
@@ -754,7 +736,7 @@ public class ITSyncAndUploadUnbufferedWritableByteChannelPropertyTest {
               .toString(),
           objectName,
           objectSize,
-          new ChunkSegmenter(Hasher.noop(), ByteStringStrategy.copy(), segmentSize, quantum),
+          new ChunkSegmenter(Hasher.enabled(), ByteStringStrategy.copy(), segmentSize, quantum),
           BufferHandle.allocate(segmentSize),
           BufferHandle.allocate(segmentSize),
           failuresQueue,
@@ -1011,6 +993,25 @@ public class ITSyncAndUploadUnbufferedWritableByteChannelPropertyTest {
 
     @Override
     public void onNext(WriteObjectRequest writeObjectRequest) {
+      if (writeObjectRequest.hasChecksummedData()) {
+        ChecksummedData checksummedData = writeObjectRequest.getChecksummedData();
+        if (!checksummedData.hasCrc32C()) {
+          errored = true;
+          sendFailure("no crc32c value specified");
+          return;
+        }
+        if (!checksummedData.getContent().isEmpty() && checksummedData.getCrc32C() == 0) {
+          errored = true;
+          sendFailure("crc32c value of 0 with non-empty content");
+          return;
+        }
+      }
+      if (writeObjectRequest.hasObjectChecksums()
+          && !writeObjectRequest.getObjectChecksums().hasCrc32C()) {
+        errored = true;
+        sendFailure("missing object_checksums.crc32c");
+        return;
+      }
       if (ctx == null) {
         UploadId uploadId = UploadId.of(writeObjectRequest.getUploadId());
         if (data.containsKey(uploadId)) {
@@ -1052,6 +1053,11 @@ public class ITSyncAndUploadUnbufferedWritableByteChannelPropertyTest {
               .build();
       responseObserver.onNext(resp);
       responseObserver.onCompleted();
+    }
+
+    private void sendFailure(String description) {
+      responseObserver.onError(
+          Code.INVALID_ARGUMENT.toStatus().withDescription(description).asRuntimeException());
     }
   }
 

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/TestUtils.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/TestUtils.java
@@ -53,6 +53,10 @@ import java.io.OutputStream;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -373,5 +377,24 @@ public final class TestUtils {
             Arrays.stream(t.getSuppressed()).map(tt -> messagesToText(tt, nextIndent)))
         .flatMap(s -> s)
         .collect(Collectors.joining("\n"));
+  }
+
+  public static void rmDashRf(Path path) throws IOException {
+    java.nio.file.Files.walkFileTree(
+        path,
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+              throws IOException {
+            java.nio.file.Files.deleteIfExists(file);
+            return FileVisitResult.CONTINUE;
+          }
+
+          @Override
+          public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+            java.nio.file.Files.deleteIfExists(dir);
+            return FileVisitResult.CONTINUE;
+          }
+        });
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/TmpDir.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/TmpDir.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import com.google.common.base.MoreObjects;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class TmpDir implements AutoCloseable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TmpDir.class);
+
+  private final Path path;
+
+  private TmpDir(Path path) {
+    this.path = path;
+  }
+
+  public Path getPath() {
+    return path;
+  }
+
+  /** Delete the TmpFile this handle is holding */
+  @Override
+  public void close() throws IOException {
+    TestUtils.rmDashRf(path);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("path", path).toString();
+  }
+
+  /**
+   * Create a temporary file, which will be deleted when close is called on the returned {@link
+   * TmpDir}
+   */
+  public static TmpDir of(Path baseDir, String prefix) throws IOException {
+    LOGGER.trace("of(baseDir : {}, prefix : {})", baseDir, prefix);
+    Path path = Files.createTempDirectory(baseDir, prefix);
+    return new TmpDir(path);
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ChecksummedTestContent.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ChecksummedTestContent.java
@@ -115,8 +115,7 @@ public final class ChecksummedTestContent {
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("byteCount", bytes.length)
-        .add("crc32c", crc32c)
-        .add("md5Base64", md5Base64)
+        .add("crc32c", Integer.toUnsignedString(crc32c))
         .toString();
   }
 


### PR DESCRIPTION
Create TestUtils.rmDashRm to recursively delete a directory, and update ITSyncAndUploadUnbufferedWritableByteChannelPropertyTest to use it.

Add TmpDir auto closable to allow managed lifecycle of a temporary directory in a test.

Remove md5Base64 from ChecksummedTestContent#toString(). Base64 values can contain path values that are not valid for filesystems.

Add ITObjectChecksumSupportTest for journaling uploads.

Update ITSyncAndUploadUnbufferedWritableByteChannelPropertyTest property tests to enable and expect crc32c values in all messages.
