### PR TITLE
fix: make FlushPolicy${Min,Max}FlushSizeFlushPolicy constructors private

### DIFF
--- a/google-cloud-storage/clirr-ignored-differences.xml
+++ b/google-cloud-storage/clirr-ignored-differences.xml
@@ -161,4 +161,21 @@
     <method>com.google.cloud.storage.BucketInfo$Builder setGoogleManagedEncryptionEnforcementConfig(com.google.cloud.storage.BucketInfo$GoogleManagedEncryptionEnforcementConfig)</method>
   </difference>
 
+  <!-- make beta api constructors private, they still retain their factory methods. -->
+  <difference>
+    <differenceType>7004</differenceType>
+    <className>com/google/cloud/storage/FlushPolicy$MinFlushSizeFlushPolicy</className>
+    <method>FlushPolicy$MinFlushSizeFlushPolicy(int)</method>
+  </difference>
+  <difference>
+    <differenceType>7009</differenceType>
+    <className>com/google/cloud/storage/FlushPolicy$MinFlushSizeFlushPolicy</className>
+    <method>FlushPolicy$MinFlushSizeFlushPolicy(int)</method>
+  </difference>
+  <difference>
+    <differenceType>7009</differenceType>
+    <className>com/google/cloud/storage/FlushPolicy$MaxFlushSizeFlushPolicy</className>
+    <method>FlushPolicy$MaxFlushSizeFlushPolicy(int)</method>
+  </difference>
+
 </differences>

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/FlushPolicy.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/FlushPolicy.java
@@ -114,7 +114,7 @@ public abstract class FlushPolicy {
 
     private final int maxFlushSize;
 
-    public MaxFlushSizeFlushPolicy(int maxFlushSize) {
+    private MaxFlushSizeFlushPolicy(int maxFlushSize) {
       this.maxFlushSize = maxFlushSize;
     }
 
@@ -195,7 +195,7 @@ public abstract class FlushPolicy {
 
     private final int minFlushSize;
 
-    public MinFlushSizeFlushPolicy(int minFlushSize) {
+    private MinFlushSizeFlushPolicy(int minFlushSize) {
       this.minFlushSize = minFlushSize;
     }
 


### PR DESCRIPTION
They still retain their public factory methods, just the constructors are now private -- they should have been to begin with.