### PR TITLE
chore: centralize all protobuf formatting methods in StorageV2ProtoUtils

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageV2ProtoUtils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageV2ProtoUtils.java
@@ -16,13 +16,22 @@
 
 package com.google.cloud.storage;
 
-import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.MessageOrBuilder;
-import com.google.protobuf.util.JsonFormat;
-import com.google.protobuf.util.JsonFormat.Printer;
+import com.google.protobuf.TextFormat;
+import com.google.storage.v2.BidiReadObjectResponse;
+import com.google.storage.v2.BidiWriteObjectRequest;
 import com.google.storage.v2.BucketAccessControl;
+import com.google.storage.v2.ChecksummedData;
 import com.google.storage.v2.ObjectAccessControl;
+import com.google.storage.v2.ObjectRangeData;
 import com.google.storage.v2.ReadObjectRequest;
+import com.google.storage.v2.ReadObjectResponse;
+import com.google.storage.v2.WriteObjectRequest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -30,9 +39,6 @@ final class StorageV2ProtoUtils {
 
   private static final String VALIDATION_TEMPLATE =
       "offset >= 0 && limit >= 0 (%s >= 0 && %s >= 0)";
-
-  private static final Printer PROTO_PRINTER =
-      JsonFormat.printer().omittingInsignificantWhitespace().preservingProtoFieldNames();
 
   private StorageV2ProtoUtils() {}
 
@@ -53,13 +59,120 @@ final class StorageV2ProtoUtils {
     return req;
   }
 
+  @FunctionalInterface
+  interface MsgFmt extends Function<MessageOrBuilder, String> {}
+
   @NonNull
-  static String fmtProto(@NonNull final MessageOrBuilder msg) {
-    try {
-      return PROTO_PRINTER.print(msg);
-    } catch (InvalidProtocolBufferException e) {
-      throw new RuntimeException(e);
+  public static String fmtProto(@NonNull Object obj) {
+    return fmtProtoWithFmt(obj, TextFormat.printer()::shortDebugString);
+  }
+
+  @NonNull
+  public static String fmtProtoWithFmt(@NonNull Object obj, MsgFmt fmt) {
+    if (obj instanceof WriteObjectRequest) {
+      return fmtProtoWithFmt((WriteObjectRequest) obj, fmt);
+    } else if (obj instanceof BidiWriteObjectRequest) {
+      return fmtProtoWithFmt((BidiWriteObjectRequest) obj, fmt);
+    } else if (obj instanceof ReadObjectResponse) {
+      return fmtProtoWithFmt((ReadObjectResponse) obj, fmt);
+    } else if (obj instanceof BidiReadObjectResponse) {
+      return fmtProtoWithFmt((BidiReadObjectResponse) obj, fmt);
+    } else if (obj instanceof ChecksummedData) {
+      return fmtProtoWithFmt((ChecksummedData) obj, fmt);
+    } else if (obj instanceof MessageOrBuilder) {
+      return fmt.apply((MessageOrBuilder) obj);
+    } else {
+      return obj.toString();
     }
+  }
+
+  @NonNull
+  private static String fmtProtoWithFmt(ChecksummedData data, MsgFmt fmt) {
+    ByteString content = data.getContent();
+    if (content.size() > 20) {
+      ChecksummedData.Builder b = data.toBuilder();
+      ByteString trim = snipBytes(content);
+      b.setContent(trim);
+
+      return fmt.apply(b.build());
+    }
+    return fmt.apply(data);
+  }
+
+  @NonNull
+  private static String fmtProtoWithFmt(@NonNull WriteObjectRequest msg, MsgFmt fmt) {
+    if (msg.hasChecksummedData()) {
+      ByteString content = msg.getChecksummedData().getContent();
+      if (content.size() > 20) {
+        WriteObjectRequest.Builder b = msg.toBuilder();
+        ByteString trim = snipBytes(content);
+        b.getChecksummedDataBuilder().setContent(trim);
+
+        return fmt.apply(b.build());
+      }
+    }
+    return fmt.apply(msg);
+  }
+
+  @NonNull
+  private static String fmtProtoWithFmt(@NonNull BidiWriteObjectRequest msg, MsgFmt fmt) {
+    if (msg.hasChecksummedData()) {
+      ByteString content = msg.getChecksummedData().getContent();
+      if (content.size() > 20) {
+        BidiWriteObjectRequest.Builder b = msg.toBuilder();
+        ByteString trim = snipBytes(content);
+        b.getChecksummedDataBuilder().setContent(trim);
+
+        return fmt.apply(b.build());
+      }
+    }
+    return fmt.apply(msg);
+  }
+
+  @NonNull
+  private static String fmtProtoWithFmt(@NonNull ReadObjectResponse msg, MsgFmt fmt) {
+    if (msg.hasChecksummedData()) {
+      ByteString content = msg.getChecksummedData().getContent();
+      if (content.size() > 20) {
+        ReadObjectResponse.Builder b = msg.toBuilder();
+        ByteString trim = snipBytes(content);
+        b.getChecksummedDataBuilder().setContent(trim);
+
+        return fmt.apply(b.build());
+      }
+    }
+    return fmt.apply(msg);
+  }
+
+  @NonNull
+  private static String fmtProtoWithFmt(@NonNull BidiReadObjectResponse msg, MsgFmt fmt) {
+    List<ObjectRangeData> rangeData = msg.getObjectDataRangesList();
+    if (!rangeData.isEmpty()) {
+      List<ObjectRangeData> snips = new ArrayList<>();
+      for (ObjectRangeData rd : rangeData) {
+        if (rd.hasChecksummedData()) {
+          ByteString content = rd.getChecksummedData().getContent();
+          if (content.size() > 20) {
+            ObjectRangeData.Builder b = rd.toBuilder();
+            ByteString trim = snipBytes(content);
+            b.getChecksummedDataBuilder().setContent(trim);
+            snips.add(b.build());
+          } else {
+            snips.add(rd);
+          }
+        }
+      }
+      BidiReadObjectResponse snipped =
+          msg.toBuilder().clearObjectDataRanges().addAllObjectDataRanges(snips).build();
+      return fmt.apply(snipped);
+    }
+    return fmt.apply(msg);
+  }
+
+  private static ByteString snipBytes(ByteString content) {
+    ByteString snip =
+        ByteString.copyFromUtf8(java.lang.String.format(Locale.US, "<snip (%d)>", content.size()));
+    return content.substring(0, 20).concat(snip);
   }
 
   /**

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/PackagePrivateMethodWorkarounds.java
@@ -23,6 +23,7 @@ import com.google.cloud.WriteChannel;
 import com.google.cloud.storage.OtelStorageDecorator.OtelDecoratedReadChannel;
 import com.google.cloud.storage.OtelStorageDecorator.OtelDecoratedWriteChannel;
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.MessageOrBuilder;
 import com.google.storage.v2.StorageClient;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -133,5 +134,9 @@ public final class PackagePrivateMethodWorkarounds {
 
   public static BlobInfo noAcl(BlobInfo bi) {
     return bi.toBuilder().setOwner(null).setAcl(ImmutableList.of()).build();
+  }
+
+  public static String fmtProto(Object msg, Function<MessageOrBuilder, String> fmt) {
+    return StorageV2ProtoUtils.fmtProtoWithFmt(msg, fmt::apply);
   }
 }


### PR DESCRIPTION
Update GrpcPlainRequestLoggingInterceptor to access StorageV2ProtoUtils.fmtProto via PackagePrivateMethodWorkarounds
