### PR TITLE
chore: rename ResumableSessionFailureScenario to UploadFailureScenario

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicBidiUnbufferedAppendableWriteableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicBidiUnbufferedAppendableWriteableByteChannel.java
@@ -417,11 +417,11 @@ final class GapicBidiUnbufferedAppendableWritableByteChannel
         } else if (persistedSize < totalSentBytes) {
           writeCtx.getConfirmedBytes().set(persistedSize);
           clientDetectedError(
-              ResumableSessionFailureScenario.SCENARIO_9.toStorageException(
+              UploadFailureScenario.SCENARIO_9.toStorageException(
                   ImmutableList.of(lastWrittenRequest), value, context, null));
         } else {
           clientDetectedError(
-              ResumableSessionFailureScenario.SCENARIO_7.toStorageException(
+              UploadFailureScenario.SCENARIO_7.toStorageException(
                   ImmutableList.of(lastWrittenRequest), value, context, null));
         }
       } else if (finalizing && value.hasResource()) {
@@ -432,11 +432,11 @@ final class GapicBidiUnbufferedAppendableWritableByteChannel
           ok(value);
         } else if (finalSize < totalSentBytes) {
           clientDetectedError(
-              ResumableSessionFailureScenario.SCENARIO_4_1.toStorageException(
+              UploadFailureScenario.SCENARIO_4_1.toStorageException(
                   ImmutableList.of(lastWrittenRequest), value, context, null));
         } else {
           clientDetectedError(
-              ResumableSessionFailureScenario.SCENARIO_4_2.toStorageException(
+              UploadFailureScenario.SCENARIO_4_2.toStorageException(
                   ImmutableList.of(lastWrittenRequest), value, context, null));
         }
       } else if (finalizing && value.hasPersistedSize()) {
@@ -449,16 +449,16 @@ final class GapicBidiUnbufferedAppendableWritableByteChannel
           writeCtx.getConfirmedBytes().set(persistedSize);
         } else if (persistedSize < totalSentBytes) {
           clientDetectedError(
-              ResumableSessionFailureScenario.SCENARIO_3.toStorageException(
+              UploadFailureScenario.SCENARIO_3.toStorageException(
                   ImmutableList.of(lastWrittenRequest), value, context, null));
         } else {
           clientDetectedError(
-              ResumableSessionFailureScenario.SCENARIO_2.toStorageException(
+              UploadFailureScenario.SCENARIO_2.toStorageException(
                   ImmutableList.of(lastWrittenRequest), value, context, null));
         }
       } else {
         clientDetectedError(
-            ResumableSessionFailureScenario.SCENARIO_0.toStorageException(
+            UploadFailureScenario.SCENARIO_0.toStorageException(
                 ImmutableList.of(lastWrittenRequest), value, context, null));
       }
     }
@@ -472,7 +472,7 @@ final class GapicBidiUnbufferedAppendableWritableByteChannel
             && ed.getErrorInfo() != null
             && ed.getErrorInfo().getReason().equals("GRPC_MISMATCHED_UPLOAD_SIZE"))) {
           clientDetectedError(
-              ResumableSessionFailureScenario.SCENARIO_5.toStorageException(
+              UploadFailureScenario.SCENARIO_5.toStorageException(
                   ImmutableList.of(lastWrittenRequest), null, context, oore));
           return;
         }
@@ -484,7 +484,7 @@ final class GapicBidiUnbufferedAppendableWritableByteChannel
         // unusual case, and it should not cause a significant overhead given its rarity.
         StorageException tmp = StorageException.asStorageException((ApiException) t);
         previousError =
-            ResumableSessionFailureScenario.toStorageException(
+            UploadFailureScenario.toStorageException(
                 tmp.getCode(),
                 tmp.getMessage(),
                 tmp.getReason(),

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicBidiUnbufferedWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicBidiUnbufferedWritableByteChannel.java
@@ -290,7 +290,7 @@ final class GapicBidiUnbufferedWritableByteChannel implements UnbufferedWritable
           ok(value);
         } else {
           clientDetectedError(
-              ResumableSessionFailureScenario.SCENARIO_7.toStorageException(
+              UploadFailureScenario.SCENARIO_7.toStorageException(
                   nullSafeList(lastWrittenRequest), value, context, null));
         }
       } else if (finalizing && value.hasResource()) {
@@ -301,16 +301,16 @@ final class GapicBidiUnbufferedWritableByteChannel implements UnbufferedWritable
           ok(value);
         } else if (finalSize < totalSentBytes) {
           clientDetectedError(
-              ResumableSessionFailureScenario.SCENARIO_4_1.toStorageException(
+              UploadFailureScenario.SCENARIO_4_1.toStorageException(
                   nullSafeList(lastWrittenRequest), value, context, null));
         } else {
           clientDetectedError(
-              ResumableSessionFailureScenario.SCENARIO_4_2.toStorageException(
+              UploadFailureScenario.SCENARIO_4_2.toStorageException(
                   nullSafeList(lastWrittenRequest), value, context, null));
         }
       } else if (!finalizing && value.hasResource()) {
         clientDetectedError(
-            ResumableSessionFailureScenario.SCENARIO_1.toStorageException(
+            UploadFailureScenario.SCENARIO_1.toStorageException(
                 nullSafeList(lastWrittenRequest), value, context, null));
       } else if (finalizing && value.hasPersistedSize()) {
         long totalSentBytes = writeCtx.getTotalSentBytes().get();
@@ -322,16 +322,16 @@ final class GapicBidiUnbufferedWritableByteChannel implements UnbufferedWritable
           writeCtx.getConfirmedBytes().set(persistedSize);
         } else if (persistedSize < totalSentBytes) {
           clientDetectedError(
-              ResumableSessionFailureScenario.SCENARIO_3.toStorageException(
+              UploadFailureScenario.SCENARIO_3.toStorageException(
                   nullSafeList(lastWrittenRequest), value, context, null));
         } else {
           clientDetectedError(
-              ResumableSessionFailureScenario.SCENARIO_2.toStorageException(
+              UploadFailureScenario.SCENARIO_2.toStorageException(
                   nullSafeList(lastWrittenRequest), value, context, null));
         }
       } else {
         clientDetectedError(
-            ResumableSessionFailureScenario.SCENARIO_0.toStorageException(
+            UploadFailureScenario.SCENARIO_0.toStorageException(
                 nullSafeList(lastWrittenRequest), value, context, null));
       }
     }
@@ -345,7 +345,7 @@ final class GapicBidiUnbufferedWritableByteChannel implements UnbufferedWritable
             && ed.getErrorInfo() != null
             && ed.getErrorInfo().getReason().equals("GRPC_MISMATCHED_UPLOAD_SIZE"))) {
           clientDetectedError(
-              ResumableSessionFailureScenario.SCENARIO_5.toStorageException(
+              UploadFailureScenario.SCENARIO_5.toStorageException(
                   nullSafeList(lastWrittenRequest), null, context, oore));
           return;
         }
@@ -357,7 +357,7 @@ final class GapicBidiUnbufferedWritableByteChannel implements UnbufferedWritable
         // unusual case, and it should not cause a significant overhead given its rarity.
         StorageException tmp = StorageException.asStorageException((ApiException) t);
         previousError =
-            ResumableSessionFailureScenario.toStorageException(
+            UploadFailureScenario.toStorageException(
                 tmp.getCode(),
                 tmp.getMessage(),
                 tmp.getReason(),

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedChunkedResumableWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedChunkedResumableWritableByteChannel.java
@@ -267,8 +267,7 @@ final class GapicUnbufferedChunkedResumableWritableByteChannel
             && ed.getErrorInfo() != null
             && ed.getErrorInfo().getReason().equals("GRPC_MISMATCHED_UPLOAD_SIZE"))) {
           StorageException storageException =
-              ResumableSessionFailureScenario.SCENARIO_5.toStorageException(
-                  segments, null, context, oore);
+              UploadFailureScenario.SCENARIO_5.toStorageException(segments, null, context, oore);
           invocationHandle.setException(storageException);
           return;
         }
@@ -280,7 +279,7 @@ final class GapicUnbufferedChunkedResumableWritableByteChannel
         // unusual case, and it should not cause a significant overhead given its rarity.
         StorageException tmp = StorageException.asStorageException((ApiException) t);
         StorageException storageException =
-            ResumableSessionFailureScenario.toStorageException(
+            UploadFailureScenario.toStorageException(
                 tmp.getCode(), tmp.getMessage(), tmp.getReason(), segments, null, context, t);
         invocationHandle.setException(storageException);
       }
@@ -305,7 +304,7 @@ final class GapicUnbufferedChunkedResumableWritableByteChannel
             writeCtx.getTotalSentBytes().set(persistedSize);
             writeCtx.getConfirmedBytes().set(persistedSize);
           } else {
-            throw ResumableSessionFailureScenario.SCENARIO_7.toStorageException(
+            throw UploadFailureScenario.SCENARIO_7.toStorageException(
                 segments, last, context, null);
           }
         } else if (finalizing && last.hasResource()) {
@@ -315,28 +314,26 @@ final class GapicUnbufferedChunkedResumableWritableByteChannel
             writeCtx.getConfirmedBytes().set(finalSize);
             resultFuture.set(last);
           } else if (finalSize < totalSentBytes) {
-            throw ResumableSessionFailureScenario.SCENARIO_4_1.toStorageException(
+            throw UploadFailureScenario.SCENARIO_4_1.toStorageException(
                 segments, last, context, null);
           } else {
-            throw ResumableSessionFailureScenario.SCENARIO_4_2.toStorageException(
+            throw UploadFailureScenario.SCENARIO_4_2.toStorageException(
                 segments, last, context, null);
           }
         } else if (!finalizing && last.hasResource()) {
-          throw ResumableSessionFailureScenario.SCENARIO_1.toStorageException(
-              segments, last, context, null);
+          throw UploadFailureScenario.SCENARIO_1.toStorageException(segments, last, context, null);
         } else if (finalizing && last.hasPersistedSize()) {
           long totalSentBytes = writeCtx.getTotalSentBytes().get();
           long persistedSize = last.getPersistedSize();
           if (persistedSize < totalSentBytes) {
-            throw ResumableSessionFailureScenario.SCENARIO_3.toStorageException(
+            throw UploadFailureScenario.SCENARIO_3.toStorageException(
                 segments, last, context, null);
           } else {
-            throw ResumableSessionFailureScenario.SCENARIO_2.toStorageException(
+            throw UploadFailureScenario.SCENARIO_2.toStorageException(
                 segments, last, context, null);
           }
         } else {
-          throw ResumableSessionFailureScenario.SCENARIO_0.toStorageException(
-              segments, last, context, null);
+          throw UploadFailureScenario.SCENARIO_0.toStorageException(segments, last, context, null);
         }
       } catch (Throwable se) {
         open = false;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedDirectWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedDirectWritableByteChannel.java
@@ -222,7 +222,7 @@ final class GapicUnbufferedDirectWritableByteChannel implements UnbufferedWritab
         // unusual case, and it should not cause a significant overhead given its rarity.
         StorageException tmp = StorageException.asStorageException((ApiException) t);
         StorageException storageException =
-            ResumableSessionFailureScenario.toStorageException(
+            UploadFailureScenario.toStorageException(
                 tmp.getCode(), tmp.getMessage(), tmp.getReason(), getRequests(), null, context, t);
         invocationHandle.setException(storageException);
       } else {
@@ -243,14 +243,14 @@ final class GapicUnbufferedDirectWritableByteChannel implements UnbufferedWritab
             writeCtx.getConfirmedBytes().set(finalSize);
             resultFuture.set(last);
           } else if (finalSize < totalSentBytes) {
-            throw ResumableSessionFailureScenario.SCENARIO_4_1.toStorageException(
+            throw UploadFailureScenario.SCENARIO_4_1.toStorageException(
                 getRequests(), last, context, null);
           } else {
-            throw ResumableSessionFailureScenario.SCENARIO_4_2.toStorageException(
+            throw UploadFailureScenario.SCENARIO_4_2.toStorageException(
                 getRequests(), last, context, null);
           }
         } else {
-          throw ResumableSessionFailureScenario.SCENARIO_0.toStorageException(
+          throw UploadFailureScenario.SCENARIO_0.toStorageException(
               getRequests(), last, context, null);
         }
       } catch (Throwable se) {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedFinalizeOnCloseResumableWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicUnbufferedFinalizeOnCloseResumableWritableByteChannel.java
@@ -226,7 +226,7 @@ final class GapicUnbufferedFinalizeOnCloseResumableWritableByteChannel
         // unusual case, and it should not cause a significant overhead given its rarity.
         StorageException tmp = StorageException.asStorageException((ApiException) t);
         StorageException storageException =
-            ResumableSessionFailureScenario.toStorageException(
+            UploadFailureScenario.toStorageException(
                 tmp.getCode(),
                 tmp.getMessage(),
                 tmp.getReason(),
@@ -247,7 +247,7 @@ final class GapicUnbufferedFinalizeOnCloseResumableWritableByteChannel
       boolean finalizing = lastWrittenRequest.getFinishWrite();
       if (last == null) {
         clientDetectedError(
-            ResumableSessionFailureScenario.toStorageException(
+            UploadFailureScenario.toStorageException(
                 0,
                 "onComplete without preceding onNext, unable to determine success.",
                 "invalid",
@@ -262,16 +262,16 @@ final class GapicUnbufferedFinalizeOnCloseResumableWritableByteChannel
           ok(finalSize);
         } else if (finalSize < totalSentBytes) {
           clientDetectedError(
-              ResumableSessionFailureScenario.SCENARIO_4_1.toStorageException(
+              UploadFailureScenario.SCENARIO_4_1.toStorageException(
                   nullSafeList(lastWrittenRequest), last, context, null));
         } else {
           clientDetectedError(
-              ResumableSessionFailureScenario.SCENARIO_4_2.toStorageException(
+              UploadFailureScenario.SCENARIO_4_2.toStorageException(
                   nullSafeList(lastWrittenRequest), last, context, null));
         }
       } else if (!finalizing || last.hasPersistedSize()) { // unexpected incremental response
         clientDetectedError(
-            ResumableSessionFailureScenario.toStorageException(
+            UploadFailureScenario.toStorageException(
                 0,
                 "Unexpected incremental response for finalizing request.",
                 "invalid",
@@ -281,7 +281,7 @@ final class GapicUnbufferedFinalizeOnCloseResumableWritableByteChannel
                 null));
       } else {
         clientDetectedError(
-            ResumableSessionFailureScenario.SCENARIO_0.toStorageException(
+            UploadFailureScenario.SCENARIO_0.toStorageException(
                 nullSafeList(lastWrittenRequest), last, context, null));
       }
     }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/UploadFailureScenarioTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/UploadFailureScenarioTest.java
@@ -18,10 +18,10 @@ package com.google.cloud.storage;
 
 import static com.google.cloud.storage.ByteSizeConstants._256KiB;
 import static com.google.cloud.storage.ByteSizeConstants._512KiB;
-import static com.google.cloud.storage.ResumableSessionFailureScenario.SCENARIO_1;
-import static com.google.cloud.storage.ResumableSessionFailureScenario.isContinue;
-import static com.google.cloud.storage.ResumableSessionFailureScenario.isOk;
 import static com.google.cloud.storage.TestUtils.assertAll;
+import static com.google.cloud.storage.UploadFailureScenario.SCENARIO_1;
+import static com.google.cloud.storage.UploadFailureScenario.isContinue;
+import static com.google.cloud.storage.UploadFailureScenario.isOk;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.client.http.EmptyContent;
@@ -53,7 +53,7 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 
-public final class ResumableSessionFailureScenarioTest {
+public final class UploadFailureScenarioTest {
   private static final GsonFactory gson = GsonFactory.getDefaultInstance();
 
   @Test
@@ -84,7 +84,7 @@ public final class ResumableSessionFailureScenarioTest {
     resp.getHeaders().setContentType("text/plain; charset=utf-8").setContentLength(5L);
 
     StorageException storageException =
-        ResumableSessionFailureScenario.SCENARIO_1.toStorageException(
+        UploadFailureScenario.SCENARIO_1.toStorageException(
             "uploadId",
             resp,
             new Cause(),
@@ -125,8 +125,7 @@ public final class ResumableSessionFailureScenarioTest {
         .setContentLength((long) bytes.length);
 
     StorageException storageException =
-        ResumableSessionFailureScenario.SCENARIO_0.toStorageException(
-            "uploadId", resp, null, () -> json);
+        UploadFailureScenario.SCENARIO_0.toStorageException("uploadId", resp, null, () -> json);
 
     assertThat(storageException.getCode()).isEqualTo(0);
     assertThat(storageException).hasMessageThat().contains("\t|<   \"generation\": \"1\",\n");
@@ -148,8 +147,7 @@ public final class ResumableSessionFailureScenarioTest {
         .setContentLength(0L);
 
     StorageException storageException =
-        ResumableSessionFailureScenario.SCENARIO_0.toStorageException(
-            "uploadId", resp, null, () -> null);
+        UploadFailureScenario.SCENARIO_0.toStorageException("uploadId", resp, null, () -> null);
 
     assertThat(storageException.getCode()).isEqualTo(0);
     assertThat(storageException).hasMessageThat().contains("|< x-goog-stored-content-length: 5");
@@ -171,8 +169,7 @@ public final class ResumableSessionFailureScenarioTest {
     resp.getHeaders().set("X-Goog-Gcs-Idempotency-Token", "5").setContentLength(0L);
 
     StorageException storageException =
-        ResumableSessionFailureScenario.SCENARIO_0.toStorageException(
-            "uploadId", resp, null, () -> null);
+        UploadFailureScenario.SCENARIO_0.toStorageException("uploadId", resp, null, () -> null);
 
     assertThat(storageException.getCode()).isEqualTo(0);
     assertThat(storageException).hasMessageThat().contains("|< x-goog-gcs-idempotency-token: 5");


### PR DESCRIPTION
The failure scenarios outlined are not resumable specific, and will be used by single-shot and appendable uploads as well.

