### PR TITLE
chore: new bidi appendable channel bootstrappable

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BidiAppendableUnbufferedWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BidiAppendableUnbufferedWritableByteChannel.java
@@ -17,8 +17,8 @@
 package com.google.cloud.storage;
 
 import com.google.cloud.BaseServiceException;
+import com.google.cloud.storage.BlobAppendableUploadImpl.AppendableUnbufferedWritableByteChannel;
 import com.google.cloud.storage.ChunkSegmenter.ChunkSegment;
-import com.google.cloud.storage.UnbufferedWritableByteChannelSession.UnbufferedWritableByteChannel;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.nio.ByteBuffer;
@@ -26,12 +26,9 @@ import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-final class BidiAppendableUnbufferedWritableByteChannel implements UnbufferedWritableByteChannel {
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(BidiAppendableUnbufferedWritableByteChannel.class);
+final class BidiAppendableUnbufferedWritableByteChannel
+    implements AppendableUnbufferedWritableByteChannel {
 
   private final BidiUploadStreamingStream stream;
   private final ChunkSegmenter chunkSegmenter;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ChannelSession.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ChannelSession.java
@@ -39,9 +39,16 @@ class ChannelSession<StartT, ResultT, ChannelT> {
 
   ChannelSession(
       ApiFuture<StartT> startFuture, BiFunction<StartT, SettableApiFuture<ResultT>, ChannelT> f) {
+    this(startFuture, f, SettableApiFuture.create());
+  }
+
+  ChannelSession(
+      ApiFuture<StartT> startFuture,
+      BiFunction<StartT, SettableApiFuture<ResultT>, ChannelT> f,
+      SettableApiFuture<ResultT> resultFuture) {
     this.startFuture = startFuture;
-    this.resultFuture = SettableApiFuture.create();
-    this.f = (s) -> f.apply(s, resultFuture);
+    this.resultFuture = resultFuture;
+    this.f = (s) -> f.apply(s, this.resultFuture);
   }
 
   public ApiFuture<ChannelT> openAsync() {

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicBidiUnbufferedAppendableWriteableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicBidiUnbufferedAppendableWriteableByteChannel.java
@@ -25,6 +25,7 @@ import com.google.api.gax.rpc.ErrorDetails;
 import com.google.api.gax.rpc.NotFoundException;
 import com.google.api.gax.rpc.OutOfRangeException;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.cloud.storage.BlobAppendableUploadImpl.AppendableUnbufferedWritableByteChannel;
 import com.google.cloud.storage.ChunkSegmenter.ChunkSegment;
 import com.google.cloud.storage.Conversions.Decoder;
 import com.google.cloud.storage.Crc32cValue.Crc32cLengthKnown;
@@ -63,7 +64,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 final class GapicBidiUnbufferedAppendableWritableByteChannel
-    implements UnbufferedWritableByteChannel {
+    implements UnbufferedWritableByteChannel, AppendableUnbufferedWritableByteChannel {
   private final BidiStreamingCallable<BidiWriteObjectRequest, BidiWriteObjectResponse> write;
   private final UnaryCallable<GetObjectRequest, Object> get;
   private final RetrierWithAlg retrier;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicBidiWritableByteChannelSessionBuilder.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/GapicBidiWritableByteChannelSessionBuilder.java
@@ -252,7 +252,7 @@ final class GapicBidiWritableByteChannelSessionBuilder {
                         c.startAppendableTakeoverStream();
                       }
                       return new AppendableObjectBufferedWritableByteChannel(
-                          flushPolicy.createBufferedChannel(c), c, boundFinalizeOnClose);
+                          flushPolicy.createBufferedChannel(c), c, boundFinalizeOnClose, false);
                     }));
       }
     }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageDataClient.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageDataClient.java
@@ -36,11 +36,11 @@ import java.util.concurrent.TimeUnit;
 @InternalApi
 final class StorageDataClient implements AutoCloseable {
 
-  private final ScheduledExecutorService executor;
+  final ScheduledExecutorService executor;
   private final Duration terminationAwaitDuration;
   private final ZeroCopyBidiStreamingCallable<BidiReadObjectRequest, BidiReadObjectResponse>
       bidiReadObject;
-  private final RetryContextProvider retryContextProvider;
+  final RetryContextProvider retryContextProvider;
   private final IOAutoCloseable onClose;
 
   private StorageDataClient(


### PR DESCRIPTION
* Add FlushPolicy.MinFlushSizeFlushPolicy.maxPendingBytes
* Add new contructor to ChannelSession to allow the resultFuture to be passed in.
* Create temporary BlobAppendableUploadImpl.AppendableUnbufferedWritableByteChannel to allow both old and new implementations to be passed to BlobAppendableUploadImpl -- this interface will be removed in cleanup
* Add new implementation using streaming buffer management as a sibling to the existing implementation. The existing implementation will be removed entirely in cleanup.
* Refactored tests to follow