### PR TITLE
test: refactor existing appendable upload tests to work with new implementation

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Buffers.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Buffers.java
@@ -173,6 +173,21 @@ final class Buffers {
     return total;
   }
 
+  static int emptyTo(ByteBuffer buf, WritableByteChannel c) throws IOException {
+    int total = 0;
+    while (buf.hasRemaining()) {
+      int written = c.write(buf);
+      if (written != -1) {
+        total += written;
+      } else if (total == 0) {
+        return -1;
+      } else {
+        break;
+      }
+    }
+    return total;
+  }
+
   static long totalRemaining(ByteBuffer[] buffers, int offset, int length) {
     long totalRemaning = 0;
     for (int i = offset; i < length; i++) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITAppendableUploadFakeTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITAppendableUploadFakeTest.java
@@ -16,20 +16,25 @@
 
 package com.google.cloud.storage;
 
+import static com.google.cloud.storage.BidiUploadTestUtils.makeRedirect;
+import static com.google.cloud.storage.BidiUploadTestUtils.packRedirectIntoAbortedException;
+import static com.google.cloud.storage.BidiUploadTestUtils.timestampNow;
 import static com.google.cloud.storage.ByteSizeConstants._2MiB;
 import static com.google.cloud.storage.StorageV2ProtoUtils.fmtProto;
-import static com.google.cloud.storage.TestUtils.GRPC_STATUS_DETAILS_KEY;
+import static com.google.cloud.storage.TestUtils.assertAll;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
+import com.google.api.core.ApiFuture;
 import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.api.gax.rpc.AbortedException;
+import com.google.cloud.storage.BidiUploadState.AppendableUploadState;
 import com.google.cloud.storage.BlobAppendableUpload.AppendableUploadWriteableByteChannel;
 import com.google.cloud.storage.BlobAppendableUploadConfig.CloseAction;
+import com.google.cloud.storage.Storage.BlobField;
 import com.google.cloud.storage.it.ChecksummedTestContent;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.FieldMask;
@@ -39,7 +44,6 @@ import com.google.rpc.Code;
 import com.google.rpc.DebugInfo;
 import com.google.storage.v2.AppendObjectSpec;
 import com.google.storage.v2.BidiWriteHandle;
-import com.google.storage.v2.BidiWriteObjectRedirectedError;
 import com.google.storage.v2.BidiWriteObjectRequest;
 import com.google.storage.v2.BidiWriteObjectResponse;
 import com.google.storage.v2.BucketName;
@@ -47,25 +51,29 @@ import com.google.storage.v2.ChecksummedData;
 import com.google.storage.v2.GetObjectRequest;
 import com.google.storage.v2.Object;
 import com.google.storage.v2.ObjectChecksums;
-import com.google.storage.v2.StorageClient;
 import com.google.storage.v2.StorageGrpc;
 import com.google.storage.v2.WriteObjectSpec;
 import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class ITAppendableUploadFakeTest {
@@ -94,182 +102,152 @@ public class ITAppendableUploadFakeTest {
 
   private static final BlobAppendableUploadConfig UPLOAD_CONFIG =
       BlobAppendableUploadConfig.of()
-          .withFlushPolicy(FlushPolicy.maxFlushSize(5))
-          .withCrc32cValidationEnabled(false)
+          .withFlushPolicy(FlushPolicy.maxFlushSize(3))
           .withCloseAction(CloseAction.FINALIZE_WHEN_CLOSING);
 
-  /**
-   *
-   *
-   * <ol>
-   *   <li>Create a new appendable object
-   *   <li>First results give redirect error
-   *   <li>Retry using a new AppendObjectSpec with routing token, generation, write handle specified
-   *       -- retry succeeds
-   *   <li>Finish writing the data as normal on the new stream
-   * </ol>
-   */
-  @Test
-  public void bidiWriteObjectRedirectedError() throws Exception {
+  private static final ChecksummedTestContent content =
+      ChecksummedTestContent.of(ALL_OBJECT_BYTES, 0, 10);
+  private static final ObjectChecksums checksums =
+      ObjectChecksums.newBuilder().setCrc32C(content.getCrc32c()).build();
+  private static final BidiWriteObjectRequest flushLookup =
+      BidiWriteObjectRequest.newBuilder().setFlush(true).setStateLookup(true).build();
+  private static final BidiWriteObjectRequest abc = incrementalRequest(0, "ABC");
+  private static final BidiWriteObjectRequest def = incrementalRequest(3, "DEF");
+  private static final BidiWriteObjectRequest ghi = incrementalRequest(6, "GHI");
+  private static final BidiWriteObjectRequest j = incrementalRequest(9, "J");
+  private static final BidiWriteObjectRequest j_flush =
+      j.toBuilder().mergeFrom(flushLookup).build();
+  private static final BidiWriteObjectRequest j_finish =
+      j.toBuilder().setFinishWrite(true).setObjectChecksums(checksums).build();
+  private static final BidiWriteObjectRequest finish_10 =
+      BidiWriteObjectRequest.newBuilder()
+          .setWriteOffset(10)
+          .setFinishWrite(true)
+          .setObjectChecksums(checksums)
+          .build();
 
-    String routingToken = UUID.randomUUID().toString();
-    BidiWriteHandle writeHandle =
-        BidiWriteHandle.newBuilder()
-            .setHandle(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-            .build();
-    BidiWriteObjectRequest req2 =
-        BidiWriteObjectRequest.newBuilder()
-            .setAppendObjectSpec(
-                AppendObjectSpec.newBuilder()
-                    .setBucket(METADATA.getBucket())
-                    .setObject(METADATA.getName())
-                    .setGeneration(METADATA.getGeneration())
-                    .setRoutingToken(routingToken)
-                    .setWriteHandle(writeHandle)
-                    .build())
-            .setFlush(true)
-            .setStateLookup(true)
-            .build();
+  private static final BidiWriteObjectRequest open_abc =
+      REQ_OPEN.toBuilder().mergeFrom(abc).build();
+  private static final BidiWriteObjectResponse res_abc =
+      BidiWriteObjectResponse.newBuilder()
+          .setResource(
+              Object.newBuilder()
+                  .setName(METADATA.getName())
+                  .setBucket(METADATA.getBucket())
+                  .setGeneration(METADATA.getGeneration())
+                  .setSize(3)
+                  .setChecksums(
+                      ObjectChecksums.newBuilder()
+                          .setCrc32C(content.slice(0, 3).getCrc32c())
+                          .build())
+                  // real object would have some extra fields like metageneration and storage
+                  // class
+                  .build())
+          .build();
+  private static final BidiWriteObjectRequest reconnect =
+      BidiWriteObjectRequest.newBuilder()
+          .setAppendObjectSpec(
+              AppendObjectSpec.newBuilder()
+                  .setBucket(METADATA.getBucket())
+                  .setObject(METADATA.getName())
+                  .setGeneration(METADATA.getGeneration())
+                  .build())
+          .setStateLookup(true)
+          .build();
+  private static final BidiWriteObjectResponse resource_10 =
+      BidiWriteObjectResponse.newBuilder()
+          .setResource(
+              Object.newBuilder()
+                  .setName(METADATA.getName())
+                  .setBucket(METADATA.getBucket())
+                  .setGeneration(METADATA.getGeneration())
+                  .setSize(10)
+                  .setChecksums(checksums)
+                  .setFinalizeTime(timestampNow())
+                  // real object would have some extra fields like metageneration and storage
+                  // class
+                  .build())
+          .build();
+  public static final GetObjectRequest get_generation_mask =
+      GetObjectRequest.newBuilder()
+          .setObject(METADATA.getName())
+          .setBucket(METADATA.getBucket())
+          .setReadMask(FieldMask.newBuilder().addPaths(BlobField.GENERATION.getGrpcName()).build())
+          .build();
 
-    BidiWriteObjectRequest req3 =
-        BidiWriteObjectRequest.newBuilder()
-            .setChecksummedData(
-                ChecksummedData.newBuilder().setContent(ByteString.copyFromUtf8("ABCDE")).build())
-            .setStateLookup(true)
-            .setFlush(true)
-            .build();
-
-    BidiWriteObjectRequest req4 =
-        BidiWriteObjectRequest.newBuilder()
-            .setWriteOffset(5)
-            .setChecksummedData(
-                ChecksummedData.newBuilder().setContent(ByteString.copyFromUtf8("FGHIJ")).build())
-            .setStateLookup(true)
-            .setFlush(true)
-            .build();
-    BidiWriteObjectRequest req5 =
-        BidiWriteObjectRequest.newBuilder().setWriteOffset(10).setFinishWrite(true).build();
-
-    ChecksummedTestContent content = ChecksummedTestContent.of(ALL_OBJECT_BYTES, 0, 10);
-    BidiWriteObjectResponse res2 = BidiWriteObjectResponse.newBuilder().setPersistedSize(0).build();
-    BidiWriteObjectResponse res3 = BidiWriteObjectResponse.newBuilder().setPersistedSize(5).build();
-
-    BidiWriteObjectResponse res4 =
-        BidiWriteObjectResponse.newBuilder().setPersistedSize(10).build();
-
-    BidiWriteObjectResponse res5 =
-        BidiWriteObjectResponse.newBuilder()
-            .setResource(
-                Object.newBuilder()
-                    .setName(METADATA.getName())
-                    .setBucket(METADATA.getBucket())
-                    .setGeneration(METADATA.getGeneration())
-                    .setSize(10)
-                    // real object would have some extra fields like metageneration and storage
-                    // class
-                    .build())
-            .setWriteHandle(writeHandle)
-            .build();
-
-    FakeStorage fake =
-        FakeStorage.of(
-            ImmutableMap.of(
-                REQ_OPEN.toBuilder().setFlush(true).setStateLookup(true).build(),
-                respond -> {
-                  BidiWriteObjectRedirectedError redirect =
-                      BidiWriteObjectRedirectedError.newBuilder()
-                          .setWriteHandle(writeHandle)
-                          .setRoutingToken(routingToken)
-                          .setGeneration(METADATA.getGeneration())
-                          .build();
-
-                  com.google.rpc.Status grpcStatusDetails =
-                      com.google.rpc.Status.newBuilder()
-                          .setCode(Code.ABORTED_VALUE)
-                          .setMessage("redirect")
-                          .addDetails(Any.pack(redirect))
-                          .build();
-
-                  Metadata trailers = new Metadata();
-                  trailers.put(GRPC_STATUS_DETAILS_KEY, grpcStatusDetails);
-                  StatusRuntimeException statusRuntimeException =
-                      Status.ABORTED.withDescription("redirect").asRuntimeException(trailers);
-                  respond.onError(statusRuntimeException);
-                },
-                req2,
-                respond -> respond.onNext(res2),
-                req3,
-                respond -> respond.onNext(res3),
-                req4,
-                respond -> respond.onNext(res4),
-                req5,
-                respond -> respond.onNext(res5)));
-
-    try (FakeServer fakeServer = FakeServer.of(fake);
-        Storage storage = fakeServer.getGrpcStorageOptions().toBuilder().build().getService()) {
-
-      BlobId id = BlobId.of("b", "o");
-      BlobAppendableUpload b =
-          storage.blobAppendableUpload(BlobInfo.newBuilder(id).build(), UPLOAD_CONFIG);
-      try (AppendableUploadWriteableByteChannel channel = b.open()) {
-        channel.write(ByteBuffer.wrap(content.getBytes()));
-      }
-      BlobInfo bi = b.getResult().get(5, TimeUnit.SECONDS);
-      assertThat(bi.getSize()).isEqualTo(10);
-    }
-  }
+  private static final ChunkSegmenter smallSegmenter =
+      new ChunkSegmenter(Hasher.enabled(), ByteStringStrategy.copy(), 3, 3);
 
   @Test
   public void bidiWriteObjectRedirectedError_maxAttempts() throws Exception {
-    // todo: This test fails currently
-    String routingToken = UUID.randomUUID().toString();
+    String routingToken1 = "routingToken1";
+    String routingToken2 = "routingToken2";
+    String routingToken3 = "routingToken3";
+    String routingToken4 = "routingToken4";
+    String routingToken5 = "routingToken5";
 
     BidiWriteHandle writeHandle =
         BidiWriteHandle.newBuilder()
             .setHandle(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
             .build();
 
-    BidiWriteObjectRequest req2 =
+    BidiWriteObjectRequest redirectReconcile =
         BidiWriteObjectRequest.newBuilder()
             .setAppendObjectSpec(
                 AppendObjectSpec.newBuilder()
                     .setBucket(METADATA.getBucket())
                     .setObject(METADATA.getName())
                     .setGeneration(METADATA.getGeneration())
-                    .setRoutingToken(routingToken)
                     .setWriteHandle(writeHandle)
                     .build())
-            .setFlush(true)
             .setStateLookup(true)
             .build();
 
-    BidiWriteObjectRedirectedError redirect =
-        BidiWriteObjectRedirectedError.newBuilder()
-            .setWriteHandle(writeHandle)
-            .setRoutingToken(routingToken)
-            .setGeneration(METADATA.getGeneration())
-            .build();
+    BidiWriteObjectRequest redirectRequest1 =
+        BidiUploadTestUtils.withRedirectToken(redirectReconcile, routingToken1);
+    BidiWriteObjectRequest redirectRequest2 =
+        BidiUploadTestUtils.withRedirectToken(redirectReconcile, routingToken2);
+    BidiWriteObjectRequest redirectRequest3 =
+        BidiUploadTestUtils.withRedirectToken(redirectReconcile, routingToken3);
+    BidiWriteObjectRequest redirectRequest4 =
+        BidiUploadTestUtils.withRedirectToken(redirectReconcile, routingToken4);
 
-    com.google.rpc.Status grpcStatusDetails =
-        com.google.rpc.Status.newBuilder()
-            .setCode(Code.ABORTED_VALUE)
-            .setMessage("redirect")
-            .addDetails(Any.pack(redirect))
-            .build();
-
-    Metadata trailers = new Metadata();
-    trailers.put(GRPC_STATUS_DETAILS_KEY, grpcStatusDetails);
-    StatusRuntimeException statusRuntimeException =
-        Status.ABORTED.withDescription("redirect").asRuntimeException(trailers);
-
-    // TODO: assert number of redirects returned
+    AtomicInteger redirectCounter = new AtomicInteger();
     FakeStorage fake =
         FakeStorage.of(
             ImmutableMap.of(
-                REQ_OPEN.toBuilder().setFlush(true).setStateLookup(true).build(),
-                respond -> respond.onError(statusRuntimeException),
-                req2,
-                respond -> respond.onError(statusRuntimeException)));
+                BidiUploadTestUtils.withFlushAndStateLookup(open_abc),
+                respond -> {
+                  BidiWriteObjectResponse.Builder b = res_abc.toBuilder();
+                  b.setWriteHandle(writeHandle);
+                  BidiWriteObjectResponse resAbcWithHandle = b.build();
+                  respond.onNext(resAbcWithHandle);
+                },
+                BidiUploadTestUtils.withFlushAndStateLookup(def),
+                respond -> {
+                  redirectCounter.getAndIncrement();
+                  respond.onError(packRedirectIntoAbortedException(makeRedirect(routingToken1)));
+                },
+                redirectRequest1,
+                respond -> {
+                  redirectCounter.getAndIncrement();
+                  respond.onError(packRedirectIntoAbortedException(makeRedirect(routingToken2)));
+                },
+                redirectRequest2,
+                respond -> {
+                  redirectCounter.getAndIncrement();
+                  respond.onError(packRedirectIntoAbortedException(makeRedirect(routingToken3)));
+                },
+                redirectRequest3,
+                respond -> {
+                  redirectCounter.getAndIncrement();
+                  respond.onError(packRedirectIntoAbortedException(makeRedirect(routingToken4)));
+                },
+                redirectRequest4,
+                respond -> {
+                  redirectCounter.getAndIncrement();
+                  respond.onError(packRedirectIntoAbortedException(makeRedirect(routingToken5)));
+                }));
 
     try (FakeServer fakeServer = FakeServer.of(fake);
         Storage storage =
@@ -283,248 +261,33 @@ public class ITAppendableUploadFakeTest {
                 .getService()) {
 
       BlobId id = BlobId.of("b", "o");
+      BlobAppendableUploadConfig config =
+          BlobAppendableUploadConfig.of()
+              .withFlushPolicy(FlushPolicy.maxFlushSize(3))
+              .withCloseAction(CloseAction.CLOSE_WITHOUT_FINALIZING);
       BlobAppendableUpload b =
-          storage.blobAppendableUpload(BlobInfo.newBuilder(id).build(), UPLOAD_CONFIG);
-      AppendableUploadWriteableByteChannel channel = b.open();
-      try {
-        StorageException e =
-            assertThrows(
-                StorageException.class,
-                () -> {
-                  channel.write(ByteBuffer.wrap("ABCDE".getBytes()));
-                });
-        assertThat(e).hasCauseThat().isInstanceOf(AbortedException.class);
-      } finally {
-        channel.close();
-      }
-    }
-  }
+          storage.blobAppendableUpload(BlobInfo.newBuilder(id).build(), config);
+      IOException ioe =
+          assertThrows(
+              IOException.class,
+              () -> {
+                AppendableUploadWriteableByteChannel channel = b.open();
+                ByteBuffer wrap = ByteBuffer.wrap(content.getBytes());
+                Buffers.emptyTo(wrap, channel);
+                channel.close();
+              });
 
-  /**
-   *
-   *
-   * <ol>
-   *   <li>Create a new appendable object, write 5 bytes, first result succeeds
-   *   <li>Write 5 more bytes--server responds with a retryable error
-   *   <li>Retry using a new AppendObjectSpec with generation, write handle specified -- retry
-   *       succeeds
-   *   <li>Finish writing the data as normal on the new stream
-   * </ol>
-   */
-  @Test
-  public void bidiWriteObjectRetryableError() throws Exception {
-    BidiWriteHandle writeHandle =
-        BidiWriteHandle.newBuilder()
-            .setHandle(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-            .build();
-    BidiWriteObjectResponse res1 =
-        BidiWriteObjectResponse.newBuilder()
-            .setResource(
-                Object.newBuilder()
-                    .setName(METADATA.getName())
-                    .setBucket(METADATA.getBucket())
-                    .setGeneration(METADATA.getGeneration())
-                    .setSize(5)
-                    // real object would have some extra fields like metageneration and storage
-                    // class
-                    .build())
-            .setWriteHandle(writeHandle)
-            .build();
-
-    BidiWriteObjectRequest req2 =
-        BidiWriteObjectRequest.newBuilder()
-            .setWriteOffset(5)
-            .setChecksummedData(
-                ChecksummedData.newBuilder().setContent(ByteString.copyFromUtf8("FGHIJ")).build())
-            .setStateLookup(true)
-            .setFlush(true)
-            .build();
-
-    BidiWriteObjectRequest req3 =
-        BidiWriteObjectRequest.newBuilder()
-            .setAppendObjectSpec(
-                AppendObjectSpec.newBuilder()
-                    .setBucket(METADATA.getBucket())
-                    .setObject(METADATA.getName())
-                    .setGeneration(METADATA.getGeneration())
-                    .setWriteHandle(writeHandle)
-                    .build())
-            .setFlush(true)
-            .setStateLookup(true)
-            .build();
-
-    BidiWriteObjectRequest req5 =
-        BidiWriteObjectRequest.newBuilder().setWriteOffset(10).setFinishWrite(true).build();
-
-    BidiWriteObjectResponse res3 = BidiWriteObjectResponse.newBuilder().setPersistedSize(5).build();
-
-    BidiWriteObjectResponse res4 =
-        BidiWriteObjectResponse.newBuilder().setPersistedSize(10).build();
-
-    BidiWriteObjectResponse res5 =
-        BidiWriteObjectResponse.newBuilder()
-            .setResource(
-                Object.newBuilder()
-                    .setName(METADATA.getName())
-                    .setBucket(METADATA.getBucket())
-                    .setGeneration(METADATA.getGeneration())
-                    .setSize(10)
-                    // real object would have some extra fields like metageneration and storage
-                    // class
-                    .build())
-            .setWriteHandle(writeHandle)
-            .build();
-
-    final AtomicBoolean retried = new AtomicBoolean(false);
-
-    FakeStorage fake =
-        FakeStorage.of(
-            ImmutableMap.of(
-                REQ_OPEN.toBuilder().setFlush(true).setStateLookup(true).build(),
-                respond -> respond.onNext(res1),
-                req2,
-                respond -> {
-                  // This same request gets run twice, the first time (as the second request),
-                  // it gets an error. The second time (as the fourth request) it succeeds.
-                  if (!retried.get()) {
-                    respond.onError(Status.INTERNAL.asRuntimeException());
-                    retried.set(true);
-                  } else {
-                    respond.onNext(res4);
-                  }
-                },
-                req3,
-                respond -> respond.onNext(res3),
-                req5,
-                respond -> respond.onNext(res5)));
-
-    try (FakeServer fakeServer = FakeServer.of(fake);
-        Storage storage = fakeServer.getGrpcStorageOptions().toBuilder().build().getService()) {
-
-      BlobId id = BlobId.of("b", "o");
-      BlobAppendableUpload b =
-          storage.blobAppendableUpload(BlobInfo.newBuilder(id).build(), UPLOAD_CONFIG);
-      ChecksummedTestContent content = ChecksummedTestContent.of(ALL_OBJECT_BYTES, 0, 10);
-      try (AppendableUploadWriteableByteChannel channel = b.open()) {
-        channel.write(ByteBuffer.wrap(content.getBytes()));
-      }
-      BlobInfo bi = b.getResult().get(5, TimeUnit.SECONDS);
-      assertThat(bi.getSize()).isEqualTo(10);
-    }
-  }
-
-  /**
-   *
-   *
-   * <ol>
-   *   <li>Create a new appendable object, write 5 bytes, first result succeeds
-   *   <li>Write 5 more bytes--server responds with a retryable error
-   *   <li>Retry using a new AppendObjectSpec with generation, write handle specified
-   *   <li>GCS responds with a persisted size indicating a partial write
-   *   <li>Client responds by taking the partial success into account and skipping some bytes on the
-   *       retry
-   *   <li>Finish writing the data as normal on the new stream
-   * </ol>
-   */
-  @Test
-  public void retryableErrorIncompleteFlush() throws Exception {
-    BidiWriteHandle writeHandle =
-        BidiWriteHandle.newBuilder()
-            .setHandle(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-            .build();
-    BidiWriteObjectResponse res1 =
-        BidiWriteObjectResponse.newBuilder()
-            .setResource(
-                Object.newBuilder()
-                    .setName(METADATA.getName())
-                    .setBucket(METADATA.getBucket())
-                    .setGeneration(METADATA.getGeneration())
-                    .setSize(5)
-                    // real object would have some extra fields like metageneration and storage
-                    // class
-                    .build())
-            .setWriteHandle(writeHandle)
-            .build();
-
-    BidiWriteObjectRequest req2 =
-        BidiWriteObjectRequest.newBuilder()
-            .setWriteOffset(5)
-            .setChecksummedData(
-                ChecksummedData.newBuilder().setContent(ByteString.copyFromUtf8("FGHIJ")).build())
-            .setStateLookup(true)
-            .setFlush(true)
-            .build();
-
-    BidiWriteObjectRequest req3 =
-        BidiWriteObjectRequest.newBuilder()
-            .setAppendObjectSpec(
-                AppendObjectSpec.newBuilder()
-                    .setBucket(METADATA.getBucket())
-                    .setObject(METADATA.getName())
-                    .setGeneration(METADATA.getGeneration())
-                    .setWriteHandle(writeHandle)
-                    .build())
-            .setFlush(true)
-            .setStateLookup(true)
-            .build();
-
-    BidiWriteObjectRequest req5 =
-        BidiWriteObjectRequest.newBuilder().setWriteOffset(10).setFinishWrite(true).build();
-
-    BidiWriteObjectResponse res3 = BidiWriteObjectResponse.newBuilder().setPersistedSize(7).build();
-
-    BidiWriteObjectRequest req4 =
-        BidiWriteObjectRequest.newBuilder()
-            .setWriteOffset(7)
-            .setChecksummedData(
-                ChecksummedData.newBuilder().setContent(ByteString.copyFromUtf8("HIJ")).build())
-            .setStateLookup(true)
-            .setFlush(true)
-            .build();
-
-    BidiWriteObjectResponse res4 =
-        BidiWriteObjectResponse.newBuilder().setPersistedSize(10).build();
-
-    BidiWriteObjectResponse res5 =
-        BidiWriteObjectResponse.newBuilder()
-            .setResource(
-                Object.newBuilder()
-                    .setName(METADATA.getName())
-                    .setBucket(METADATA.getBucket())
-                    .setGeneration(METADATA.getGeneration())
-                    .setSize(10)
-                    // real object would have some extra fields like metageneration and storage
-                    // class
-                    .build())
-            .setWriteHandle(writeHandle)
-            .build();
-
-    FakeStorage fake =
-        FakeStorage.of(
-            ImmutableMap.of(
-                REQ_OPEN.toBuilder().setFlush(true).setStateLookup(true).build(),
-                respond -> respond.onNext(res1),
-                req2,
-                respond -> respond.onError(Status.INTERNAL.asRuntimeException()),
-                req3,
-                respond -> respond.onNext(res3),
-                req4,
-                respond -> respond.onNext(res4),
-                req5,
-                respond -> respond.onNext(res5)));
-
-    try (FakeServer fakeServer = FakeServer.of(fake);
-        Storage storage = fakeServer.getGrpcStorageOptions().toBuilder().build().getService()) {
-
-      BlobId id = BlobId.of("b", "o");
-      BlobAppendableUpload b =
-          storage.blobAppendableUpload(BlobInfo.newBuilder(id).build(), UPLOAD_CONFIG);
-      ChecksummedTestContent content = ChecksummedTestContent.of(ALL_OBJECT_BYTES, 0, 10);
-      try (AppendableUploadWriteableByteChannel channel = b.open()) {
-        channel.write(ByteBuffer.wrap(content.getBytes()));
-      }
-      BlobInfo bi = b.getResult().get(5, TimeUnit.SECONDS);
-      assertThat(bi.getSize()).isEqualTo(10);
+      assertAll(
+          () -> assertThat(redirectCounter.get()).isEqualTo(4),
+          () -> {
+            ExecutionException ee =
+                assertThrows(
+                    ExecutionException.class, () -> b.getResult().get(3, TimeUnit.SECONDS));
+            assertThat(ee).hasCauseThat().isInstanceOf(StorageException.class);
+            assertThat(ee).hasCauseThat().hasCauseThat().isInstanceOf(AbortedException.class);
+          },
+          () -> assertThat(ioe).hasCauseThat().isInstanceOf(StorageException.class),
+          () -> assertThat(ioe).hasCauseThat().hasCauseThat().isInstanceOf(AbortedException.class));
     }
   }
 
@@ -534,96 +297,25 @@ public class ITAppendableUploadFakeTest {
    */
   @Test
   public void testFlushMultipleSegments() throws Exception {
-    BidiWriteHandle writeHandle =
-        BidiWriteHandle.newBuilder()
-            .setHandle(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-            .build();
-
-    ChunkSegmenter smallSegmenter =
-        new ChunkSegmenter(Hasher.noop(), ByteStringStrategy.copy(), 3, 3);
-
-    BidiWriteObjectRequest req1 =
-        REQ_OPEN.toBuilder()
-            .setChecksummedData(
-                ChecksummedData.newBuilder().setContent(ByteString.copyFromUtf8("ABC")))
-            .build();
-
-    BidiWriteObjectResponse res1 =
-        BidiWriteObjectResponse.newBuilder()
-            .setResource(
-                Object.newBuilder()
-                    .setName(METADATA.getName())
-                    .setBucket(METADATA.getBucket())
-                    .setGeneration(METADATA.getGeneration())
-                    .setSize(10)
-                    // real object would have some extra fields like metageneration and storage
-                    // class
-                    .build())
-            .setWriteHandle(writeHandle)
-            .build();
-
-    BidiWriteObjectResponse last =
-        BidiWriteObjectResponse.newBuilder()
-            .setResource(
-                Object.newBuilder()
-                    .setName(METADATA.getName())
-                    .setBucket(METADATA.getBucket())
-                    .setGeneration(METADATA.getGeneration())
-                    .setSize(10)
-                    // real object would have some extra fields like metageneration and storage
-                    // class
-                    .build())
-            .build();
 
     FakeStorage fake =
         FakeStorage.of(
             ImmutableMap.of(
-                req1,
+                open_abc,
                 respond -> {},
-                incrementalRequest(3, "DEF"),
+                def,
                 respond -> {},
-                incrementalRequest(6, "GHI"),
+                ghi,
                 respond -> {},
-                incrementalRequest(9, "J", true),
-                respond -> respond.onNext(res1),
-                finishMessage(10),
-                respond -> respond.onNext(last)));
+                j_flush,
+                respond -> respond.onNext(incrementalResponse(10)),
+                finish_10,
+                respond -> {
+                  respond.onNext(resource_10);
+                  respond.onCompleted();
+                }));
 
-    try (FakeServer fakeServer = FakeServer.of(fake);
-        GrpcStorageImpl storage =
-            (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().toBuilder().build().getService()) {
-      StorageClient storageClient = storage.storageClient;
-      BidiWriteCtx<BidiAppendableWrite> writeCtx =
-          new BidiWriteCtx<>(
-              new BidiAppendableWrite(
-                  BidiWriteObjectRequest.newBuilder()
-                      .setWriteObjectSpec(
-                          WriteObjectSpec.newBuilder()
-                              .setResource(
-                                  Object.newBuilder()
-                                      .setBucket(METADATA.getBucket())
-                                      .setName(METADATA.getName()))
-                              .setAppendable(true)
-                              .build())
-                      .build()));
-      SettableApiFuture<BidiWriteObjectResponse> done = SettableApiFuture.create();
-
-      GapicBidiUnbufferedAppendableWritableByteChannel channel =
-          new GapicBidiUnbufferedAppendableWritableByteChannel(
-              storageClient.bidiWriteObjectCallable(),
-              storageClient.getObjectCallable(),
-              TestUtils.retrierFromStorageOptions(fakeServer.getGrpcStorageOptions())
-                  .withAlg(
-                      fakeServer.getGrpcStorageOptions().getRetryAlgorithmManager().idempotent()),
-              done,
-              smallSegmenter,
-              writeCtx,
-              GrpcCallContext::createDefault);
-      ChecksummedTestContent content = ChecksummedTestContent.of(ALL_OBJECT_BYTES, 0, 10);
-      channel.write(ByteBuffer.wrap(content.getBytes()));
-      channel.finalizeWrite();
-      assertThat(done.get().getResource().getSize()).isEqualTo(10);
-    }
+    runTestFlushMultipleSegments(fake);
   }
 
   /**
@@ -635,133 +327,39 @@ public class ITAppendableUploadFakeTest {
    */
   @Test
   public void testFlushMultipleSegments_failsHalfway() throws Exception {
-    BidiWriteHandle writeHandle =
-        BidiWriteHandle.newBuilder()
-            .setHandle(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-            .build();
-
-    ChunkSegmenter smallSegmenter =
-        new ChunkSegmenter(Hasher.noop(), ByteStringStrategy.copy(), 3, 3);
-
-    BidiWriteObjectRequest req1 =
-        REQ_OPEN.toBuilder()
-            .setChecksummedData(
-                ChecksummedData.newBuilder().setContent(ByteString.copyFromUtf8("ABC")))
-            .build();
-
-    BidiWriteObjectResponse res1 =
-        BidiWriteObjectResponse.newBuilder()
-            .setResource(
-                Object.newBuilder()
-                    .setName(METADATA.getName())
-                    .setBucket(METADATA.getBucket())
-                    .setGeneration(METADATA.getGeneration())
-                    .setSize(3)
-                    // real object would have some extra fields like metageneration and storage
-                    // class
-                    .build())
-            .setWriteHandle(writeHandle)
-            .build();
-
-    BidiWriteObjectRequest req2 = incrementalRequest(3, "DEF");
-    BidiWriteObjectRequest req3 = incrementalRequest(6, "GHI");
-
-    BidiWriteObjectRequest reconnect =
-        BidiWriteObjectRequest.newBuilder()
-            .setAppendObjectSpec(
-                AppendObjectSpec.newBuilder()
-                    .setBucket(METADATA.getBucket())
-                    .setObject(METADATA.getName())
-                    .setGeneration(METADATA.getGeneration())
-                    .build())
-            .setFlush(true)
-            .setStateLookup(true)
-            .build();
-
-    BidiWriteObjectRequest req4 = incrementalRequest(9, "J", true);
-    BidiWriteObjectRequest req5 = finishMessage(10);
-
-    BidiWriteObjectResponse last =
-        BidiWriteObjectResponse.newBuilder()
-            .setResource(
-                Object.newBuilder()
-                    .setName(METADATA.getName())
-                    .setBucket(METADATA.getBucket())
-                    .setGeneration(METADATA.getGeneration())
-                    .setSize(10)
-                    // real object would have some extra fields like metageneration and storage
-                    // class
-                    .build())
-            .build();
     Map<BidiWriteObjectRequest, Integer> map = new ConcurrentHashMap<>();
-
+    Consumer<StreamObserver<BidiWriteObjectResponse>> finish10Respond =
+        maxRetries(j_finish, resource_10, map, 1);
     FakeStorage fake =
         FakeStorage.of(
             ImmutableMap.of(
-                req1,
-                maxRetries(req1, null, map, 1),
-                req2,
-                maxRetries(req2, null, map, 1),
-                req3,
-                retryableErrorOnce(req3, null, map, 2),
+                open_abc,
+                maxRetries(open_abc, res_abc, map, 1),
+                def,
+                maxRetries(def, map, 1),
+                ghi,
+                retryableErrorOnce(ghi, map, 2),
                 reconnect,
-                maxRetries(reconnect, incrementalResponse(6), map, 2),
-                req4,
-                maxRetries(req4, incrementalResponse(10), map, 1),
-                req5,
-                maxRetries(req5, last, map, 1)),
+                maxRetries(reconnect, incrementalResponse(6), map, 1),
+                j_finish,
+                respond -> {
+                  finish10Respond.accept(respond);
+                  respond.onCompleted();
+                }),
             ImmutableMap.of(
-                GetObjectRequest.newBuilder()
-                    .setObject(METADATA.getName())
-                    .setBucket(METADATA.getBucket())
-                    .setReadMask(
-                        (FieldMask.newBuilder()
-                            .addPaths(Storage.BlobField.GENERATION.getGrpcName())
-                            .build()))
-                    .build(),
+                get_generation_mask,
                 Object.newBuilder().setGeneration(METADATA.getGeneration()).build()));
 
-    try (FakeServer fakeServer = FakeServer.of(fake);
-        GrpcStorageImpl storage =
-            (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().toBuilder().build().getService()) {
-      StorageClient storageClient = storage.storageClient;
-      BidiWriteCtx<BidiAppendableWrite> writeCtx =
-          new BidiWriteCtx<>(
-              new BidiAppendableWrite(
-                  BidiWriteObjectRequest.newBuilder()
-                      .setWriteObjectSpec(
-                          WriteObjectSpec.newBuilder()
-                              .setResource(
-                                  Object.newBuilder()
-                                      .setBucket(METADATA.getBucket())
-                                      .setName(METADATA.getName()))
-                              .setAppendable(true)
-                              .build())
-                      .build()));
-      SettableApiFuture<BidiWriteObjectResponse> done = SettableApiFuture.create();
+    runTestFlushMultipleSegments(fake);
 
-      GapicBidiUnbufferedAppendableWritableByteChannel channel =
-          new GapicBidiUnbufferedAppendableWritableByteChannel(
-              storageClient.bidiWriteObjectCallable(),
-              storageClient.getObjectCallable(),
-              TestUtils.retrierFromStorageOptions(fakeServer.getGrpcStorageOptions())
-                  .withAlg(
-                      fakeServer.getGrpcStorageOptions().getRetryAlgorithmManager().idempotent()),
-              done,
-              smallSegmenter,
-              writeCtx,
-              GrpcCallContext::createDefault);
-      ChecksummedTestContent content = ChecksummedTestContent.of(ALL_OBJECT_BYTES, 0, 10);
-      channel.write(ByteBuffer.wrap(content.getBytes()));
-      channel.finalizeWrite();
-      assertThat(done.get().getResource().getSize()).isEqualTo(10);
-
-      assertThat(map.get(req1)).isEqualTo(1);
-      assertThat(map.get(req2)).isEqualTo(1);
-      assertThat(map.get(req3)).isEqualTo(2);
-      assertThat(map.get(req4)).isEqualTo(1);
-      assertThat(map.get(req5)).isEqualTo(1);
-    }
+    assertThat(map)
+        .isEqualTo(
+            ImmutableMap.of(
+                open_abc, 1,
+                def, 1,
+                ghi, 2,
+                reconnect, 1,
+                j_finish, 1));
   }
 
   /**
@@ -771,6 +369,7 @@ public class ITAppendableUploadFakeTest {
    * and only sending "HI", and updating the offsets accordingly.
    */
   @Test
+  @Ignore("messages splitting")
   public void testFlushMultipleSegments_failsHalfway_partialFlush() throws Exception {
     BidiWriteHandle writeHandle =
         BidiWriteHandle.newBuilder()
@@ -778,7 +377,7 @@ public class ITAppendableUploadFakeTest {
             .build();
 
     ChunkSegmenter smallSegmenter =
-        new ChunkSegmenter(Hasher.noop(), ByteStringStrategy.copy(), 3, 3);
+        new ChunkSegmenter(Hasher.enabled(), ByteStringStrategy.copy(), 3, 3);
 
     BidiWriteObjectRequest req1 =
         REQ_OPEN.toBuilder()
@@ -828,6 +427,7 @@ public class ITAppendableUploadFakeTest {
                     .setBucket(METADATA.getBucket())
                     .setGeneration(METADATA.getGeneration())
                     .setSize(10)
+                    .setFinalizeTime(timestampNow())
                     // real object would have some extra fields like metageneration and storage
                     // class
                     .build())
@@ -865,37 +465,36 @@ public class ITAppendableUploadFakeTest {
     try (FakeServer fakeServer = FakeServer.of(fake);
         GrpcStorageImpl storage =
             (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().toBuilder().build().getService()) {
-      StorageClient storageClient = storage.storageClient;
-      BidiWriteCtx<BidiAppendableWrite> writeCtx =
-          new BidiWriteCtx<>(
-              new BidiAppendableWrite(
-                  BidiWriteObjectRequest.newBuilder()
-                      .setWriteObjectSpec(
-                          WriteObjectSpec.newBuilder()
-                              .setResource(
-                                  Object.newBuilder()
-                                      .setBucket(METADATA.getBucket())
-                                      .setName(METADATA.getName()))
-                              .setAppendable(true)
-                              .build())
-                      .build()));
       SettableApiFuture<BidiWriteObjectResponse> done = SettableApiFuture.create();
-
-      GapicBidiUnbufferedAppendableWritableByteChannel channel =
-          new GapicBidiUnbufferedAppendableWritableByteChannel(
-              storageClient.bidiWriteObjectCallable(),
-              storageClient.getObjectCallable(),
-              TestUtils.retrierFromStorageOptions(fakeServer.getGrpcStorageOptions())
-                  .withAlg(
-                      fakeServer.getGrpcStorageOptions().getRetryAlgorithmManager().idempotent()),
-              done,
+      BidiAppendableUnbufferedWritableByteChannel channel =
+          new BidiAppendableUnbufferedWritableByteChannel(
+              new BidiUploadStreamingStream(
+                  BidiUploadState.appendableNew(
+                      BidiWriteObjectRequest.newBuilder()
+                          .setWriteObjectSpec(
+                              WriteObjectSpec.newBuilder()
+                                  .setResource(
+                                      Object.newBuilder()
+                                          .setBucket(METADATA.getBucket())
+                                          .setName(METADATA.getName()))
+                                  .setAppendable(true)
+                                  .build())
+                          .build(),
+                      GrpcCallContext::createDefault,
+                      32,
+                      SettableApiFuture.create(),
+                      Crc32cValue.zero()),
+                  storage.storageDataClient.executor,
+                  storage.storageClient.bidiWriteObjectCallable(),
+                  3,
+                  storage.storageDataClient.retryContextProvider.create()),
               smallSegmenter,
-              writeCtx,
-              GrpcCallContext::createDefault);
+              0);
       ChecksummedTestContent content = ChecksummedTestContent.of(ALL_OBJECT_BYTES, 0, 10);
       channel.write(ByteBuffer.wrap(content.getBytes()));
-      channel.finalizeWrite();
-      assertThat(done.get().getResource().getSize()).isEqualTo(10);
+      channel.nextWriteShouldFinalize();
+      channel.close();
+      assertThat(done.get(777, TimeUnit.MILLISECONDS).getResource().getSize()).isEqualTo(10);
 
       assertThat(map.get(req1)).isEqualTo(1);
       assertThat(map.get(req2)).isEqualTo(1);
@@ -914,6 +513,7 @@ public class ITAppendableUploadFakeTest {
    * in the channel works properly
    */
   @Test
+  @Ignore("partial message eviction")
   public void testFlushMultipleSegmentsTwice_firstSucceeds_secondFailsHalfway_partialFlush()
       throws Exception {
     BidiWriteHandle writeHandle =
@@ -922,7 +522,7 @@ public class ITAppendableUploadFakeTest {
             .build();
 
     ChunkSegmenter smallSegmenter =
-        new ChunkSegmenter(Hasher.noop(), ByteStringStrategy.copy(), 3, 3);
+        new ChunkSegmenter(Hasher.enabled(), ByteStringStrategy.copy(), 3, 3);
 
     BidiWriteObjectRequest req1 =
         REQ_OPEN.toBuilder()
@@ -974,6 +574,7 @@ public class ITAppendableUploadFakeTest {
                     .setBucket(METADATA.getBucket())
                     .setGeneration(METADATA.getGeneration())
                     .setSize(20)
+                    .setFinalizeTime(timestampNow())
                     // real object would have some extra fields like metageneration and storage
                     // class
                     .build())
@@ -1013,39 +614,38 @@ public class ITAppendableUploadFakeTest {
     try (FakeServer fakeServer = FakeServer.of(fake);
         GrpcStorageImpl storage =
             (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().toBuilder().build().getService()) {
-      StorageClient storageClient = storage.storageClient;
-      BidiWriteCtx<BidiAppendableWrite> writeCtx =
-          new BidiWriteCtx<>(
-              new BidiAppendableWrite(
-                  BidiWriteObjectRequest.newBuilder()
-                      .setWriteObjectSpec(
-                          WriteObjectSpec.newBuilder()
-                              .setResource(
-                                  Object.newBuilder()
-                                      .setBucket(METADATA.getBucket())
-                                      .setName(METADATA.getName()))
-                              .setAppendable(true)
-                              .build())
-                      .build()));
       SettableApiFuture<BidiWriteObjectResponse> done = SettableApiFuture.create();
-
-      GapicBidiUnbufferedAppendableWritableByteChannel channel =
-          new GapicBidiUnbufferedAppendableWritableByteChannel(
-              storageClient.bidiWriteObjectCallable(),
-              storageClient.getObjectCallable(),
-              TestUtils.retrierFromStorageOptions(fakeServer.getGrpcStorageOptions())
-                  .withAlg(
-                      fakeServer.getGrpcStorageOptions().getRetryAlgorithmManager().idempotent()),
-              done,
+      BidiAppendableUnbufferedWritableByteChannel channel =
+          new BidiAppendableUnbufferedWritableByteChannel(
+              new BidiUploadStreamingStream(
+                  BidiUploadState.appendableNew(
+                      BidiWriteObjectRequest.newBuilder()
+                          .setWriteObjectSpec(
+                              WriteObjectSpec.newBuilder()
+                                  .setResource(
+                                      Object.newBuilder()
+                                          .setBucket(METADATA.getBucket())
+                                          .setName(METADATA.getName()))
+                                  .setAppendable(true)
+                                  .build())
+                          .build(),
+                      GrpcCallContext::createDefault,
+                      32,
+                      SettableApiFuture.create(),
+                      Crc32cValue.zero()),
+                  storage.storageDataClient.executor,
+                  storage.storageClient.bidiWriteObjectCallable(),
+                  3,
+                  storage.storageDataClient.retryContextProvider.create()),
               smallSegmenter,
-              writeCtx,
-              GrpcCallContext::createDefault);
+              0);
       ChecksummedTestContent content1 = ChecksummedTestContent.of(ALL_OBJECT_BYTES, 0, 10);
       ChecksummedTestContent content2 = ChecksummedTestContent.of(ALL_OBJECT_BYTES, 10, 10);
       channel.write(ByteBuffer.wrap(content1.getBytes()));
       channel.write(ByteBuffer.wrap(content2.getBytes()));
-      channel.finalizeWrite();
-      assertThat(done.get().getResource().getSize()).isEqualTo(20);
+      channel.nextWriteShouldFinalize();
+      channel.close();
+      assertThat(done.get(777, TimeUnit.MILLISECONDS).getResource().getSize()).isEqualTo(20);
 
       assertThat(map.get(reconnect)).isEqualTo(1);
       assertThat(map.get(req2)).isEqualTo(1);
@@ -1064,6 +664,12 @@ public class ITAppendableUploadFakeTest {
    * skipping the partially ack'd bytes
    */
   @Test
+  /*
+  @Ignore("Ignore until the new implementation handles partial message consumption. \n"
+      + "[0:3] + [3:3] + [6:3] -> 8\n"
+      + "Today we only replay whole messages")
+  */
+  @Ignore("messages splitting")
   public void testFlushMultipleSegments_200ResponsePartialFlushHalfway() throws Exception {
     BidiWriteHandle writeHandle =
         BidiWriteHandle.newBuilder()
@@ -1071,7 +677,7 @@ public class ITAppendableUploadFakeTest {
             .build();
 
     ChunkSegmenter smallSegmenter =
-        new ChunkSegmenter(Hasher.noop(), ByteStringStrategy.copy(), 3, 3);
+        new ChunkSegmenter(Hasher.enabled(), ByteStringStrategy.copy(), 3, 3);
 
     BidiWriteObjectRequest req1 =
         REQ_OPEN.toBuilder()
@@ -1122,6 +728,7 @@ public class ITAppendableUploadFakeTest {
                     .setBucket(METADATA.getBucket())
                     .setGeneration(METADATA.getGeneration())
                     .setSize(10)
+                    .setFinalizeTime(timestampNow())
                     // real object would have some extra fields like metageneration and storage
                     // class
                     .build())
@@ -1157,38 +764,40 @@ public class ITAppendableUploadFakeTest {
 
     try (FakeServer fakeServer = FakeServer.of(fake);
         GrpcStorageImpl storage =
-            (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().toBuilder().build().getService()) {
-      StorageClient storageClient = storage.storageClient;
-      BidiWriteCtx<BidiAppendableWrite> writeCtx =
-          new BidiWriteCtx<>(
-              new BidiAppendableWrite(
-                  BidiWriteObjectRequest.newBuilder()
-                      .setWriteObjectSpec(
-                          WriteObjectSpec.newBuilder()
-                              .setResource(
-                                  Object.newBuilder()
-                                      .setBucket(METADATA.getBucket())
-                                      .setName(METADATA.getName()))
-                              .setAppendable(true)
-                              .build())
-                      .build()));
-      SettableApiFuture<BidiWriteObjectResponse> done = SettableApiFuture.create();
-
-      GapicBidiUnbufferedAppendableWritableByteChannel channel =
-          new GapicBidiUnbufferedAppendableWritableByteChannel(
-              storageClient.bidiWriteObjectCallable(),
-              storageClient.getObjectCallable(),
-              TestUtils.retrierFromStorageOptions(fakeServer.getGrpcStorageOptions())
-                  .withAlg(
-                      fakeServer.getGrpcStorageOptions().getRetryAlgorithmManager().idempotent()),
-              done,
-              smallSegmenter,
-              writeCtx,
-              GrpcCallContext::createDefault);
+            (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().getService()) {
+      BidiWriteObjectRequest initial =
+          BidiWriteObjectRequest.newBuilder()
+              .setWriteObjectSpec(
+                  WriteObjectSpec.newBuilder()
+                      .setResource(
+                          Object.newBuilder()
+                              .setBucket(METADATA.getBucket())
+                              .setName(METADATA.getName()))
+                      .setAppendable(true)
+                      .build())
+              .build();
+      AppendableUploadState uploadState =
+          BidiUploadState.appendableNew(
+              initial,
+              GrpcCallContext::createDefault,
+              32,
+              SettableApiFuture.create(),
+              Crc32cValue.zero());
+      BidiUploadStreamingStream stream =
+          new BidiUploadStreamingStream(
+              uploadState,
+              storage.storageDataClient.executor,
+              storage.storageClient.bidiWriteObjectCallable(),
+              3,
+              storage.storageDataClient.retryContextProvider.create());
+      BidiAppendableUnbufferedWritableByteChannel channel =
+          new BidiAppendableUnbufferedWritableByteChannel(stream, smallSegmenter, 0);
       ChecksummedTestContent content = ChecksummedTestContent.of(ALL_OBJECT_BYTES, 0, 10);
       channel.write(ByteBuffer.wrap(content.getBytes()));
-      channel.finalizeWrite();
-      assertThat(done.get().getResource().getSize()).isEqualTo(10);
+      channel.nextWriteShouldFinalize();
+      channel.close();
+      assertThat(stream.getResultFuture().get(777, TimeUnit.MILLISECONDS).getResource().getSize())
+          .isEqualTo(10);
 
       assertThat(map.get(req1)).isEqualTo(1);
       assertThat(map.get(req2)).isEqualTo(1);
@@ -1201,319 +810,53 @@ public class ITAppendableUploadFakeTest {
   }
 
   /**
-   * If the last message in a flush of multiple segments (or the only message in a flush with just
-   * one segment) returns a 200 response but does a partial flush, we won't get a server side error
-   * like in the previous test, because we won't try to do a write with a larger offset than the
-   * persisted size. Instead, the channel keeps a manual count for this case, and throws an error if
-   * it happens, which triggers a retry, and the retry loop handles flushing the last request again
-   * while skipping the partially ack'd bytes
-   */
-  @Test
-  public void testFlushMultipleSegments_200ResponsePartialFlushOnLastMessage() throws Exception {
-    BidiWriteHandle writeHandle =
-        BidiWriteHandle.newBuilder()
-            .setHandle(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-            .build();
-
-    ChunkSegmenter smallSegmenter =
-        new ChunkSegmenter(Hasher.noop(), ByteStringStrategy.copy(), 3, 3);
-
-    BidiWriteObjectRequest req1 =
-        REQ_OPEN.toBuilder()
-            .setChecksummedData(
-                ChecksummedData.newBuilder().setContent(ByteString.copyFromUtf8("ABC")))
-            .build();
-
-    BidiWriteObjectResponse res1 =
-        BidiWriteObjectResponse.newBuilder()
-            .setResource(
-                Object.newBuilder()
-                    .setName(METADATA.getName())
-                    .setBucket(METADATA.getBucket())
-                    .setGeneration(METADATA.getGeneration())
-                    .setSize(7)
-                    // real object would have some extra fields like metageneration and storage
-                    // class
-                    .build())
-            .setWriteHandle(writeHandle)
-            .build();
-
-    BidiWriteObjectRequest req2 = incrementalRequest(3, "DEF");
-    BidiWriteObjectRequest req3 = incrementalRequest(6, "GHI", true);
-
-    BidiWriteObjectRequest reconnect =
-        BidiWriteObjectRequest.newBuilder()
-            .setAppendObjectSpec(
-                AppendObjectSpec.newBuilder()
-                    .setBucket(METADATA.getBucket())
-                    .setObject(METADATA.getName())
-                    .setGeneration(METADATA.getGeneration())
-                    .setWriteHandle(writeHandle)
-                    .build())
-            .setFlush(true)
-            .setStateLookup(true)
-            .build();
-
-    BidiWriteObjectRequest req4 = incrementalRequest(7, "HI", true);
-
-    BidiWriteObjectRequest req5 = finishMessage(9);
-
-    BidiWriteObjectResponse last =
-        BidiWriteObjectResponse.newBuilder()
-            .setResource(
-                Object.newBuilder()
-                    .setName(METADATA.getName())
-                    .setBucket(METADATA.getBucket())
-                    .setGeneration(METADATA.getGeneration())
-                    .setSize(9)
-                    // real object would have some extra fields like metageneration and storage
-                    // class
-                    .build())
-            .build();
-    Map<BidiWriteObjectRequest, Integer> map = new HashMap<>();
-
-    FakeStorage fake =
-        FakeStorage.of(
-            ImmutableMap.of(
-                req1,
-                maxRetries(req1, null, map, 1),
-                req2,
-                maxRetries(req2, null, map, 1),
-                req3,
-                maxRetries(req3, res1, map, 1),
-                reconnect,
-                maxRetries(reconnect, incrementalResponse(7), map, 1),
-                req4,
-                maxRetries(req4, incrementalResponse(9), map, 1),
-                req5,
-                maxRetries(req5, last, map, 1)));
-
-    try (FakeServer fakeServer = FakeServer.of(fake);
-        GrpcStorageImpl storage =
-            (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().toBuilder().build().getService()) {
-      StorageClient storageClient = storage.storageClient;
-      BidiWriteCtx<BidiAppendableWrite> writeCtx =
-          new BidiWriteCtx<>(
-              new BidiAppendableWrite(
-                  BidiWriteObjectRequest.newBuilder()
-                      .setWriteObjectSpec(
-                          WriteObjectSpec.newBuilder()
-                              .setResource(
-                                  Object.newBuilder()
-                                      .setBucket(METADATA.getBucket())
-                                      .setName(METADATA.getName()))
-                              .setAppendable(true)
-                              .build())
-                      .build()));
-      SettableApiFuture<BidiWriteObjectResponse> done = SettableApiFuture.create();
-
-      GapicBidiUnbufferedAppendableWritableByteChannel channel =
-          new GapicBidiUnbufferedAppendableWritableByteChannel(
-              storageClient.bidiWriteObjectCallable(),
-              storageClient.getObjectCallable(),
-              TestUtils.retrierFromStorageOptions(fakeServer.getGrpcStorageOptions())
-                  .withAlg(
-                      fakeServer.getGrpcStorageOptions().getRetryAlgorithmManager().idempotent()),
-              done,
-              smallSegmenter,
-              writeCtx,
-              GrpcCallContext::createDefault);
-      ChecksummedTestContent content = ChecksummedTestContent.of(ALL_OBJECT_BYTES, 0, 9);
-      channel.write(ByteBuffer.wrap(content.getBytes()));
-      channel.finalizeWrite();
-      assertThat(done.get().getResource().getSize()).isEqualTo(9);
-
-      assertThat(map.get(req1)).isEqualTo(1);
-      assertThat(map.get(req2)).isEqualTo(1);
-      assertThat(map.get(req3)).isEqualTo(1);
-      assertThat(map.get(req4)).isEqualTo(1);
-      assertThat(map.get(req5)).isEqualTo(1);
-      assertThat(map.get(reconnect)).isEqualTo(1);
-    }
-  }
-
-  @Test
-  public void takeoverRedirectError() throws Exception {
-    BidiWriteHandle writeHandle =
-        BidiWriteHandle.newBuilder()
-            .setHandle(ByteString.copyFromUtf8(UUID.randomUUID().toString()))
-            .build();
-    String routingToken = UUID.randomUUID().toString();
-
-    BidiWriteObjectRequest req1 =
-        BidiWriteObjectRequest.newBuilder()
-            .setAppendObjectSpec(
-                AppendObjectSpec.newBuilder()
-                    .setBucket(METADATA.getBucket())
-                    .setObject(METADATA.getName())
-                    .setGeneration(METADATA.getGeneration())
-                    .build())
-            .setFlush(true)
-            .setStateLookup(true)
-            .build();
-
-    BidiWriteObjectRequest req2 =
-        BidiWriteObjectRequest.newBuilder()
-            .setAppendObjectSpec(
-                AppendObjectSpec.newBuilder()
-                    .setBucket(METADATA.getBucket())
-                    .setObject(METADATA.getName())
-                    .setGeneration(METADATA.getGeneration())
-                    .setWriteHandle(writeHandle)
-                    .setRoutingToken(routingToken)
-                    .build())
-            .setFlush(true)
-            .setStateLookup(true)
-            .build();
-
-    BidiWriteObjectRequest req3 =
-        BidiWriteObjectRequest.newBuilder()
-            .setWriteOffset(10)
-            .setChecksummedData(
-                ChecksummedData.newBuilder().setContent(ByteString.copyFromUtf8("KLMNO")).build())
-            .setStateLookup(true)
-            .setFlush(true)
-            .build();
-
-    BidiWriteObjectRequest req4 =
-        BidiWriteObjectRequest.newBuilder()
-            .setWriteOffset(15)
-            .setChecksummedData(
-                ChecksummedData.newBuilder().setContent(ByteString.copyFromUtf8("PQRST")).build())
-            .setStateLookup(true)
-            .setFlush(true)
-            .build();
-
-    BidiWriteObjectRequest req5 =
-        BidiWriteObjectRequest.newBuilder().setWriteOffset(20).setFinishWrite(true).build();
-
-    BidiWriteObjectResponse res2 =
-        BidiWriteObjectResponse.newBuilder().setPersistedSize(10).build();
-
-    BidiWriteObjectResponse res3 =
-        BidiWriteObjectResponse.newBuilder().setPersistedSize(15).build();
-
-    BidiWriteObjectResponse res4 =
-        BidiWriteObjectResponse.newBuilder().setPersistedSize(20).build();
-
-    BidiWriteObjectResponse res5 =
-        BidiWriteObjectResponse.newBuilder()
-            .setResource(
-                Object.newBuilder()
-                    .setName(METADATA.getName())
-                    .setBucket(METADATA.getBucket())
-                    .setGeneration(METADATA.getGeneration())
-                    .setSize(20)
-                    // real object would have some extra fields like metageneration and storage
-                    // class
-                    .build())
-            .setWriteHandle(writeHandle)
-            .build();
-
-    FakeStorage fake =
-        FakeStorage.of(
-            ImmutableMap.of(
-                req1,
-                respond -> {
-                  BidiWriteObjectRedirectedError redirect =
-                      BidiWriteObjectRedirectedError.newBuilder()
-                          .setWriteHandle(writeHandle)
-                          .setRoutingToken(routingToken)
-                          .setGeneration(METADATA.getGeneration())
-                          .build();
-
-                  com.google.rpc.Status grpcStatusDetails =
-                      com.google.rpc.Status.newBuilder()
-                          .setCode(Code.ABORTED_VALUE)
-                          .setMessage("redirect")
-                          .addDetails(Any.pack(redirect))
-                          .build();
-
-                  Metadata trailers = new Metadata();
-                  trailers.put(GRPC_STATUS_DETAILS_KEY, grpcStatusDetails);
-                  StatusRuntimeException statusRuntimeException =
-                      Status.ABORTED.withDescription("redirect").asRuntimeException(trailers);
-                  respond.onError(statusRuntimeException);
-                },
-                req2,
-                respond -> respond.onNext(res2),
-                req3,
-                respond -> respond.onNext(res3),
-                req4,
-                respond -> respond.onNext(res4),
-                req5,
-                respond -> respond.onNext(res5)));
-
-    try (FakeServer fakeServer = FakeServer.of(fake);
-        Storage storage = fakeServer.getGrpcStorageOptions().toBuilder().build().getService()) {
-
-      BlobId id = BlobId.of("b", "o", METADATA.getGeneration());
-      BlobAppendableUpload b =
-          storage.blobAppendableUpload(BlobInfo.newBuilder(id).build(), UPLOAD_CONFIG);
-      ChecksummedTestContent content = ChecksummedTestContent.of(ALL_OBJECT_BYTES, 10, 10);
-      try (AppendableUploadWriteableByteChannel channel = b.open()) {
-        channel.write(ByteBuffer.wrap(content.getBytes()));
-      }
-      BlobInfo bi = b.getResult().get(5, TimeUnit.SECONDS);
-      assertThat(bi.getSize()).isEqualTo(20);
-    }
-  }
-
-  /**
    * We get a retryable error in our first flush. We don't have a generation so we do a metadata
    * lookup, but we get an ObjectNotFound, which means that GCS never received the WriteObjectSpec
    * and never created the object. Thus, we just send the WriteObjectSpec again
    */
   @Test
+  @Ignore("TODO: does this need to be implemented?")
   public void retryableError_ObjectNotFound() throws Exception {
-    BidiWriteObjectRequest req1 = REQ_OPEN.toBuilder().setFlush(true).setStateLookup(true).build();
 
-    Map<BidiWriteObjectRequest, Integer> map = new ConcurrentHashMap<>();
-    BidiWriteObjectResponse res =
-        BidiWriteObjectResponse.newBuilder()
-            .setResource(
-                Object.newBuilder()
-                    .setName(METADATA.getName())
-                    .setBucket(METADATA.getBucket())
-                    .setGeneration(METADATA.getGeneration())
-                    .setSize(5)
-                    // real object would have some extra fields like metageneration and storage
-                    // class
-                    .build())
+    ChecksummedTestContent abcde = content.slice(0, 5);
+    ChecksummedTestContent fghij = content.slice(5, 5);
+
+    BidiWriteObjectRequest req1 =
+        REQ_OPEN.toBuilder()
+            .setFlush(true)
+            .setStateLookup(true)
+            .setChecksummedData(abcde.asChecksummedData())
             .build();
 
-    BidiWriteObjectRequest req2 = finishMessage(5);
+    BidiWriteObjectRequest req2 =
+        BidiWriteObjectRequest.newBuilder()
+            .setWriteOffset(5)
+            .setChecksummedData(fghij.asChecksummedData())
+            .setFinishWrite(true)
+            .build();
+    BidiWriteObjectResponse res = BidiUploadTest.resourceFor(content);
 
+    Map<BidiWriteObjectRequest, Integer> map = new ConcurrentHashMap<>();
     FakeStorage fake =
         FakeStorage.of(
             ImmutableMap.of(
-                req1, retryableErrorOnce(req1, res, map, 2), req2, maxRetries(req2, res, map, 1)),
-            ImmutableMap.of(
-                GetObjectRequest.newBuilder()
-                    .setObject(METADATA.getName())
-                    .setBucket(METADATA.getBucket())
-                    .setReadMask(
-                        (FieldMask.newBuilder()
-                            .addPaths(Storage.BlobField.GENERATION.getGrpcName())
-                            .build()))
-                    .build(),
-                Object.getDefaultInstance()));
+                req1, retryableErrorOnce(req1, res, map, 2),
+                req2, maxRetries(req2, res, map, 1)),
+            ImmutableMap.of(get_generation_mask, Object.getDefaultInstance()));
 
     try (FakeServer fakeServer = FakeServer.of(fake);
-        Storage storage = fakeServer.getGrpcStorageOptions().toBuilder().build().getService()) {
+        Storage storage = fakeServer.getGrpcStorageOptions().getService()) {
 
       BlobId id = BlobId.of("b", "o");
       BlobAppendableUpload b =
           storage.blobAppendableUpload(BlobInfo.newBuilder(id).build(), UPLOAD_CONFIG);
-      ChecksummedTestContent content = ChecksummedTestContent.of(ALL_OBJECT_BYTES, 0, 5);
       try (AppendableUploadWriteableByteChannel channel = b.open()) {
         channel.write(ByteBuffer.wrap(content.getBytes()));
       }
       BlobInfo bi = b.getResult().get(5, TimeUnit.SECONDS);
       assertThat(bi.getSize()).isEqualTo(5);
 
-      assertThat(map.get(req1)).isEqualTo(2);
-      assertThat(map.get(req2)).isEqualTo(1);
+      assertThat(map).isEqualTo(ImmutableMap.of(req1, 2, req2, 1));
     }
   }
 
@@ -1571,7 +914,11 @@ public class ITAppendableUploadFakeTest {
             .build();
     BidiWriteObjectResponse res5 = incrementalResponse(25);
     BidiWriteObjectRequest req6 =
-        BidiWriteObjectRequest.newBuilder().setWriteOffset(25).setFinishWrite(true).build();
+        BidiWriteObjectRequest.newBuilder()
+            .setWriteOffset(25)
+            .setFinishWrite(true)
+            .setObjectChecksums(ObjectChecksums.newBuilder().setCrc32C(all.getCrc32c()).build())
+            .build();
     BidiWriteObjectResponse res6 =
         BidiWriteObjectResponse.newBuilder()
             .setResource(
@@ -1580,6 +927,7 @@ public class ITAppendableUploadFakeTest {
                     .setBucket(METADATA.getBucket())
                     .setGeneration(METADATA.getGeneration())
                     .setSize(25)
+                    .setFinalizeTime(timestampNow())
                     .setChecksums(ObjectChecksums.newBuilder().setCrc32C(all.getCrc32c()).build())
                     // real object would have some extra fields like metageneration and storage
                     // class
@@ -1589,40 +937,76 @@ public class ITAppendableUploadFakeTest {
     FakeStorage fake =
         FakeStorage.of(
             ImmutableMap.of(
-                req1, respond -> respond.onNext(res1),
-                req2, respond -> respond.onNext(res2),
-                req3, respond -> respond.onNext(res3),
-                req4, respond -> respond.onNext(res4),
-                req5, respond -> respond.onNext(res5),
-                req6, respond -> respond.onNext(res6)));
+                req1,
+                respond -> respond.onNext(res1),
+                req2,
+                respond -> respond.onNext(res2),
+                req3,
+                respond -> respond.onNext(res3),
+                req4,
+                respond -> respond.onNext(res4),
+                req5,
+                respond -> respond.onNext(res5),
+                req6,
+                respond -> {
+                  respond.onNext(res6);
+                  respond.onCompleted();
+                }));
     try (FakeServer fakeServer = FakeServer.of(fake);
         Storage storage = fakeServer.getGrpcStorageOptions().toBuilder().build().getService()) {
       BlobId id = BlobId.of("b", "o");
 
-      BlobAppendableUploadConfig uploadConfig = UPLOAD_CONFIG.withCrc32cValidationEnabled(true);
+      BlobAppendableUploadConfig config =
+          BlobAppendableUploadConfig.of()
+              .withFlushPolicy(FlushPolicy.maxFlushSize(5))
+              .withCloseAction(CloseAction.FINALIZE_WHEN_CLOSING);
       BlobAppendableUpload upload =
-          storage.blobAppendableUpload(BlobInfo.newBuilder(id).build(), uploadConfig);
+          storage.blobAppendableUpload(BlobInfo.newBuilder(id).build(), config);
       try (AppendableUploadWriteableByteChannel channel = upload.open()) {
         channel.write(ByteBuffer.wrap(b));
       }
-      upload.getResult().get(5, TimeUnit.SECONDS);
+      ApiFuture<BlobInfo> result = upload.getResult();
+      result.get(5, TimeUnit.SECONDS);
     }
   }
 
-  private Consumer<StreamObserver<BidiWriteObjectResponse>> maxRetries(
-      BidiWriteObjectRequest req,
-      BidiWriteObjectResponse res,
-      Map<BidiWriteObjectRequest, Integer> retryMap,
+  private static Consumer<StreamObserver<BidiWriteObjectResponse>> maxRetries(
+      @NonNull BidiWriteObjectRequest req,
+      Map<@NonNull BidiWriteObjectRequest, Integer> retryMap,
+      int maxAttempts) {
+    return maxRetries(req, null, retryMap, maxAttempts);
+  }
+
+  private static Consumer<StreamObserver<BidiWriteObjectResponse>> maxRetries(
+      @NonNull BidiWriteObjectRequest req,
+      @Nullable BidiWriteObjectResponse res,
+      @NonNull Map<@NonNull BidiWriteObjectRequest, Integer> retryMap,
       int maxAttempts) {
     return respond -> {
-      retryMap.putIfAbsent(req, 0);
-      int attempts = retryMap.get(req) + 1;
-      retryMap.put(req, attempts);
+      int attempts = retryMap.compute(req, (r, count) -> count == null ? 1 : count + 1);
       if (attempts > maxAttempts) {
-        respond.onError(
+        DebugInfo details =
+            DebugInfo.newBuilder().setDetail(TextFormat.printer().shortDebugString(req)).build();
+
+        com.google.rpc.Status grpcStatusDetails =
+            com.google.rpc.Status.newBuilder()
+                .setCode(com.google.rpc.Code.ABORTED_VALUE)
+                .setMessage("details")
+                .addDetails(Any.pack(details))
+                .build();
+
+        Metadata trailers = new Metadata();
+        trailers.put(TestUtils.GRPC_STATUS_DETAILS_KEY, grpcStatusDetails);
+        StatusRuntimeException t =
             Status.ABORTED
-                .withDescription("maxRetriesMethod exceed maxAttempts in fake")
-                .asRuntimeException());
+                .withDescription(
+                    String.format(
+                        Locale.US,
+                        "request received %d times, but only allowed %d times",
+                        attempts,
+                        maxAttempts))
+                .asRuntimeException(trailers);
+        respond.onError(t);
       } else {
         if (res != null) {
           respond.onNext(res);
@@ -1631,15 +1015,20 @@ public class ITAppendableUploadFakeTest {
     };
   }
 
-  private Consumer<StreamObserver<BidiWriteObjectResponse>> retryableErrorOnce(
-      BidiWriteObjectRequest req,
-      BidiWriteObjectResponse res,
-      Map<BidiWriteObjectRequest, Integer> retryMap,
+  private static Consumer<StreamObserver<BidiWriteObjectResponse>> retryableErrorOnce(
+      @NonNull BidiWriteObjectRequest req,
+      @NonNull Map<@NonNull BidiWriteObjectRequest, Integer> retryMap,
+      int maxAttempts) {
+    return retryableErrorOnce(req, null, retryMap, maxAttempts);
+  }
+
+  private static Consumer<StreamObserver<BidiWriteObjectResponse>> retryableErrorOnce(
+      @NonNull BidiWriteObjectRequest req,
+      @Nullable BidiWriteObjectResponse res,
+      @NonNull Map<@NonNull BidiWriteObjectRequest, Integer> retryMap,
       int maxAttempts) {
     return respond -> {
-      retryMap.putIfAbsent(req, 0);
-      int attempts = retryMap.get(req) + 1;
-      retryMap.put(req, attempts);
+      int attempts = retryMap.compute(req, (r, count) -> count == null ? 1 : count + 1);
       if (attempts == 1) {
         respond.onError(Status.INTERNAL.asRuntimeException());
       } else if (attempts > maxAttempts) {
@@ -1655,12 +1044,12 @@ public class ITAppendableUploadFakeTest {
     };
   }
 
-  private BidiWriteObjectRequest incrementalRequest(long offset, String content, boolean flush) {
+  private static BidiWriteObjectRequest incrementalRequest(
+      long offset, String content, boolean flush) {
     BidiWriteObjectRequest.Builder builder =
         BidiWriteObjectRequest.newBuilder()
             .setWriteOffset(offset)
-            .setChecksummedData(
-                ChecksummedData.newBuilder().setContent(ByteString.copyFromUtf8(content)));
+            .setChecksummedData(ChecksummedTestContent.of(content).asChecksummedData());
 
     if (flush) {
       builder.setFlush(true).setStateLookup(true);
@@ -1668,16 +1057,57 @@ public class ITAppendableUploadFakeTest {
     return builder.build();
   }
 
-  private BidiWriteObjectRequest incrementalRequest(long offset, String content) {
+  private static BidiWriteObjectRequest incrementalRequest(long offset, String content) {
     return incrementalRequest(offset, content, false);
   }
 
-  private BidiWriteObjectResponse incrementalResponse(long perSize) {
+  private static BidiWriteObjectResponse incrementalResponse(long perSize) {
     return BidiWriteObjectResponse.newBuilder().setPersistedSize(perSize).build();
   }
 
-  private BidiWriteObjectRequest finishMessage(long offset) {
+  private static BidiWriteObjectRequest finishMessage(long offset) {
     return BidiWriteObjectRequest.newBuilder().setWriteOffset(offset).setFinishWrite(true).build();
+  }
+
+  private static void runTestFlushMultipleSegments(FakeStorage fake) throws Exception {
+    try (FakeServer fakeServer = FakeServer.of(fake);
+        GrpcStorageImpl storage =
+            (GrpcStorageImpl) fakeServer.getGrpcStorageOptions().getService()) {
+
+      BidiWriteObjectRequest initialRequest =
+          BidiWriteObjectRequest.newBuilder()
+              .setWriteObjectSpec(
+                  WriteObjectSpec.newBuilder()
+                      .setResource(
+                          Object.newBuilder()
+                              .setBucket(METADATA.getBucket())
+                              .setName(METADATA.getName()))
+                      .setAppendable(true)
+                      .build())
+              .build();
+      AppendableUploadState state =
+          BidiUploadState.appendableNew(
+              initialRequest,
+              GrpcCallContext::createDefault,
+              32,
+              SettableApiFuture.create(),
+              Crc32cValue.zero());
+      BidiUploadStreamingStream stream =
+          new BidiUploadStreamingStream(
+              state,
+              storage.storageDataClient.executor,
+              storage.storageClient.bidiWriteObjectCallable(),
+              3,
+              storage.storageDataClient.retryContextProvider.create());
+      BidiAppendableUnbufferedWritableByteChannel channel =
+          new BidiAppendableUnbufferedWritableByteChannel(stream, smallSegmenter, 0);
+      channel.write(ByteBuffer.wrap(content.getBytes()));
+      channel.nextWriteShouldFinalize();
+      channel.close();
+      BidiWriteObjectResponse response = stream.getResultFuture().get(777, TimeUnit.MILLISECONDS);
+      assertThat(response.getResource().getSize()).isEqualTo(10);
+      assertThat(response.getResource().getChecksums().getCrc32C()).isEqualTo(content.getCrc32c());
+    }
   }
 
   static final class FakeStorage extends StorageGrpc.StorageImplBase {
@@ -1727,7 +1157,6 @@ public class ITAppendableUploadFakeTest {
       };
     }
 
-    @SuppressWarnings("StringBufferReplaceableByString")
     static @NonNull StatusRuntimeException unexpectedRequest(
         Message req, Collection<? extends Message> messages) {
       DebugInfo details =
@@ -1762,10 +1191,6 @@ public class ITAppendableUploadFakeTest {
         Map<BidiWriteObjectRequest, Consumer<StreamObserver<BidiWriteObjectResponse>>> db,
         Map<GetObjectRequest, Object> getdb) {
       return new FakeStorage(db, getdb);
-    }
-
-    static FakeStorage from(Map<BidiWriteObjectRequest, BidiWriteObjectResponse> db) {
-      return new FakeStorage(Maps.transformValues(db, resp -> (respond) -> respond.onNext(resp)));
     }
   }
 


### PR DESCRIPTION
* Add incremental checksums to all messages
* Add final object_checksums for all finalization
* Remove tests that were testing the same thing -- especially when the setup was fairly involved
* Remove some Integration tests that are now covered by unit tests of the bidi stream / bidi upload state (redirect limits, etc)
* Refactor lots of common messages and test run flows to reduce duplication and make debugging easier
* Ignore some tests that previously would partially split data rather than messages -- the current implementation only evicts when a whole message is consumed
* In general, signal `onComplete()` after `onNext` in response to a finalize message
* Update ITAppendableUploadTest to run for multiple permutations of BlobAppendableUploadConfigs