### PR TITLE
chore: make DefaultBufferedWritableByteChannel capable of being non-blocking

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobAppendableUploadConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobAppendableUploadConfig.java
@@ -272,7 +272,7 @@ public final class BlobAppendableUploadConfig {
                     c = new BidiAppendableUnbufferedWritableByteChannel(stream, chunkSegmenter, 0);
                   }
                   return new AppendableObjectBufferedWritableByteChannel(
-                      flushPolicy.createBufferedChannel(c),
+                      flushPolicy.createBufferedChannel(c, /* blocking= */ false),
                       c,
                       this.closeAction == CloseAction.FINALIZE_WHEN_CLOSING);
                 },

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/FlushPolicy.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/FlushPolicy.java
@@ -86,7 +86,7 @@ public abstract class FlushPolicy {
   }
 
   abstract BufferedWritableByteChannel createBufferedChannel(
-      UnbufferedWritableByteChannel unbuffered);
+      UnbufferedWritableByteChannel unbuffered, boolean blocking);
 
   abstract long getMaxPendingBytes();
 
@@ -155,9 +155,10 @@ public abstract class FlushPolicy {
     }
 
     @Override
-    BufferedWritableByteChannel createBufferedChannel(UnbufferedWritableByteChannel unbuffered) {
+    BufferedWritableByteChannel createBufferedChannel(
+        UnbufferedWritableByteChannel unbuffered, boolean blocking) {
       return new DefaultBufferedWritableByteChannel(
-          BufferHandle.allocate(maxFlushSize), unbuffered);
+          BufferHandle.allocate(maxFlushSize), unbuffered, blocking);
     }
 
     @Override
@@ -264,9 +265,10 @@ public abstract class FlushPolicy {
     }
 
     @Override
-    BufferedWritableByteChannel createBufferedChannel(UnbufferedWritableByteChannel unbuffered) {
+    BufferedWritableByteChannel createBufferedChannel(
+        UnbufferedWritableByteChannel unbuffered, boolean blocking) {
       return new MinFlushBufferedWritableByteChannel(
-          BufferHandle.allocate(minFlushSize), unbuffered, false);
+          BufferHandle.allocate(minFlushSize), unbuffered, blocking);
     }
 
     @Override

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITAppendableUploadFakeTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITAppendableUploadFakeTest.java
@@ -491,7 +491,7 @@ public class ITAppendableUploadFakeTest {
               smallSegmenter,
               0);
       ChecksummedTestContent content = ChecksummedTestContent.of(ALL_OBJECT_BYTES, 0, 10);
-      channel.write(ByteBuffer.wrap(content.getBytes()));
+      StorageChannelUtils.blockingEmptyTo(ByteBuffer.wrap(content.getBytes()), channel);
       channel.nextWriteShouldFinalize();
       channel.close();
       assertThat(done.get(777, TimeUnit.MILLISECONDS).getResource().getSize()).isEqualTo(10);
@@ -641,8 +641,8 @@ public class ITAppendableUploadFakeTest {
               0);
       ChecksummedTestContent content1 = ChecksummedTestContent.of(ALL_OBJECT_BYTES, 0, 10);
       ChecksummedTestContent content2 = ChecksummedTestContent.of(ALL_OBJECT_BYTES, 10, 10);
-      channel.write(ByteBuffer.wrap(content1.getBytes()));
-      channel.write(ByteBuffer.wrap(content2.getBytes()));
+      StorageChannelUtils.blockingEmptyTo(ByteBuffer.wrap(content1.getBytes()), channel);
+      StorageChannelUtils.blockingEmptyTo(ByteBuffer.wrap(content2.getBytes()), channel);
       channel.nextWriteShouldFinalize();
       channel.close();
       assertThat(done.get(777, TimeUnit.MILLISECONDS).getResource().getSize()).isEqualTo(20);
@@ -793,7 +793,7 @@ public class ITAppendableUploadFakeTest {
       BidiAppendableUnbufferedWritableByteChannel channel =
           new BidiAppendableUnbufferedWritableByteChannel(stream, smallSegmenter, 0);
       ChecksummedTestContent content = ChecksummedTestContent.of(ALL_OBJECT_BYTES, 0, 10);
-      channel.write(ByteBuffer.wrap(content.getBytes()));
+      StorageChannelUtils.blockingEmptyTo(ByteBuffer.wrap(content.getBytes()), channel);
       channel.nextWriteShouldFinalize();
       channel.close();
       assertThat(stream.getResultFuture().get(777, TimeUnit.MILLISECONDS).getResource().getSize())
@@ -912,7 +912,7 @@ public class ITAppendableUploadFakeTest {
       BlobAppendableUpload upload =
           storage.blobAppendableUpload(BlobInfo.newBuilder(id).build(), config);
       try (AppendableUploadWriteableByteChannel channel = upload.open()) {
-        channel.write(ByteBuffer.wrap(b));
+        StorageChannelUtils.blockingEmptyTo(ByteBuffer.wrap(b), channel);
       }
       ApiFuture<BlobInfo> result = upload.getResult();
       result.get(5, TimeUnit.SECONDS);
@@ -1050,7 +1050,7 @@ public class ITAppendableUploadFakeTest {
               storage.storageDataClient.retryContextProvider.create());
       BidiAppendableUnbufferedWritableByteChannel channel =
           new BidiAppendableUnbufferedWritableByteChannel(stream, smallSegmenter, 0);
-      channel.write(ByteBuffer.wrap(content.getBytes()));
+      StorageChannelUtils.blockingEmptyTo(ByteBuffer.wrap(content.getBytes()), channel);
       channel.nextWriteShouldFinalize();
       channel.close();
       BidiWriteObjectResponse response = stream.getResultFuture().get(777, TimeUnit.MILLISECONDS);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/MinFlushBufferedWritableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/MinFlushBufferedWritableByteChannelTest.java
@@ -28,6 +28,7 @@ import com.google.cloud.storage.DefaultBufferedWritableByteChannelTest.AuditingB
 import com.google.cloud.storage.DefaultBufferedWritableByteChannelTest.CountingWritableByteChannelAdapter;
 import com.google.cloud.storage.UnbufferedWritableByteChannelSession.UnbufferedWritableByteChannel;
 import com.google.cloud.storage.it.ChecksummedTestContent;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -661,16 +662,20 @@ public final class MinFlushBufferedWritableByteChannelTest {
     }
   }
 
-  private static final class OnlyConsumeNBytes implements UnbufferedWritableByteChannel {
+  static final class OnlyConsumeNBytes implements UnbufferedWritableByteChannel {
     private static final Logger LOGGER = LoggerFactory.getLogger(OnlyConsumeNBytes.class);
     private final long bytesToConsume;
     private final int consumptionIncrement;
     private long bytesConsumed;
 
-    private OnlyConsumeNBytes(int bytesToConsume, int consumptionIncrement) {
+    OnlyConsumeNBytes(int bytesToConsume, int consumptionIncrement) {
       this.bytesToConsume = bytesToConsume;
       this.consumptionIncrement = consumptionIncrement;
       this.bytesConsumed = 0;
+    }
+
+    long getBytesConsumed() {
+      return bytesConsumed;
     }
 
     @Override
@@ -706,5 +711,14 @@ public final class MinFlushBufferedWritableByteChannelTest {
 
     @Override
     public void close() {}
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("bytesToConsume", bytesToConsume)
+          .add("consumptionIncrement", consumptionIncrement)
+          .add("bytesConsumed", bytesConsumed)
+          .toString();
+    }
   }
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ChecksummedTestContent.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ChecksummedTestContent.java
@@ -30,6 +30,7 @@ import com.google.protobuf.UnsafeByteOperations;
 import com.google.storage.v2.BidiWriteObjectRequest;
 import com.google.storage.v2.ChecksummedData;
 import java.io.ByteArrayInputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -126,6 +127,10 @@ public final class ChecksummedTestContent {
 
   public BidiWriteObjectRequest.Builder asBidiWrite() {
     return BidiWriteObjectRequest.newBuilder().setChecksummedData(asChecksummedData());
+  }
+
+  public ByteBuffer asByteBuffer() {
+    return ByteBuffer.wrap(bytes);
   }
 
   @Override


### PR DESCRIPTION
non-blocking mode will only be used by appendable uploads, all existing usage will continue to use the existing blocking semantics.