### PR TITLE
fix: update BlobAppendableUploadConfig and FlushPolicy.MinFlushSizeFlushPolicy to default to 4MiB minFlushSize and 16MiB maxPendingBytes

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobAppendableUploadConfig.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobAppendableUploadConfig.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.storage;
 
-import static com.google.cloud.storage.ByteSizeConstants._256KiB;
 import static java.util.Objects.requireNonNull;
 
 import com.google.api.core.ApiFuture;
@@ -54,7 +53,7 @@ public final class BlobAppendableUploadConfig {
 
   private static final BlobAppendableUploadConfig INSTANCE =
       new BlobAppendableUploadConfig(
-          FlushPolicy.minFlushSize(_256KiB), CloseAction.CLOSE_WITHOUT_FINALIZING, 3);
+          FlushPolicy.minFlushSize(), CloseAction.CLOSE_WITHOUT_FINALIZING, 3);
 
   private final FlushPolicy flushPolicy;
   private final CloseAction closeAction;
@@ -71,7 +70,7 @@ public final class BlobAppendableUploadConfig {
    * The {@link FlushPolicy} which will be used to determine when and how many bytes to flush to
    * GCS.
    *
-   * <p><i>Default:</i> {@link FlushPolicy#minFlushSize(int) FlushPolicy.minFlushSize(256 * 1024)}
+   * <p><i>Default:</i> {@link FlushPolicy#minFlushSize()}
    *
    * @see #withFlushPolicy(FlushPolicy)
    * @since 2.51.0 This new api is in preview and is subject to breaking changes.
@@ -84,7 +83,7 @@ public final class BlobAppendableUploadConfig {
   /**
    * Return an instance with the {@code FlushPolicy} set to be the specified value.
    *
-   * <p><i>Default:</i> {@link FlushPolicy#minFlushSize(int) FlushPolicy.minFlushSize(256 * 1024)}
+   * <p><i>Default:</i> {@link FlushPolicy#minFlushSize()}
    *
    * @see #getFlushPolicy()
    * @since 2.51.0 This new api is in preview and is subject to breaking changes.

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/ByteSizeConstants.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/ByteSizeConstants.java
@@ -26,6 +26,7 @@ final class ByteSizeConstants {
   static final int _768KiB = 768 * _1KiB;
   static final int _1MiB = 1024 * _1KiB;
   static final int _2MiB = 2 * _1MiB;
+  static final int _4MiB = 4 * _1MiB;
   static final int _16MiB = 16 * _1MiB;
   static final int _32MiB = 32 * _1MiB;
   static final long _1GiB = 1024 * _1MiB;

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/FlushPolicy.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/FlushPolicy.java
@@ -18,6 +18,7 @@ package com.google.cloud.storage;
 
 import static com.google.cloud.storage.ByteSizeConstants._16MiB;
 import static com.google.cloud.storage.ByteSizeConstants._2MiB;
+import static com.google.cloud.storage.ByteSizeConstants._4MiB;
 
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalExtensionOnly;
@@ -66,6 +67,13 @@ public abstract class FlushPolicy {
 
   /**
    * Default instance factory method for {@link MinFlushSizeFlushPolicy}.
+   *
+   * <p><i>Default:</i> logically equivalent to the following:
+   *
+   * <pre>
+   * {@link #minFlushSize(int) FlushPolicy.minFlushSize}(4 * 1024 * 1024)
+   *     .{@link MinFlushSizeFlushPolicy#withMaxPendingBytes(long) withMaxPendingBytes}(16 * 1024 * 1024)
+   * </pre>
    *
    * @since 2.51.0 This new api is in preview and is subject to breaking changes.
    */
@@ -204,7 +212,7 @@ public abstract class FlushPolicy {
   @BetaApi
   public static final class MinFlushSizeFlushPolicy extends FlushPolicy {
     private static final MinFlushSizeFlushPolicy INSTANCE =
-        new MinFlushSizeFlushPolicy(_2MiB, _16MiB);
+        new MinFlushSizeFlushPolicy(_4MiB, _16MiB);
 
     private final int minFlushSize;
     private final long maxPendingBytes;
@@ -217,7 +225,7 @@ public abstract class FlushPolicy {
     /**
      * The minimum number of bytes to include in each automatic flush
      *
-     * <p><i>Default:</i> {@code 2097152 (2 MiB)}
+     * <p><i>Default:</i> {@code 4194304 (4 MiB)}
      *
      * @see #withMinFlushSize(int)
      */
@@ -229,7 +237,7 @@ public abstract class FlushPolicy {
     /**
      * Return an instance with the {@code minFlushSize} set to the specified value.
      *
-     * <p><i>Default:</i> {@code 2097152 (2 MiB)}
+     * <p><i>Default:</i> {@code 4194304 (4 MiB)}
      *
      * @param minFlushSize The number of bytes to buffer before flushing.
      * @return The new instance

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/ITAppendableUploadTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/ITAppendableUploadTest.java
@@ -269,8 +269,9 @@ public final class ITAppendableUploadTest {
         ImmutableList.of(
             FlushPolicy.minFlushSize(1_000),
             FlushPolicy.minFlushSize(1_000).withMaxPendingBytes(5_000),
-            FlushPolicy.maxFlushSize(1_000),
-            FlushPolicy.maxFlushSize(500_000));
+            FlushPolicy.maxFlushSize(500_000),
+            FlushPolicy.minFlushSize(),
+            FlushPolicy.maxFlushSize());
     private static final ImmutableList<CloseAction> closeActions =
         ImmutableList.copyOf(CloseAction.values());
     public static final ImmutableList<Integer> objectSizes =


### PR DESCRIPTION
Workload: upload a series of objects as fast as possible using 12 workers to upload concurrently.

|        | minFlushSize | maxPendingBytes |  duration |
|--------|-------------:|----------------:|----------:|
| Before |       256KiB |            8MiB | 3.646 min |
| After  |         4MiB |           16MiB | 2.014 min |

Add default instances of FlushPolicy.{min,max}FlushSize() to parameters of ITAppendableUploadTest