### PR TITLE
feat: add AppendableUploadWriteableByteChannel#flush()

### DIFF
--- a/google-cloud-storage/clirr-ignored-differences.xml
+++ b/google-cloud-storage/clirr-ignored-differences.xml
@@ -184,4 +184,12 @@
     <method>int write(java.nio.ByteBuffer)</method>
   </difference>
 
+  <!-- @InternalExtensionOnly -->
+  <difference>
+    <differenceType>7012</differenceType>
+    <className>com/google/cloud/storage/BlobAppendableUpload$AppendableUploadWriteableByteChannel</className>
+    <method>void flush()</method>
+  </difference>
+
+
 </differences>

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BidiAppendableUnbufferedWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BidiAppendableUnbufferedWritableByteChannel.java
@@ -106,6 +106,11 @@ final class BidiAppendableUnbufferedWritableByteChannel implements UnbufferedWri
     this.nextWriteShouldFinalize = true;
   }
 
+  void flush() throws InterruptedException {
+    stream.flush();
+    stream.awaitAckOf(writeOffset);
+  }
+
   private long internalWrite(ByteBuffer[] srcs, int srcsOffset, int srcsLength) throws IOException {
     if (!open) {
       throw new ClosedChannelException();

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BidiUploadStreamingStream.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BidiUploadStreamingStream.java
@@ -218,6 +218,10 @@ final class BidiUploadStreamingStream {
     state.awaitTakeoverStateReconciliation(this::restart);
   }
 
+  void awaitAckOf(long writeOffset) throws InterruptedException {
+    state.awaitAck(writeOffset);
+  }
+
   /**
    * It is possible for this value to change after reading, however it is guaranteed that the amount
    * of available capacity will only ever increase.

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobAppendableUpload.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobAppendableUpload.java
@@ -127,6 +127,19 @@ public interface BlobAppendableUpload extends BlobWriteSession {
     /**
      * <b>This method is blocking</b>
      *
+     * <p>Block the invoking thread, waiting until the number of bytes written so far has been
+     * acknowledged by Google Cloud Storage.
+     *
+     * @throws IOException if an error happens while waiting for the flush to complete
+     * @throws java.io.InterruptedIOException if the current thread is interrupted while waiting
+     * @since 2.56.0 This new api is in preview and is subject to breaking changes.
+     */
+    @BetaApi
+    void flush() throws IOException;
+
+    /**
+     * <b>This method is blocking</b>
+     *
      * <p>Finalize the upload and close this instance to further {@link #write(ByteBuffer)}ing. This
      * will close any underlying stream and release any releasable resources once out of scope.
      *

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BufferedWritableByteChannelSession.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BufferedWritableByteChannelSession.java
@@ -24,6 +24,8 @@ interface BufferedWritableByteChannelSession<ResultT>
     extends WritableByteChannelSession<BufferedWritableByteChannel, ResultT> {
 
   interface BufferedWritableByteChannel extends WritableByteChannel {
+
+    /** Block the invoking thread until all written bytes are accepted by the lower layer */
     void flush() throws IOException;
   }
 }

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultBufferedWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/DefaultBufferedWritableByteChannel.java
@@ -200,7 +200,7 @@ final class DefaultBufferedWritableByteChannel implements BufferedWritableByteCh
 
   @Override
   public void flush() throws IOException {
-    if (enqueuedBytes()) {
+    while (enqueuedBytes()) {
       ByteBuffer buffer = handle.get();
       Buffers.flip(buffer);
       channel.write(buffer);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/MinFlushBufferedWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/MinFlushBufferedWritableByteChannel.java
@@ -155,7 +155,7 @@ final class MinFlushBufferedWritableByteChannel implements BufferedWritableByteC
 
   @Override
   public void flush() throws IOException {
-    if (enqueuedBytes()) {
+    while (enqueuedBytes()) {
       ByteBuffer buffer = handle.get();
       Buffers.flip(buffer);
       channel.write(buffer);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/OtelStorageDecorator.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/OtelStorageDecorator.java
@@ -2217,6 +2217,7 @@ final class OtelStorageDecorator implements Storage {
       @Override
       @BetaApi
       public void finalizeAndClose() throws IOException {
+        setScope();
         try {
           delegate.finalizeAndClose();
         } catch (IOException | RuntimeException e) {
@@ -2235,6 +2236,7 @@ final class OtelStorageDecorator implements Storage {
       @Override
       @BetaApi
       public void closeWithoutFinalizing() throws IOException {
+        setScope();
         try {
           delegate.closeWithoutFinalizing();
         } catch (IOException | RuntimeException e) {
@@ -2267,6 +2269,12 @@ final class OtelStorageDecorator implements Storage {
           uploadSpan.end();
           clearScope();
         }
+      }
+
+      @Override
+      public void flush() throws IOException {
+        setScope();
+        delegate.flush();
       }
 
       @Override

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/UnbufferedWritableByteChannelSession.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/UnbufferedWritableByteChannelSession.java
@@ -26,24 +26,30 @@ interface UnbufferedWritableByteChannelSession<ResultT>
     extends WritableByteChannelSession<UnbufferedWritableByteChannel, ResultT> {
 
   interface UnbufferedWritableByteChannel extends WritableByteChannel, GatheringByteChannel {
+
+    /** Default assumed to be blocking, non-blocking allowed but must be documented. */
     @Override
     default int write(ByteBuffer src) throws IOException {
       return Math.toIntExact(write(new ByteBuffer[] {src}, 0, 1));
     }
 
+    /** Default assumed to be blocking, non-blocking allowed but must be documented. */
     @Override
     default long write(ByteBuffer[] srcs) throws IOException {
       return write(srcs, 0, srcs.length);
     }
 
+    /** This method must block until terminal state is reached. */
     default int writeAndClose(ByteBuffer src) throws IOException {
       return Math.toIntExact(writeAndClose(new ByteBuffer[] {src}, 0, 1));
     }
 
+    /** This method must block until terminal state is reached. */
     default long writeAndClose(ByteBuffer[] srcs) throws IOException {
       return writeAndClose(srcs, 0, srcs.length);
     }
 
+    /** This method must block until terminal state is reached. */
     default long writeAndClose(ByteBuffer[] srcs, int offset, int length) throws IOException {
       long write = write(srcs, offset, length);
       close();

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/DefaultBufferedWritableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/DefaultBufferedWritableByteChannelTest.java
@@ -259,7 +259,7 @@ public final class DefaultBufferedWritableByteChannelTest {
 
       assertWithMessage("Unexpected total flushed length")
           .that(adapter.writeEndPoints)
-          .isEqualTo(ImmutableList.of(3L, 5L, 10L, 12L));
+          .isEqualTo(ImmutableList.of(3L, 5L, 6L, 11L, 12L));
       assertThat(baos.toByteArray()).isEqualTo(allData);
     }
   }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/MinFlushBufferedWritableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/MinFlushBufferedWritableByteChannelTest.java
@@ -338,7 +338,7 @@ public final class MinFlushBufferedWritableByteChannelTest {
 
       assertWithMessage("Unexpected total flushed length")
           .that(adapter.writeEndPoints)
-          .isEqualTo(ImmutableList.of(3L, 5L, 12L));
+          .isEqualTo(ImmutableList.of(3L, 5L, 6L, 12L));
       assertThat(baos.toByteArray()).isEqualTo(allData);
     }
   }


### PR DESCRIPTION
Allows blocking the invoking thread until the number of bytes acknowledged by GCS matches the number of written bytes prior to calling flush().