### PR TITLE
chore: update BlobInfo.contexts diff handling to be deep rather than shallow

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonConversions.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonConversions.java
@@ -260,7 +260,8 @@ final class JsonConversions {
 
   private final Codec<BlobInfo.ObjectCustomContextPayload, ObjectCustomContextPayload>
       objectCustomContextPayloadCodec =
-          Codec.of(this::objectCustomContextPayloadEncode, this::objectCustomContextPayloadDecode);
+          Codec.of(this::objectCustomContextPayloadEncode, this::objectCustomContextPayloadDecode)
+              .nullable();
 
   private JsonConversions() {}
 

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonUtils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonUtils.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonObjectParser;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.cloud.storage.UnifiedOpts.NamedField;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.MapDifference;
+import com.google.common.collect.MapDifference.ValueDifference;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+final class JsonUtils {
+
+  private static final Gson gson =
+      new GsonBuilder()
+          // ensure null values are not stripped, they are important to us
+          .serializeNulls()
+          .setPrettyPrinting()
+          .create();
+  @VisibleForTesting static final JsonObjectParser jop = new JsonObjectParser(new GsonFactory());
+  private static final Pattern array_part = Pattern.compile("(.*)\\[(\\d+)]");
+
+  private JsonUtils() {}
+
+  /**
+   * Given a GenericJson src, and a list of {@code fieldsForOutput} create a new GenericJson where
+   * every field specified in {@code fieldsForOutput} is present. If a field exists in {@code src}
+   * with a specified name, that value will be used. If the field does not exist in {@code src} it
+   * will be set to {@code null}.
+   */
+  static <T extends GenericJson> T getOutputJson(T src, Set<NamedField> fieldsForOutput) {
+    Set<String> fieldPaths =
+        fieldsForOutput.stream()
+            .map(NamedField::getApiaryName)
+            .collect(ImmutableSet.toImmutableSet());
+    try {
+      // The datamodel of the apiairy json representation doesn't have a common parent for all
+      // field types, rather than writing a significant amount of code to handle all of these types
+      // leverage Gson.
+      // 1. serialize the object to it's json string
+      // 2. load that back with gson
+      // 3. use gson's datamodel which is more sane to allow named field traversal and cross
+      //    selection
+      // 4. output the json string of the resulting gson object
+      // 5. deserialize the json string to the apiary model class.
+      String string = jop.getJsonFactory().toPrettyString(src);
+      JsonObject jsonObject = gson.fromJson(string, JsonObject.class);
+      JsonObject ret = getOutputJson(jsonObject, fieldPaths);
+      String json = gson.toJson(ret);
+      Class<? extends GenericJson> aClass = src.getClass();
+      //noinspection unchecked
+      Class<T> clazz = (Class<T>) aClass;
+      return jop.parseAndClose(new StringReader(json), clazz);
+    } catch (IOException e) {
+      // StringReader does not throw an IOException
+      throw StorageException.coalesce(e);
+    }
+  }
+
+  /**
+   * Given the provided {@code inputJson} flatten it to a Map&lt;String, String> where keys are the
+   * field path, and values are the string representation of the value. Then, create a
+   * Map&lt;String, String> by defining an entry for each value from {@code fieldsInOutput} with a
+   * null value. Then, diff the two maps retaining those entries that present in both, and adding
+   * entries that only exist in the right. Then, turn that diffed map back into a tree.
+   */
+  @VisibleForTesting
+  static @NonNull JsonObject getOutputJson(JsonObject inputJson, Set<String> fieldsInOutput) {
+
+    Map<String, String> l = flatten(inputJson);
+    Map<String, String> r = Utils.setToMap(fieldsInOutput, k -> null);
+
+    MapDifference<String, String> diff = Maps.difference(l, r);
+
+    // use hashmap so we can have null values
+    HashMap<String, String> flat = new HashMap<>();
+    Stream.of(
+            diff.entriesInCommon().entrySet().stream(),
+            diff.entriesOnlyOnRight().entrySet().stream(),
+            // if the key is present in both maps, but has a differing value select the value from
+            // the left side, as that is the value from inputJson
+            Maps.transformValues(diff.entriesDiffering(), ValueDifference::leftValue)
+                .entrySet()
+                .stream())
+        // flatten
+        .flatMap(x -> x)
+        .forEach(e -> flat.put(e.getKey(), e.getValue()));
+
+    return treeify(flat);
+  }
+
+  /**
+   * Given a {@link JsonObject} produce a map where keys represent the full field path using json
+   * traversal notation ({@code a.b.c.d}) and the value is the string representations of that leaf
+   * value.
+   *
+   * <p>Inverse of {@link #treeify(Map)}
+   *
+   * @see #treeify
+   */
+  @VisibleForTesting
+  static Map<String, String> flatten(JsonObject o) {
+    // use hashmap so we can have null values
+    HashMap<String, String> ret = new HashMap<>();
+    for (Entry<String, JsonElement> e : o.asMap().entrySet()) {
+      ret.putAll(flatten(e.getKey(), e.getValue()));
+    }
+    return ret;
+  }
+
+  /**
+   * Given a map where keys represent json field paths and values represent values, produce a {@link
+   * JsonObject} with the tree structure matching those paths and values.
+   *
+   * <p>Inverse of {@link #flatten(JsonObject)}
+   *
+   * @see #flatten(JsonObject)
+   */
+  @VisibleForTesting
+  static JsonObject treeify(Map<String, String> m) {
+    JsonObject o = new JsonObject();
+    for (Entry<String, String> e : m.entrySet()) {
+      String key = e.getKey();
+      String[] splits = key.split("\\.");
+      String leaf = splits[splits.length - 1];
+
+      JsonElement curr = o;
+      int currIdx = -1;
+      for (int i = 0, splitsEnd = splits.length, leafIdx = splitsEnd - 1; i < splitsEnd; i++) {
+        final String name;
+        final int idx;
+        {
+          String split = splits[i];
+          Matcher matcher = array_part.matcher(split);
+          if (matcher.matches()) {
+            name = matcher.group(1);
+            String idxString = matcher.group(2);
+            idx = Integer.parseInt(idxString);
+          } else {
+            idx = -1;
+            name = split;
+          }
+        }
+
+        if (curr.isJsonObject()) {
+          if (i != leafIdx) {
+            curr =
+                curr.getAsJsonObject()
+                    .asMap()
+                    .computeIfAbsent(
+                        name,
+                        s -> {
+                          if (idx > -1) {
+                            return new JsonArray();
+                          }
+                          return new JsonObject();
+                        });
+          } else if (idx > -1) {
+            curr = curr.getAsJsonObject().asMap().computeIfAbsent(name, s -> new JsonArray());
+          }
+          if (currIdx == -1) {
+            currIdx = idx;
+          } else {
+            currIdx = -1;
+          }
+        }
+
+        if (curr.isJsonArray()) {
+          JsonArray a = curr.getAsJsonArray();
+          int size = a.size();
+          int nullElementsToAdd = 0;
+          if (size < currIdx) {
+            nullElementsToAdd = currIdx - size;
+          }
+
+          for (int j = 0; j < nullElementsToAdd; j++) {
+            a.add(JsonNull.INSTANCE);
+          }
+        }
+
+        if (i == leafIdx) {
+          String v = e.getValue();
+          if (curr.isJsonObject()) {
+            curr.getAsJsonObject().addProperty(leaf, v);
+          } else if (curr.isJsonArray()) {
+            JsonArray a = curr.getAsJsonArray();
+            JsonElement toAdd;
+            if (idx != currIdx) {
+              JsonObject tmp = new JsonObject();
+              tmp.addProperty(leaf, v);
+              toAdd = tmp;
+            } else {
+              toAdd = v == null ? JsonNull.INSTANCE : new JsonPrimitive(v);
+            }
+
+            if (a.size() == currIdx) {
+              a.add(toAdd);
+            } else {
+              List<JsonElement> l = a.asList();
+              l.add(currIdx, toAdd);
+              // the add above will push all values after it down an index, we instead want to
+              // replace it. Remove the next index so we have the same overall size of array.
+              l.remove(currIdx + 1);
+            }
+          }
+        }
+      }
+    }
+    return o;
+  }
+
+  private static Map<String, String> flatten(String k, JsonElement e) {
+    HashMap<String, String> ret = new HashMap<>();
+    if (e.isJsonObject()) {
+      JsonObject o = e.getAsJsonObject();
+      for (Entry<String, JsonElement> oe : o.asMap().entrySet()) {
+        String prefix = k + "." + oe.getKey();
+        ret.putAll(flatten(prefix, oe.getValue()));
+      }
+    } else if (e.isJsonArray()) {
+      List<JsonElement> asList = e.getAsJsonArray().asList();
+      for (int i = 0, asListSize = asList.size(); i < asListSize; i++) {
+        JsonElement ee = asList.get(i);
+        ret.putAll(flatten(k + "[" + i + "]", ee));
+      }
+    } else if (e.isJsonNull()) {
+      ret.put(k, null);
+    } else {
+      ret.put(k, e.getAsString());
+    }
+    return ret;
+  }
+}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonUtils.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonUtils.java
@@ -63,7 +63,8 @@ final class JsonUtils {
    * with a specified name, that value will be used. If the field does not exist in {@code src} it
    * will be set to {@code null}.
    */
-  static <T extends GenericJson> T getOutputJson(T src, Set<NamedField> fieldsForOutput) {
+  static <T extends GenericJson> T getOutputJsonWithSelectedFields(
+      T src, Set<NamedField> fieldsForOutput) {
     Set<String> fieldPaths =
         fieldsForOutput.stream()
             .map(NamedField::getApiaryName)

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
@@ -85,6 +85,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -527,31 +528,57 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage, 
     } else {
       StorageObject tmp = codecs.blobInfo().encode(updated);
       StorageObject pb = new StorageObject();
-      Stream.of(
-              modifiedFields.stream(),
-              BlobField.REQUIRED_FIELDS.stream(),
-              Stream.of(BlobField.GENERATION))
-          .flatMap(s -> s) // .flatten()
-          .map(
-              f -> {
-                if (f instanceof NestedNamedField) {
-                  return ((NestedNamedField) f).getParent();
-                } else {
-                  return f;
+      ImmutableSet<NamedField> fields =
+          Stream.of(
+                  modifiedFields.stream(),
+                  BlobField.REQUIRED_FIELDS.stream(),
+                  Stream.of(BlobField.GENERATION))
+              .flatMap(s -> s)
+              .collect(ImmutableSet.toImmutableSet());
+
+      Map<NamedField, Set<NamedField>> fieldsByRoot = new HashMap<>();
+      {
+        for (NamedField f : fields) {
+          Set<NamedField> fieldSet =
+              fieldsByRoot.computeIfAbsent(NamedField.root(f), v -> new HashSet<>());
+          fieldSet.add(f);
+        }
+      }
+
+      fieldsByRoot.forEach(
+          (topLevelField, subFields) -> {
+            // only do the deep diffing for select fields, most fields simply use their top level
+            // name and don't have to worry about nesting.
+            // The following ifs are the same shape, but, they can not be collapsed. The iteration
+            // is per top-level field, and if you attempt to do the other at the same time you will
+            // potentially override its values.
+            if (topLevelField == BlobField.OBJECT_CONTEXTS) {
+              // our field names are from the root of the storage object, create a temporary
+              // instance that only contains the contexts
+              StorageObject storageObject = new StorageObject();
+              storageObject.setContexts(tmp.getContexts());
+              StorageObject outputJson = JsonUtils.getOutputJson(storageObject, subFields);
+              pb.setContexts(outputJson.getContexts());
+            } else if (topLevelField == BlobField.METADATA) {
+              // our field names are from the root of the storage object, create a temporary
+              // instance that only contains the metadata
+              StorageObject storageObject = new StorageObject();
+              storageObject.setMetadata(tmp.getMetadata());
+              StorageObject outputJson = JsonUtils.getOutputJson(storageObject, subFields);
+              pb.setMetadata(outputJson.getMetadata());
+            } else {
+              checkState(subFields.size() <= 1, "unexpected nested field(s) %s", subFields);
+              String jsonName = topLevelField.getApiaryName();
+              if (tmp.containsKey(jsonName)) {
+                pb.put(jsonName, tmp.get(jsonName));
+              } else {
+                BlobField lookup = BlobField.lookup(topLevelField);
+                if (lookup != null) {
+                  pb.put(jsonName, Data.nullOf(lookup.getJsonClass()));
                 }
-              })
-          .forEach(
-              field -> {
-                String jsonName = field.getApiaryName();
-                if (tmp.containsKey(jsonName)) {
-                  pb.put(jsonName, tmp.get(jsonName));
-                } else {
-                  BlobField lookup = BlobField.lookup(field);
-                  if (lookup != null) {
-                    pb.put(jsonName, Data.nullOf(lookup.getJsonClass()));
-                  }
-                }
-              });
+              }
+            }
+          });
 
       ResultRetryAlgorithm<?> algorithm = retryAlgorithmManager.getForObjectsUpdate(pb, optionsMap);
       return run(

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageImpl.java
@@ -557,14 +557,16 @@ final class StorageImpl extends BaseService<StorageOptions> implements Storage, 
               // instance that only contains the contexts
               StorageObject storageObject = new StorageObject();
               storageObject.setContexts(tmp.getContexts());
-              StorageObject outputJson = JsonUtils.getOutputJson(storageObject, subFields);
+              StorageObject outputJson =
+                  JsonUtils.getOutputJsonWithSelectedFields(storageObject, subFields);
               pb.setContexts(outputJson.getContexts());
             } else if (topLevelField == BlobField.METADATA) {
               // our field names are from the root of the storage object, create a temporary
               // instance that only contains the metadata
               StorageObject storageObject = new StorageObject();
               storageObject.setMetadata(tmp.getMetadata());
-              StorageObject outputJson = JsonUtils.getOutputJson(storageObject, subFields);
+              StorageObject outputJson =
+                  JsonUtils.getOutputJsonWithSelectedFields(storageObject, subFields);
               pb.setMetadata(outputJson.getMetadata());
             } else {
               checkState(subFields.size() <= 1, "unexpected nested field(s) %s", subFields);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/UnifiedOpts.java
@@ -3059,6 +3059,15 @@ final class UnifiedOpts {
     static NamedField nested(NamedField parent, NamedField child) {
       return new NestedNamedField(parent, child);
     }
+
+    static NamedField root(NamedField f) {
+      if (f instanceof NestedNamedField) {
+        NestedNamedField nested = (NestedNamedField) f;
+        return root(nested.getParent());
+      } else {
+        return f;
+      }
+    }
   }
 
   private static CommonObjectRequestParams.Builder customerSuppliedKey(

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/JsonUtilsTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/JsonUtilsTest.java
@@ -61,7 +61,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class JsonUtilsTest {
 
   @Example
-  public void getOutputJson_metadata() throws IOException {
+  public void getOutputJson_WithSelectedFields_metadata() throws IOException {
     StorageObject src = jop.parseAndClose(new StringReader(jsonString), StorageObject.class);
     StorageObject expected =
         new StorageObject()
@@ -79,13 +79,13 @@ public final class JsonUtilsTest {
             .flatMap(s -> s)
             .collect(ImmutableSet.toImmutableSet());
 
-    StorageObject dst = JsonUtils.getOutputJson(src, modifiedFields);
+    StorageObject dst = JsonUtils.getOutputJsonWithSelectedFields(src, modifiedFields);
 
     assertThat(dst).isEqualTo(expected);
   }
 
   @Example
-  public void getOutputJson_contexts() throws IOException {
+  public void getOutputJson_WithSelectedFields_contexts() throws IOException {
     StorageObject src = jop.parseAndClose(new StringReader(jsonString), StorageObject.class);
     StorageObject expected =
         new StorageObject()
@@ -105,13 +105,13 @@ public final class JsonUtilsTest {
             .collect(ImmutableSet.toImmutableSet());
     NamedField custom = nested.getParent();
 
-    StorageObject dst = JsonUtils.getOutputJson(src, modifiedFields);
+    StorageObject dst = JsonUtils.getOutputJsonWithSelectedFields(src, modifiedFields);
 
     assertThat(dst).isEqualTo(expected);
   }
 
   @Property(tries = 10_000)
-  void getOutputJson_works(@ForAll("jts") JsonTrimmingScenario s) {
+  void getOutputJson_WithSelectedFields_works(@ForAll("jts") JsonTrimmingScenario s) {
     JsonObject actual = JsonUtils.getOutputJson(s.original, s.fieldsToRetain);
 
     assertThat(actual).isEqualTo(s.expected);

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/JsonUtilsTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/JsonUtilsTest.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.cloud.storage.JsonUtils.jop;
+import static com.google.cloud.storage.TestUtils.hashMapOf;
+import static com.google.cloud.storage.UnifiedOpts.NamedField.literal;
+import static com.google.cloud.storage.UnifiedOpts.NamedField.nested;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.client.util.Data;
+import com.google.api.services.storage.model.ObjectCustomContextPayload;
+import com.google.api.services.storage.model.StorageObject;
+import com.google.api.services.storage.model.StorageObject.Contexts;
+import com.google.cloud.storage.Storage.BlobField;
+import com.google.cloud.storage.UnifiedOpts.NamedField;
+import com.google.cloud.storage.UnifiedOpts.NestedNamedField;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.Example;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.Tuple;
+import net.jqwik.api.arbitraries.SetArbitrary;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public final class JsonUtilsTest {
+
+  @Example
+  public void getOutputJson_metadata() throws IOException {
+    StorageObject src = jop.parseAndClose(new StringReader(jsonString), StorageObject.class);
+    StorageObject expected =
+        new StorageObject()
+            .setBucket("some-bucket")
+            .setName("some-name")
+            .setGeneration(1755811928351810L)
+            .setMetadata(hashMapOf("k1", Data.nullOf(String.class)));
+
+    NestedNamedField nested = (NestedNamedField) nested(literal("metadata"), literal("k1"));
+    ImmutableSet<NamedField> modifiedFields =
+        Stream.of(
+                BlobField.REQUIRED_FIELDS.stream(),
+                Stream.of(BlobField.GENERATION),
+                Stream.of(nested))
+            .flatMap(s -> s)
+            .collect(ImmutableSet.toImmutableSet());
+
+    StorageObject dst = JsonUtils.getOutputJson(src, modifiedFields);
+
+    assertThat(dst).isEqualTo(expected);
+  }
+
+  @Example
+  public void getOutputJson_contexts() throws IOException {
+    StorageObject src = jop.parseAndClose(new StringReader(jsonString), StorageObject.class);
+    StorageObject expected =
+        new StorageObject()
+            .setBucket("some-bucket")
+            .setName("some-name")
+            .setGeneration(1755811928351810L)
+            .setContexts(c(hashMapOf("k2", null)));
+
+    NestedNamedField nested =
+        (NestedNamedField) nested(nested(literal("contexts"), literal("custom")), literal("k2"));
+    ImmutableSet<NamedField> modifiedFields =
+        Stream.of(
+                BlobField.REQUIRED_FIELDS.stream(),
+                Stream.of(BlobField.GENERATION),
+                Stream.of(nested))
+            .flatMap(s -> s)
+            .collect(ImmutableSet.toImmutableSet());
+    NamedField custom = nested.getParent();
+
+    StorageObject dst = JsonUtils.getOutputJson(src, modifiedFields);
+
+    assertThat(dst).isEqualTo(expected);
+  }
+
+  @Property(tries = 10_000)
+  void getOutputJson_works(@ForAll("jts") JsonTrimmingScenario s) {
+    JsonObject actual = JsonUtils.getOutputJson(s.original, s.fieldsToRetain);
+
+    assertThat(actual).isEqualTo(s.expected);
+  }
+
+  @Provide("jts")
+  static Arbitrary<JsonTrimmingScenario> jsonTrimmingScenarioArbitrary() {
+    return fieldPaths()
+        .flatMap(
+            fieldPaths ->
+                Combinators.combine(
+                        // carry through our field paths as-is
+                        Arbitraries.just(fieldPaths),
+                        // create a new map that contains any number of the defined field paths
+                        // where we set the value to "3"
+                        // the value here isn't actually important, just that it's set to a non-null
+                        // value.
+                        Arbitraries.maps(Arbitraries.of(fieldPaths), Arbitraries.just("3")))
+                    .as(Tuple::of)
+                    .flatMap(
+                        t -> {
+                          Set<String> paths = t.get1();
+                          assertThat(paths).isNotNull();
+                          Map<String, String> m = t.get2();
+                          assertThat(m).isNotNull();
+
+                          return Combinators.combine(
+                                  // carry through our m as is
+                                  Arbitraries.just(m),
+                                  // select a subset of the field paths we want to make sure are
+                                  // present in the output object
+                                  Arbitraries.of(paths).set().ofMinSize(1).ofMaxSize(paths.size()))
+                              .as(JsonTrimmingScenario::of);
+                        }));
+  }
+
+  private static SetArbitrary<String> fieldPaths() {
+    return fieldPath().set().ofMinSize(1).ofMaxSize(30);
+  }
+
+  /**
+   * Generate a json field path with a depth between 1 and 4 (inclusive).
+   *
+   * <p>A json field path is of the form `a.b.c.d`
+   */
+  private static @NonNull Arbitrary<String> fieldPath() {
+    return Arbitraries.integers()
+        .between(1, 4)
+        .flatMap(
+            depth ->
+                Arbitraries.strings()
+                    .withCharRange('a', 'f')
+                    .ofLength(depth)
+                    .map(
+                        s -> {
+                          StringBuilder sb = new StringBuilder();
+                          char[] charArray = s.toCharArray();
+                          for (int i = 0; i < charArray.length; i++) {
+                            char c = charArray[i];
+                            sb.append(c);
+                            if (i == 0) {
+                              // add the overall length as part of the first key
+                              // this makes is it so different depth keys don't collide
+                              // and cause trouble for things like `a.a.a: 3` and `a.a.a.a: 4`
+                              sb.append(charArray.length);
+                            }
+                            if (i + 1 < charArray.length) {
+                              sb.append(".");
+                            }
+                          }
+                          return sb.toString();
+                        }));
+  }
+
+  @Example
+  public void treeify_flatten_roundtrip_withArray() {
+    JsonObject o = new JsonObject();
+    JsonArray a = new JsonArray();
+    JsonArray b = new JsonArray();
+    b.add(JsonNull.INSTANCE);
+    b.add(JsonNull.INSTANCE);
+    b.add(JsonNull.INSTANCE);
+    b.add("b3");
+    JsonObject a0 = new JsonObject();
+    a0.addProperty("id", "a0");
+    JsonObject a1 = new JsonObject();
+    a1.addProperty("id", "a1");
+    a.add(a0);
+    a.add(a1);
+    o.add("a", a);
+    o.add("b", b);
+
+    Map<String, @Nullable String> expected = new TreeMap<>();
+    expected.put("a[0].id", "a0");
+    expected.put("a[1].id", "a1");
+    expected.put("b[3]", "b3");
+    expected.put("b[2]", null);
+    expected.put("b[1]", null);
+    expected.put("b[0]", null);
+
+    Map<String, String> flatten = new TreeMap<>(JsonUtils.flatten(o));
+    assertThat(flatten).isEqualTo(expected);
+
+    JsonObject treeify = JsonUtils.treeify(expected);
+    assertThat(treeify).isEqualTo(o);
+  }
+
+  @Example
+  public void treeify_arrayWithHoles() {
+    JsonObject o = new JsonObject();
+    JsonArray b = new JsonArray();
+    b.add(JsonNull.INSTANCE);
+    b.add(JsonNull.INSTANCE);
+    b.add(JsonNull.INSTANCE);
+    b.add("b3");
+    o.add("b", b);
+
+    Map<String, @Nullable String> expected = new TreeMap<>();
+    expected.put("b[3]", "b3");
+
+    JsonObject treeify = JsonUtils.treeify(expected);
+    assertThat(treeify).isEqualTo(o);
+  }
+
+  @Example
+  public void treeify_flatten_roundtrip() {
+    ImmutableMap<String, String> m =
+        ImmutableMap.of(
+            "a.b.c.d", "D",
+            "a.b.c.e", "E",
+            "f.g", "G",
+            "h", "H",
+            "z.x.y", "Y");
+
+    JsonObject expected = new JsonObject();
+    JsonObject a = new JsonObject();
+    JsonObject b = new JsonObject();
+    JsonObject c = new JsonObject();
+    JsonObject f = new JsonObject();
+    JsonObject x = new JsonObject();
+    JsonObject z = new JsonObject();
+
+    x.addProperty("y", "Y");
+    z.add("x", x);
+    expected.add("z", z);
+
+    f.addProperty("g", "G");
+
+    c.addProperty("d", "D");
+    c.addProperty("e", "E");
+
+    b.add("c", c);
+    a.add("b", b);
+
+    expected.add("a", a);
+    expected.add("f", f);
+    expected.addProperty("h", "H");
+
+    JsonObject treeified = JsonUtils.treeify(m);
+    assertThat(treeified).isEqualTo(expected);
+
+    Map<String, String> flattened = JsonUtils.flatten(treeified);
+    assertThat(flattened).isEqualTo(m);
+  }
+
+  private static Contexts c(Map<String, String> m) {
+    Contexts contexts = new Contexts();
+    if (!m.isEmpty()) {
+      contexts.setCustom(Maps.transformValues(m, JsonUtilsTest::p));
+    }
+    return contexts;
+  }
+
+  private static @NonNull ObjectCustomContextPayload p(@Nullable String v) {
+    if (v == null) {
+      return Data.nullOf(ObjectCustomContextPayload.class);
+    }
+    return new ObjectCustomContextPayload().setValue(v);
+  }
+
+  private static final class JsonTrimmingScenario {
+    private static final Gson gson =
+        new GsonBuilder()
+            // ensure null values are not stripped, they are important to us
+            .serializeNulls()
+            .create();
+
+    private final JsonObject original;
+    private final TreeSet<String> fieldsToRetain;
+    private final JsonObject expected;
+
+    private JsonTrimmingScenario(
+        JsonObject original, TreeSet<String> fieldsToRetain, JsonObject expected) {
+      this.original = original;
+      this.fieldsToRetain = fieldsToRetain;
+      this.expected = expected;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("\noriginal", gson.toJson(original))
+          .add("\nfieldsToRetain", fieldsToRetain)
+          .add("\nexpected", gson.toJson(expected))
+          .toString();
+    }
+
+    public static JsonTrimmingScenario of(Map<String, String> m, Set<String> fieldsToRetain) {
+      TreeSet<String> ftr = new TreeSet<>(fieldsToRetain);
+      JsonObject original = JsonUtils.treeify(m);
+      HashMap<String, String> mm = new HashMap<>(Maps.filterKeys(m, fieldsToRetain::contains));
+      for (String f : fieldsToRetain) {
+        if (m.containsKey(f)) {
+          continue;
+        }
+
+        mm.put(f, null);
+      }
+      JsonObject expected = JsonUtils.treeify(mm);
+      return new JsonTrimmingScenario(original, ftr, expected);
+    }
+  }
+
+  // language=JSON
+  private static final String jsonString =
+      "{\n"
+          + "  \"bucket\": \"some-bucket\",\n"
+          + "  \"contentType\": \"application/octet-stream\",\n"
+          + "  \"crc32c\": \"AAAAAA\\u003d\\u003d\",\n"
+          + "  \"etag\": \"CMLIoJLtnI8DEAE\\u003d\",\n"
+          + "  \"generation\": \"1755811928351810\",\n"
+          + "  \"id\": \"some-bucket/some-name/1755811928351810\",\n"
+          + "  \"md5Hash\": \"1B2M2Y8AsgTpgAmY7PhCfg\\u003d\\u003d\",\n"
+          + "  \"mediaLink\": \"https://storage.googleapis.com/download/storage/v1/b/some-bucket/o/some-name?generation\\u003d1755811928351810\\u0026alt\\u003dmedia\",\n"
+          + "  \"metadata\": {\n"
+          + "    \"k1\": \"\"\n"
+          + "  },\n"
+          + "  \"metageneration\": \"1\",\n"
+          + "  \"name\": \"some-name\",\n"
+          + "  \"selfLink\": \"https://www.googleapis.com/storage/v1/b/some-bucket/o/some-name\",\n"
+          + "  \"storageClass\": \"STANDARD\",\n"
+          + "  \"contexts\": {\n"
+          + "    \"custom\": {\n"
+          + "      \"k2\": null,\n"
+          + "      \"k3\": {\n"
+          + "        \"value\": \"glavin\"\n"
+          + "      }\n"
+          + "    }\n"
+          + "  }\n"
+          + "}";
+}


### PR DESCRIPTION
Add JsonUtils class to provide some helpers for performing arbitrarily deep field selection. Our existing implementation is flat for everything exception metadata, with the addition of object contexts we now have an N depth diff (metadata is always depth 2, but a context path is `contexts.custom.<key>.value`) and the value of the key is an object instead of a string. We accomplish this arbitrary diffing by first flattening the src object to a map of paths to leaves and their corresponding string values. Then we diff the keys to produce a new map, and then treeify that new map back to a json structure.

This is quite robust, but isn't terribly efficient so we only use it for contexts and metadata fields.

Update BlobInfo.BuilderImpl#setContexts to deeply resolve the diff against the provided value.

Update BlobInfo object contexts maps to use unmodifiable hashmaps instead of ImmutableMap. ImmutableMap doesn't allow null values, but we need to accept null values to allow customers to remove individual values.

Add object contexts to the existing ITNestedUpdateMaskTest.

gRPC didn't require any special handling as it's `update_mask` already takes care of things appropriately after the deep diffing is added.

