### PR TITLE
samples(fix): update all samples to apply try-with-resource to clients

### DIFF
--- a/samples/snippets/src/main/java/com/example/storage/ConfigureRetries.java
+++ b/samples/snippets/src/main/java/com/example/storage/ConfigureRetries.java
@@ -60,8 +60,8 @@ public final class ConfigureRetries {
       boolean success = storage.delete(blobId);
 
       System.out.printf(
-          "Deletion of Blob %s completed %s.%n", blobId,
-          success ? "successfully" : "unsuccessfully");
+          "Deletion of Blob %s completed %s.%n",
+          blobId, success ? "successfully" : "unsuccessfully");
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/ConfigureRetries.java
+++ b/samples/snippets/src/main/java/com/example/storage/ConfigureRetries.java
@@ -26,13 +26,13 @@ import com.google.cloud.storage.StorageRetryStrategy;
 import org.threeten.bp.Duration;
 
 public final class ConfigureRetries {
-  public static void main(String[] args) {
+  public static void main(String[] args) throws Exception {
     String bucketName = "my-bucket";
     String blobName = "blob/to/delete";
     deleteBlob(bucketName, blobName);
   }
 
-  static void deleteBlob(String bucketName, String blobName) {
+  static void deleteBlob(String bucketName, String blobName) throws Exception {
     // Customize retry behavior
     RetrySettings retrySettings =
         StorageOptions.getDefaultRetrySettings().toBuilder()
@@ -53,14 +53,16 @@ public final class ConfigureRetries {
             .build();
 
     // Instantiate a client
-    Storage storage = alwaysRetryStorageOptions.getService();
+    try (Storage storage = alwaysRetryStorageOptions.getService()) {
 
-    // Delete the blob
-    BlobId blobId = BlobId.of(bucketName, blobName);
-    boolean success = storage.delete(blobId);
+      // Delete the blob
+      BlobId blobId = BlobId.of(bucketName, blobName);
+      boolean success = storage.delete(blobId);
 
-    System.out.printf(
-        "Deletion of Blob %s completed %s.%n", blobId, success ? "successfully" : "unsuccessfully");
+      System.out.printf(
+          "Deletion of Blob %s completed %s.%n", blobId,
+          success ? "successfully" : "unsuccessfully");
+    }
   }
 }
 // [END storage_configure_retries]

--- a/samples/snippets/src/main/java/com/example/storage/GenerateSignedPostPolicyV4.java
+++ b/samples/snippets/src/main/java/com/example/storage/GenerateSignedPostPolicyV4.java
@@ -37,7 +37,7 @@ public class GenerateSignedPostPolicyV4 {
    * Storage.generateSignedPostPolicyV4 for more details.
    */
   public static void generateSignedPostPolicyV4(
-      String projectId, String bucketName, String blobName) {
+      String projectId, String bucketName, String blobName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -47,37 +47,39 @@ public class GenerateSignedPostPolicyV4 {
     // The name to give the object uploaded to GCS
     // String blobName = "your-object-name"
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    StorageOptions storageOptions = StorageOptions.newBuilder().setProjectId(projectId).build();
+    try (Storage storage = storageOptions.getService()) {
 
-    PostPolicyV4.PostFieldsV4 fields =
-        PostPolicyV4.PostFieldsV4.newBuilder().setCustomMetadataField("test", "data").build();
+      PostPolicyV4.PostFieldsV4 fields =
+          PostPolicyV4.PostFieldsV4.newBuilder().setCustomMetadataField("test", "data").build();
 
-    PostPolicyV4 policy =
-        storage.generateSignedPostPolicyV4(
-            BlobInfo.newBuilder(bucketName, blobName).build(), 10, TimeUnit.MINUTES, fields);
+      PostPolicyV4 policy =
+          storage.generateSignedPostPolicyV4(
+              BlobInfo.newBuilder(bucketName, blobName).build(), 10, TimeUnit.MINUTES, fields);
 
-    StringBuilder htmlForm =
-        new StringBuilder(
-            "<form action='"
-                + policy.getUrl()
-                + "' method='POST' enctype='multipart/form-data'>\n");
-    for (Map.Entry<String, String> entry : policy.getFields().entrySet()) {
-      htmlForm.append(
-          "  <input name='"
-              + entry.getKey()
-              + "' value='"
-              + entry.getValue()
-              + "' type='hidden' />\n");
+      StringBuilder htmlForm =
+          new StringBuilder(
+              "<form action='"
+                  + policy.getUrl()
+                  + "' method='POST' enctype='multipart/form-data'>\n");
+      for (Map.Entry<String, String> entry : policy.getFields().entrySet()) {
+        htmlForm.append(
+            "  <input name='"
+                + entry.getKey()
+                + "' value='"
+                + entry.getValue()
+                + "' type='hidden' />\n");
+      }
+      htmlForm.append("  <input type='file' name='file'/><br />\n");
+      htmlForm.append("  <input type='submit' value='Upload File'/><br />\n");
+      htmlForm.append("</form>\n");
+
+      System.out.println(
+          "You can use the following HTML form to upload an object to bucket "
+              + bucketName
+              + " for the next ten minutes:");
+      System.out.println(htmlForm.toString());
     }
-    htmlForm.append("  <input type='file' name='file'/><br />\n");
-    htmlForm.append("  <input type='submit' value='Upload File'/><br />\n");
-    htmlForm.append("</form>\n");
-
-    System.out.println(
-        "You can use the following HTML form to upload an object to bucket "
-            + bucketName
-            + " for the next ten minutes:");
-    System.out.println(htmlForm.toString());
   }
 }
 // [END storage_generate_signed_post_policy_v4]

--- a/samples/snippets/src/main/java/com/example/storage/GetServiceAccount.java
+++ b/samples/snippets/src/main/java/com/example/storage/GetServiceAccount.java
@@ -22,14 +22,16 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class GetServiceAccount {
-  public static void getServiceAccount(String projectId) {
+  public static void getServiceAccount(String projectId) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
-    ServiceAccount serviceAccount = storage.getServiceAccount(projectId);
-    System.out.println(
-        "The GCS service account for project " + projectId + " is: " + serviceAccount.getEmail());
+    StorageOptions storageOptions = StorageOptions.newBuilder().setProjectId(projectId).build();
+    try (Storage storage = storageOptions.getService()) {
+      ServiceAccount serviceAccount = storage.getServiceAccount(projectId);
+      System.out.println(
+          "The GCS service account for project " + projectId + " is: " + serviceAccount.getEmail());
+    }
   }
 }
 // [END storage_get_service_account]

--- a/samples/snippets/src/main/java/com/example/storage/QuickstartOpenTelemetrySample.java
+++ b/samples/snippets/src/main/java/com/example/storage/QuickstartOpenTelemetrySample.java
@@ -51,7 +51,8 @@ public class QuickstartOpenTelemetrySample {
                     .build())
             .build();
     StorageOptions options = StorageOptions.newBuilder().setOpenTelemetry(openTelemetry).build();
-    try (OpenTelemetrySdk otel = openTelemetry; Storage storage = options.getService()) {
+    try (OpenTelemetrySdk otel = openTelemetry;
+        Storage storage = options.getService()) {
       System.out.println("Created an instance of storage with OpenTelemetry configured");
     }
   }

--- a/samples/snippets/src/main/java/com/example/storage/QuickstartOpenTelemetrySample.java
+++ b/samples/snippets/src/main/java/com/example/storage/QuickstartOpenTelemetrySample.java
@@ -51,8 +51,9 @@ public class QuickstartOpenTelemetrySample {
                     .build())
             .build();
     StorageOptions options = StorageOptions.newBuilder().setOpenTelemetry(openTelemetry).build();
-    Storage storage = options.getService();
-    System.out.println("Created an instance of storage with OpenTelemetry configured");
+    try (OpenTelemetrySdk otel = openTelemetry; Storage storage = options.getService()) {
+      System.out.println("Created an instance of storage with OpenTelemetry configured");
+    }
   }
 }
 // [END storage_enable_otel_tracing]

--- a/samples/snippets/src/main/java/com/example/storage/QuickstartSample.java
+++ b/samples/snippets/src/main/java/com/example/storage/QuickstartSample.java
@@ -26,15 +26,16 @@ import com.google.cloud.storage.StorageOptions;
 public class QuickstartSample {
   public static void main(String... args) throws Exception {
     // Instantiates a client
-    Storage storage = StorageOptions.getDefaultInstance().getService();
+    try (Storage storage = StorageOptions.getDefaultInstance().getService()) {
 
-    // The name for the new bucket
-    String bucketName = args[0]; // "my-new-bucket";
+      // The name for the new bucket
+      String bucketName = args[0]; // "my-new-bucket";
 
-    // Creates the new bucket
-    Bucket bucket = storage.create(BucketInfo.of(bucketName));
+      // Creates the new bucket
+      Bucket bucket = storage.create(BucketInfo.of(bucketName));
 
-    System.out.printf("Bucket %s created.%n", bucket.getName());
+      System.out.printf("Bucket %s created.%n", bucket.getName());
+    }
   }
 }
 // [END storage_quickstart]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketDefaultOwner.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketDefaultOwner.java
@@ -27,7 +27,7 @@ import com.google.cloud.storage.StorageOptions;
 
 public class AddBucketDefaultOwner {
 
-  public static void addBucketDefaultOwner(String bucketName, String userEmail) {
+  public static void addBucketDefaultOwner(String bucketName, String userEmail) throws Exception {
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
@@ -35,12 +35,13 @@ public class AddBucketDefaultOwner {
     // The email of the user you wish to add as a default owner
     // String userEmail = "someuser@domain.com"
 
-    Storage storage = StorageOptions.newBuilder().build().getService();
-    Bucket bucket = storage.get(bucketName);
-    Acl newDefaultOwner = Acl.of(new User(userEmail), Role.OWNER);
+    try (Storage storage = StorageOptions.newBuilder().build().getService()) {
+      Bucket bucket = storage.get(bucketName);
+      Acl newDefaultOwner = Acl.of(new User(userEmail), Role.OWNER);
 
-    bucket.createDefaultAcl(newDefaultOwner);
-    System.out.println("Added user " + userEmail + " as an owner on " + bucketName);
+      bucket.createDefaultAcl(newDefaultOwner);
+      System.out.println("Added user " + userEmail + " as an owner on " + bucketName);
+    }
   }
 }
 // [END storage_add_bucket_default_owner]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketIamConditionalBinding.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketIamConditionalBinding.java
@@ -39,7 +39,8 @@ public class AddBucketIamConditionalBinding {
 
     // For more information please read:
     // https://cloud.google.com/storage/docs/access-control/iam
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
       Policy originalPolicy =
           storage.getIamPolicy(bucketName, Storage.BucketSourceOption.requestedPolicyVersion(3));

--- a/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketIamConditionalBinding.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketIamConditionalBinding.java
@@ -29,7 +29,8 @@ import java.util.List;
 
 public class AddBucketIamConditionalBinding {
   /** Example of adding a conditional binding to the Bucket-level IAM */
-  public static void addBucketIamConditionalBinding(String projectId, String bucketName) {
+  public static void addBucketIamConditionalBinding(String projectId, String bucketName)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -38,44 +39,45 @@ public class AddBucketIamConditionalBinding {
 
     // For more information please read:
     // https://cloud.google.com/storage/docs/access-control/iam
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    Policy originalPolicy =
-        storage.getIamPolicy(bucketName, Storage.BucketSourceOption.requestedPolicyVersion(3));
+      Policy originalPolicy =
+          storage.getIamPolicy(bucketName, Storage.BucketSourceOption.requestedPolicyVersion(3));
 
-    String role = "roles/storage.objectViewer";
-    String member = "group:example@google.com";
+      String role = "roles/storage.objectViewer";
+      String member = "group:example@google.com";
 
-    // Create a condition
-    String conditionTitle = "Title";
-    String conditionDescription = "Description";
-    String conditionExpression =
-        "resource.name.startsWith(\"projects/_/buckets/bucket-name/objects/prefix-a-\")";
-    Condition.Builder conditionBuilder = Condition.newBuilder();
-    conditionBuilder.setTitle(conditionTitle);
-    conditionBuilder.setDescription(conditionDescription);
-    conditionBuilder.setExpression(conditionExpression);
+      // Create a condition
+      String conditionTitle = "Title";
+      String conditionDescription = "Description";
+      String conditionExpression =
+          "resource.name.startsWith(\"projects/_/buckets/bucket-name/objects/prefix-a-\")";
+      Condition.Builder conditionBuilder = Condition.newBuilder();
+      conditionBuilder.setTitle(conditionTitle);
+      conditionBuilder.setDescription(conditionDescription);
+      conditionBuilder.setExpression(conditionExpression);
 
-    // getBindingsList() returns an ImmutableList, we copy over to an ArrayList so it's mutable
-    List<Binding> bindings = new ArrayList(originalPolicy.getBindingsList());
+      // getBindingsList() returns an ImmutableList, we copy over to an ArrayList so it's mutable
+      List<Binding> bindings = new ArrayList(originalPolicy.getBindingsList());
 
-    // Add condition to a binding
-    Binding.Builder newBindingBuilder =
-        Binding.newBuilder()
-            .setRole(role)
-            .setMembers(Arrays.asList(member))
-            .setCondition(conditionBuilder.build());
-    bindings.add(newBindingBuilder.build());
+      // Add condition to a binding
+      Binding.Builder newBindingBuilder =
+          Binding.newBuilder()
+              .setRole(role)
+              .setMembers(Arrays.asList(member))
+              .setCondition(conditionBuilder.build());
+      bindings.add(newBindingBuilder.build());
 
-    // Update policy with new conditional binding
-    Policy.Builder updatedPolicyBuilder = originalPolicy.toBuilder();
-    updatedPolicyBuilder.setBindings(bindings).setVersion(3);
+      // Update policy with new conditional binding
+      Policy.Builder updatedPolicyBuilder = originalPolicy.toBuilder();
+      updatedPolicyBuilder.setBindings(bindings).setVersion(3);
 
-    storage.setIamPolicy(bucketName, updatedPolicyBuilder.build());
+      storage.setIamPolicy(bucketName, updatedPolicyBuilder.build());
 
-    System.out.printf(
-        "Added %s with role %s to %s with condition %s %s %s\n",
-        member, role, bucketName, conditionTitle, conditionDescription, conditionExpression);
+      System.out.printf(
+          "Added %s with role %s to %s with condition %s %s %s\n",
+          member, role, bucketName, conditionTitle, conditionDescription, conditionExpression);
+    }
   }
 }
 // [END storage_add_bucket_conditional_iam_binding]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketIamMember.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketIamMember.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 public class AddBucketIamMember {
   /** Example of adding a member to the Bucket-level IAM */
-  public static void addBucketIamMember(String projectId, String bucketName) {
+  public static void addBucketIamMember(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -37,28 +37,29 @@ public class AddBucketIamMember {
 
     // For more information please read:
     // https://cloud.google.com/storage/docs/access-control/iam
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    Policy originalPolicy =
-        storage.getIamPolicy(bucketName, Storage.BucketSourceOption.requestedPolicyVersion(3));
+      Policy originalPolicy =
+          storage.getIamPolicy(bucketName, Storage.BucketSourceOption.requestedPolicyVersion(3));
 
-    String role = "roles/storage.objectViewer";
-    String member = "group:example@google.com";
+      String role = "roles/storage.objectViewer";
+      String member = "group:example@google.com";
 
-    // getBindingsList() returns an ImmutableList and copying over to an ArrayList so it's mutable.
-    List<Binding> bindings = new ArrayList(originalPolicy.getBindingsList());
+      // getBindingsList() returns an ImmutableList and copying over to an ArrayList so it's mutable.
+      List<Binding> bindings = new ArrayList(originalPolicy.getBindingsList());
 
-    // Create a new binding using role and member
-    Binding.Builder newMemberBindingBuilder = Binding.newBuilder();
-    newMemberBindingBuilder.setRole(role).setMembers(Arrays.asList(member));
-    bindings.add(newMemberBindingBuilder.build());
+      // Create a new binding using role and member
+      Binding.Builder newMemberBindingBuilder = Binding.newBuilder();
+      newMemberBindingBuilder.setRole(role).setMembers(Arrays.asList(member));
+      bindings.add(newMemberBindingBuilder.build());
 
-    // Update policy to add member
-    Policy.Builder updatedPolicyBuilder = originalPolicy.toBuilder();
-    updatedPolicyBuilder.setBindings(bindings).setVersion(3);
-    Policy updatedPolicy = storage.setIamPolicy(bucketName, updatedPolicyBuilder.build());
+      // Update policy to add member
+      Policy.Builder updatedPolicyBuilder = originalPolicy.toBuilder();
+      updatedPolicyBuilder.setBindings(bindings).setVersion(3);
+      Policy updatedPolicy = storage.setIamPolicy(bucketName, updatedPolicyBuilder.build());
 
-    System.out.printf("Added %s with role %s to %s\n", member, role, bucketName);
+      System.out.printf("Added %s with role %s to %s\n", member, role, bucketName);
+    }
   }
 }
 // [END storage_add_bucket_iam_member]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketIamMember.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketIamMember.java
@@ -37,7 +37,8 @@ public class AddBucketIamMember {
 
     // For more information please read:
     // https://cloud.google.com/storage/docs/access-control/iam
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
       Policy originalPolicy =
           storage.getIamPolicy(bucketName, Storage.BucketSourceOption.requestedPolicyVersion(3));
@@ -45,7 +46,8 @@ public class AddBucketIamMember {
       String role = "roles/storage.objectViewer";
       String member = "group:example@google.com";
 
-      // getBindingsList() returns an ImmutableList and copying over to an ArrayList so it's mutable.
+      // getBindingsList() returns an ImmutableList and copying over to an ArrayList so it's
+      // mutable.
       List<Binding> bindings = new ArrayList(originalPolicy.getBindingsList());
 
       // Create a new binding using role and member

--- a/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketLabel.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketLabel.java
@@ -42,7 +42,8 @@ public class AddBucketLabel {
     Map<String, String> newLabels = new HashMap<>();
     newLabels.put(labelKey, labelValue);
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
       Bucket bucket = storage.get(bucketName);
       Map<String, String> labels = bucket.getLabels();
       if (labels != null) {
@@ -51,7 +52,12 @@ public class AddBucketLabel {
       bucket.toBuilder().setLabels(newLabels).build().update();
 
       System.out.println(
-          "Added label " + labelKey + " with value " + labelValue + " to bucket " + bucketName
+          "Added label "
+              + labelKey
+              + " with value "
+              + labelValue
+              + " to bucket "
+              + bucketName
               + ".");
     }
   }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketLabel.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketLabel.java
@@ -26,7 +26,7 @@ import java.util.Map;
 
 public class AddBucketLabel {
   public static void addBucketLabel(
-      String projectId, String bucketName, String labelKey, String labelValue) {
+      String projectId, String bucketName, String labelKey, String labelValue) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -42,16 +42,18 @@ public class AddBucketLabel {
     Map<String, String> newLabels = new HashMap<>();
     newLabels.put(labelKey, labelValue);
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
-    Bucket bucket = storage.get(bucketName);
-    Map<String, String> labels = bucket.getLabels();
-    if (labels != null) {
-      newLabels.putAll(labels);
-    }
-    bucket.toBuilder().setLabels(newLabels).build().update();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
+      Map<String, String> labels = bucket.getLabels();
+      if (labels != null) {
+        newLabels.putAll(labels);
+      }
+      bucket.toBuilder().setLabels(newLabels).build().update();
 
-    System.out.println(
-        "Added label " + labelKey + " with value " + labelValue + " to bucket " + bucketName + ".");
+      System.out.println(
+          "Added label " + labelKey + " with value " + labelValue + " to bucket " + bucketName
+              + ".");
+    }
   }
 }
 // [END storage_add_bucket_label]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketOwner.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketOwner.java
@@ -38,7 +38,8 @@ public class AddBucketOwner {
     // Email of the user you wish to add as an owner
     // String userEmail = "someuser@domain.com"
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
       Bucket bucket = storage.get(bucketName);
       Acl newOwner = Acl.of(new User(userEmail), Role.OWNER);
 

--- a/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketOwner.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/AddBucketOwner.java
@@ -27,7 +27,8 @@ import com.google.cloud.storage.StorageOptions;
 
 public class AddBucketOwner {
 
-  public static void addBucketOwner(String projectId, String bucketName, String userEmail) {
+  public static void addBucketOwner(String projectId, String bucketName, String userEmail)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -37,12 +38,13 @@ public class AddBucketOwner {
     // Email of the user you wish to add as an owner
     // String userEmail = "someuser@domain.com"
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
-    Bucket bucket = storage.get(bucketName);
-    Acl newOwner = Acl.of(new User(userEmail), Role.OWNER);
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
+      Acl newOwner = Acl.of(new User(userEmail), Role.OWNER);
 
-    bucket.createAcl(newOwner);
-    System.out.println("Added user " + userEmail + " as an owner on " + bucketName);
+      bucket.createAcl(newOwner);
+      System.out.println("Added user " + userEmail + " as an owner on " + bucketName);
+    }
   }
 }
 

--- a/samples/snippets/src/main/java/com/example/storage/bucket/ChangeDefaultStorageClass.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/ChangeDefaultStorageClass.java
@@ -35,7 +35,8 @@ public class ChangeDefaultStorageClass {
     // https://googleapis.dev/java/google-cloud-clients/latest/com/google/cloud/storage/StorageClass.html
     StorageClass storageClass = StorageClass.COLDLINE;
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
       Bucket bucket = storage.get(bucketName);
       bucket = bucket.toBuilder().setStorageClass(storageClass).build().update();
 

--- a/samples/snippets/src/main/java/com/example/storage/bucket/ChangeDefaultStorageClass.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/ChangeDefaultStorageClass.java
@@ -23,7 +23,8 @@ import com.google.cloud.storage.StorageClass;
 import com.google.cloud.storage.StorageOptions;
 
 public class ChangeDefaultStorageClass {
-  public static void changeDefaultStorageClass(String projectId, String bucketName) {
+  public static void changeDefaultStorageClass(String projectId, String bucketName)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -34,15 +35,16 @@ public class ChangeDefaultStorageClass {
     // https://googleapis.dev/java/google-cloud-clients/latest/com/google/cloud/storage/StorageClass.html
     StorageClass storageClass = StorageClass.COLDLINE;
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
-    Bucket bucket = storage.get(bucketName);
-    bucket = bucket.toBuilder().setStorageClass(storageClass).build().update();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
+      bucket = bucket.toBuilder().setStorageClass(storageClass).build().update();
 
-    System.out.println(
-        "Default storage class for bucket "
-            + bucketName
-            + " has been set to "
-            + bucket.getStorageClass());
+      System.out.println(
+          "Default storage class for bucket "
+              + bucketName
+              + " has been set to "
+              + bucket.getStorageClass());
+    }
   }
 }
 // [END storage_change_default_storage_class]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/ConfigureBucketCors.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/ConfigureBucketCors.java
@@ -30,7 +30,7 @@ public class ConfigureBucketCors {
       String bucketName,
       String origin,
       String responseHeader,
-      Integer maxAgeSeconds) {
+      Integer maxAgeSeconds) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -47,31 +47,32 @@ public class ConfigureBucketCors {
     // requests
     // Integer maxAgeSeconds = 3600;
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
-    Bucket bucket = storage.get(bucketName);
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
 
-    // See the HttpMethod documentation for other HTTP methods available:
-    // https://cloud.google.com/appengine/docs/standard/java/javadoc/com/google/appengine/api/urlfetch/HTTPMethod
-    HttpMethod method = HttpMethod.GET;
+      // See the HttpMethod documentation for other HTTP methods available:
+      // https://cloud.google.com/appengine/docs/standard/java/javadoc/com/google/appengine/api/urlfetch/HTTPMethod
+      HttpMethod method = HttpMethod.GET;
 
-    Cors cors =
-        Cors.newBuilder()
-            .setOrigins(ImmutableList.of(Cors.Origin.of(origin)))
-            .setMethods(ImmutableList.of(method))
-            .setResponseHeaders(ImmutableList.of(responseHeader))
-            .setMaxAgeSeconds(maxAgeSeconds)
-            .build();
+      Cors cors =
+          Cors.newBuilder()
+              .setOrigins(ImmutableList.of(Cors.Origin.of(origin)))
+              .setMethods(ImmutableList.of(method))
+              .setResponseHeaders(ImmutableList.of(responseHeader))
+              .setMaxAgeSeconds(maxAgeSeconds)
+              .build();
 
-    bucket.toBuilder().setCors(ImmutableList.of(cors)).build().update();
+      bucket.toBuilder().setCors(ImmutableList.of(cors)).build().update();
 
-    System.out.println(
-        "Bucket "
-            + bucketName
-            + " was updated with a CORS config to allow GET requests from "
-            + origin
-            + " sharing "
-            + responseHeader
-            + " responses across origins");
+      System.out.println(
+          "Bucket "
+              + bucketName
+              + " was updated with a CORS config to allow GET requests from "
+              + origin
+              + " sharing "
+              + responseHeader
+              + " responses across origins");
+    }
   }
 }
 // [END storage_cors_configuration]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/ConfigureBucketCors.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/ConfigureBucketCors.java
@@ -30,7 +30,8 @@ public class ConfigureBucketCors {
       String bucketName,
       String origin,
       String responseHeader,
-      Integer maxAgeSeconds) throws Exception {
+      Integer maxAgeSeconds)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -47,7 +48,8 @@ public class ConfigureBucketCors {
     // requests
     // Integer maxAgeSeconds = 3600;
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
       Bucket bucket = storage.get(bucketName);
 
       // See the HttpMethod documentation for other HTTP methods available:

--- a/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucket.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucket.java
@@ -23,18 +23,19 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class CreateBucket {
-  public static void createBucket(String projectId, String bucketName) {
+  public static void createBucket(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID to give your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    Bucket bucket = storage.create(BucketInfo.newBuilder(bucketName).build());
+      Bucket bucket = storage.create(BucketInfo.newBuilder(bucketName).build());
 
-    System.out.println("Created bucket " + bucket.getName());
+      System.out.println("Created bucket " + bucket.getName());
+    }
   }
 }
 // [END storage_create_bucket]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucket.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucket.java
@@ -30,7 +30,8 @@ public class CreateBucket {
     // The ID to give your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
       Bucket bucket = storage.create(BucketInfo.newBuilder(bucketName).build());
 

--- a/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketDualRegion.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketDualRegion.java
@@ -32,7 +32,7 @@ public class CreateBucketDualRegion {
       String bucketName,
       String location,
       String firstRegion,
-      String secondRegion) {
+      String secondRegion) throws Exception {
     // The ID of your GCP project.
     // String projectId = "your-project-id";
 
@@ -51,30 +51,31 @@ public class CreateBucketDualRegion {
     // See this documentation for other valid locations and regions:
     // https://cloud.google.com/storage/docs/locations
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    CustomPlacementConfig config =
-        CustomPlacementConfig.newBuilder()
-            .setDataLocations(Arrays.asList(firstRegion, secondRegion))
-            .build();
+      CustomPlacementConfig config =
+          CustomPlacementConfig.newBuilder()
+              .setDataLocations(Arrays.asList(firstRegion, secondRegion))
+              .build();
 
-    BucketInfo bucketInfo =
-        BucketInfo.newBuilder(bucketName)
-            .setLocation(location)
-            .setCustomPlacementConfig(config)
-            .build();
+      BucketInfo bucketInfo =
+          BucketInfo.newBuilder(bucketName)
+              .setLocation(location)
+              .setCustomPlacementConfig(config)
+              .build();
 
-    Bucket bucket = storage.create(bucketInfo);
+      Bucket bucket = storage.create(bucketInfo);
 
-    System.out.println(
-        "Created bucket "
-            + bucket.getName()
-            + " in location "
-            + bucket.getLocation()
-            + " with location type "
-            + bucket.getLocationType()
-            + " with Custom Placement Config "
-            + bucket.getCustomPlacementConfig().toString());
+      System.out.println(
+          "Created bucket "
+              + bucket.getName()
+              + " in location "
+              + bucket.getLocation()
+              + " with location type "
+              + bucket.getLocationType()
+              + " with Custom Placement Config "
+              + bucket.getCustomPlacementConfig().toString());
+    }
   }
 }
 // [END storage_create_bucket_dual_region]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketDualRegion.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketDualRegion.java
@@ -28,11 +28,8 @@ import java.util.Arrays;
 public class CreateBucketDualRegion {
 
   public static void createBucketDualRegion(
-      String projectId,
-      String bucketName,
-      String location,
-      String firstRegion,
-      String secondRegion) throws Exception {
+      String projectId, String bucketName, String location, String firstRegion, String secondRegion)
+      throws Exception {
     // The ID of your GCP project.
     // String projectId = "your-project-id";
 
@@ -51,7 +48,8 @@ public class CreateBucketDualRegion {
     // See this documentation for other valid locations and regions:
     // https://cloud.google.com/storage/docs/locations
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
       CustomPlacementConfig config =
           CustomPlacementConfig.newBuilder()

--- a/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketPubSubNotification.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketPubSubNotification.java
@@ -33,7 +33,7 @@ public class CreateBucketPubSubNotification {
       Map<String, String> customAttributes,
       EventType[] eventTypes,
       String objectNamePrefix,
-      PayloadFormat payloadFormat) {
+      PayloadFormat payloadFormat) throws Exception {
     // The ID to give your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
@@ -49,17 +49,18 @@ public class CreateBucketPubSubNotification {
     // Desired content of the Payload
     // PayloadFormat payloadFormat = PayloadFormat.JSON_API_V1.JSON_API_V1;
 
-    Storage storage = StorageOptions.newBuilder().build().getService();
-    NotificationInfo notificationInfo =
-        NotificationInfo.newBuilder(topicName)
-            .setCustomAttributes(customAttributes)
-            .setEventTypes(eventTypes)
-            .setObjectNamePrefix(objectNamePrefix)
-            .setPayloadFormat(payloadFormat)
-            .build();
-    Notification notification = storage.createNotification(bucketName, notificationInfo);
-    String topic = notification.getTopic();
-    System.out.println("Successfully created notification for topic " + topic);
+    try (Storage storage = StorageOptions.newBuilder().build().getService()) {
+      NotificationInfo notificationInfo =
+          NotificationInfo.newBuilder(topicName)
+              .setCustomAttributes(customAttributes)
+              .setEventTypes(eventTypes)
+              .setObjectNamePrefix(objectNamePrefix)
+              .setPayloadFormat(payloadFormat)
+              .build();
+      Notification notification = storage.createNotification(bucketName, notificationInfo);
+      String topic = notification.getTopic();
+      System.out.println("Successfully created notification for topic " + topic);
+    }
   }
 }
 // [END storage_create_bucket_notifications]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketPubSubNotification.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketPubSubNotification.java
@@ -33,7 +33,8 @@ public class CreateBucketPubSubNotification {
       Map<String, String> customAttributes,
       EventType[] eventTypes,
       String objectNamePrefix,
-      PayloadFormat payloadFormat) throws Exception {
+      PayloadFormat payloadFormat)
+      throws Exception {
     // The ID to give your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 

--- a/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketWithObjectRetention.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketWithObjectRetention.java
@@ -24,24 +24,26 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class CreateBucketWithObjectRetention {
-  public static void createBucketWithObjectRetention(String projectId, String bucketName) {
+  public static void createBucketWithObjectRetention(String projectId, String bucketName)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID to give your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    Bucket bucket =
-        storage.create(
-            BucketInfo.of(bucketName), Storage.BucketTargetOption.enableObjectRetention(true));
+      Bucket bucket =
+          storage.create(
+              BucketInfo.of(bucketName), Storage.BucketTargetOption.enableObjectRetention(true));
 
-    System.out.println(
-        "Created bucket "
-            + bucket.getName()
-            + " with object retention enabled setting: "
-            + bucket.getObjectRetention().getMode().toString());
+      System.out.println(
+          "Created bucket "
+              + bucket.getName()
+              + " with object retention enabled setting: "
+              + bucket.getObjectRetention().getMode().toString());
+    }
   }
 }
 

--- a/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketWithObjectRetention.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketWithObjectRetention.java
@@ -32,7 +32,8 @@ public class CreateBucketWithObjectRetention {
     // The ID to give your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
       Bucket bucket =
           storage.create(

--- a/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketWithStorageClassAndLocation.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketWithStorageClassAndLocation.java
@@ -24,14 +24,15 @@ import com.google.cloud.storage.StorageClass;
 import com.google.cloud.storage.StorageOptions;
 
 public class CreateBucketWithStorageClassAndLocation {
-  public static void createBucketWithStorageClassAndLocation(String projectId, String bucketName) {
+  public static void createBucketWithStorageClassAndLocation(String projectId, String bucketName)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID to give your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     // See the StorageClass documentation for other valid storage classes:
     // https://googleapis.dev/java/google-cloud-clients/latest/com/google/cloud/storage/StorageClass.html
@@ -55,6 +56,7 @@ public class CreateBucketWithStorageClassAndLocation {
             + bucket.getLocation()
             + " with storage class "
             + bucket.getStorageClass());
+    }
   }
 }
 // [END storage_create_bucket_class_location]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketWithStorageClassAndLocation.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketWithStorageClassAndLocation.java
@@ -32,30 +32,31 @@ public class CreateBucketWithStorageClassAndLocation {
     // The ID to give your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    // See the StorageClass documentation for other valid storage classes:
-    // https://googleapis.dev/java/google-cloud-clients/latest/com/google/cloud/storage/StorageClass.html
-    StorageClass storageClass = StorageClass.COLDLINE;
+      // See the StorageClass documentation for other valid storage classes:
+      // https://googleapis.dev/java/google-cloud-clients/latest/com/google/cloud/storage/StorageClass.html
+      StorageClass storageClass = StorageClass.COLDLINE;
 
-    // See this documentation for other valid locations:
-    // http://g.co/cloud/storage/docs/bucket-locations#location-mr
-    String location = "ASIA";
+      // See this documentation for other valid locations:
+      // http://g.co/cloud/storage/docs/bucket-locations#location-mr
+      String location = "ASIA";
 
-    Bucket bucket =
-        storage.create(
-            BucketInfo.newBuilder(bucketName)
-                .setStorageClass(storageClass)
-                .setLocation(location)
-                .build());
+      Bucket bucket =
+          storage.create(
+              BucketInfo.newBuilder(bucketName)
+                  .setStorageClass(storageClass)
+                  .setLocation(location)
+                  .build());
 
-    System.out.println(
-        "Created bucket "
-            + bucket.getName()
-            + " in "
-            + bucket.getLocation()
-            + " with storage class "
-            + bucket.getStorageClass());
+      System.out.println(
+          "Created bucket "
+              + bucket.getName()
+              + " in "
+              + bucket.getLocation()
+              + " with storage class "
+              + bucket.getStorageClass());
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketWithTurboReplication.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketWithTurboReplication.java
@@ -35,22 +35,23 @@ public class CreateBucketWithTurboReplication {
     // The dual-region location to create your bucket in
     // String location = "NAM4"
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    Bucket bucket =
-        storage.create(
-            BucketInfo.newBuilder(bucketName)
-                .setLocation(location)
-                .setRpo(Rpo.ASYNC_TURBO)
-                .build());
+      Bucket bucket =
+          storage.create(
+              BucketInfo.newBuilder(bucketName)
+                  .setLocation(location)
+                  .setRpo(Rpo.ASYNC_TURBO)
+                  .build());
 
-    System.out.println(
-        "Created bucket "
-            + bucket.getName()
-            + " in "
-            + bucket.getLocation()
-            + " with RPO setting"
-            + bucket.getRpo());
+      System.out.println(
+          "Created bucket "
+              + bucket.getName()
+              + " in "
+              + bucket.getLocation()
+              + " with RPO setting"
+              + bucket.getRpo());
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketWithTurboReplication.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/CreateBucketWithTurboReplication.java
@@ -25,7 +25,7 @@ import com.google.cloud.storage.StorageOptions;
 
 public class CreateBucketWithTurboReplication {
   public static void createBucketWithTurboReplication(
-      String projectId, String bucketName, String location) {
+      String projectId, String bucketName, String location) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -35,7 +35,7 @@ public class CreateBucketWithTurboReplication {
     // The dual-region location to create your bucket in
     // String location = "NAM4"
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     Bucket bucket =
         storage.create(
@@ -51,6 +51,7 @@ public class CreateBucketWithTurboReplication {
             + bucket.getLocation()
             + " with RPO setting"
             + bucket.getRpo());
+    }
   }
 }
 // [END storage_create_bucket_turbo_replication]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/DeleteBucket.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DeleteBucket.java
@@ -29,11 +29,12 @@ public class DeleteBucket {
     // The ID of the bucket to delete
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName);
-    bucket.delete();
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
+      bucket.delete();
 
-    System.out.println("Bucket " + bucket.getName() + " was deleted");
+      System.out.println("Bucket " + bucket.getName() + " was deleted");
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/DeleteBucket.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DeleteBucket.java
@@ -22,18 +22,19 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class DeleteBucket {
-  public static void deleteBucket(String projectId, String bucketName) {
+  public static void deleteBucket(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of the bucket to delete
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName);
     bucket.delete();
 
     System.out.println("Bucket " + bucket.getName() + " was deleted");
+    }
   }
 }
 // [END storage_delete_bucket]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/DeleteBucketPubSubNotification.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DeleteBucketPubSubNotification.java
@@ -22,19 +22,21 @@ import com.google.cloud.storage.StorageOptions;
 
 public class DeleteBucketPubSubNotification {
 
-  public static void deleteBucketPubSubNotification(String bucketName, String notificationId) {
+  public static void deleteBucketPubSubNotification(String bucketName, String notificationId)
+      throws Exception {
     // The ID to give your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
     // The NotificationId for the notification you would like to delete
     // String notificationId = "your-unique-notification-id"
 
-    Storage storage = StorageOptions.newBuilder().build().getService();
-    boolean success = storage.deleteNotification(bucketName, notificationId);
-    if (success) {
-      System.out.println("Successfully deleted notification");
-    } else {
-      System.out.println("Failed to find notification");
+    try (Storage storage = StorageOptions.newBuilder().build().getService()) {
+      boolean success = storage.deleteNotification(bucketName, notificationId);
+      if (success) {
+        System.out.println("Successfully deleted notification");
+      } else {
+        System.out.println("Failed to find notification");
+      }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/DisableBucketVersioning.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DisableBucketVersioning.java
@@ -29,11 +29,12 @@ public class DisableBucketVersioning {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName);
-    bucket.toBuilder().setVersioningEnabled(false).build().update();
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
+      bucket.toBuilder().setVersioningEnabled(false).build().update();
 
-    System.out.println("Versioning is now disabled for bucket " + bucketName);
+      System.out.println("Versioning is now disabled for bucket " + bucketName);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/DisableBucketVersioning.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DisableBucketVersioning.java
@@ -22,18 +22,19 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class DisableBucketVersioning {
-  public static void disableBucketVersioning(String projectId, String bucketName) {
+  public static void disableBucketVersioning(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName);
     bucket.toBuilder().setVersioningEnabled(false).build().update();
 
     System.out.println("Versioning is now disabled for bucket " + bucketName);
+    }
   }
 }
 // [END storage_disable_versioning]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/DisableDefaultEventBasedHold.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DisableDefaultEventBasedHold.java
@@ -21,19 +21,18 @@ package com.example.storage.bucket;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BucketTargetOption;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
 public class DisableDefaultEventBasedHold {
   public static void disableDefaultEventBasedHold(String projectId, String bucketName)
-      throws StorageException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     // first look up the bucket, so we will have its metageneration
     Bucket bucket = storage.get(bucketName);
     storage.update(
@@ -41,6 +40,7 @@ public class DisableDefaultEventBasedHold {
         BucketTargetOption.metagenerationMatch());
 
     System.out.println("Default event-based hold was disabled for " + bucketName);
+    }
   }
 }
 // [END storage_disable_default_event_based_hold]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/DisableDefaultEventBasedHold.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DisableDefaultEventBasedHold.java
@@ -32,14 +32,15 @@ public class DisableDefaultEventBasedHold {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    // first look up the bucket, so we will have its metageneration
-    Bucket bucket = storage.get(bucketName);
-    storage.update(
-        bucket.toBuilder().setDefaultEventBasedHold(false).build(),
-        BucketTargetOption.metagenerationMatch());
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      // first look up the bucket, so we will have its metageneration
+      Bucket bucket = storage.get(bucketName);
+      storage.update(
+          bucket.toBuilder().setDefaultEventBasedHold(false).build(),
+          BucketTargetOption.metagenerationMatch());
 
-    System.out.println("Default event-based hold was disabled for " + bucketName);
+      System.out.println("Default event-based hold was disabled for " + bucketName);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/DisableLifecycleManagement.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DisableLifecycleManagement.java
@@ -31,14 +31,15 @@ public class DisableLifecycleManagement {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    // first look up the bucket, so we will have its metageneration
-    Bucket bucket = storage.get(bucketName);
-    storage.update(
-        bucket.toBuilder().deleteLifecycleRules().build(),
-        BucketTargetOption.metagenerationMatch());
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      // first look up the bucket, so we will have its metageneration
+      Bucket bucket = storage.get(bucketName);
+      storage.update(
+          bucket.toBuilder().deleteLifecycleRules().build(),
+          BucketTargetOption.metagenerationMatch());
 
-    System.out.println("Lifecycle management was disabled for bucket " + bucketName);
+      System.out.println("Lifecycle management was disabled for bucket " + bucketName);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/DisableLifecycleManagement.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DisableLifecycleManagement.java
@@ -23,14 +23,15 @@ import com.google.cloud.storage.Storage.BucketTargetOption;
 import com.google.cloud.storage.StorageOptions;
 
 public class DisableLifecycleManagement {
-  public static void disableLifecycleManagement(String projectId, String bucketName) {
+  public static void disableLifecycleManagement(String projectId, String bucketName)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     // first look up the bucket, so we will have its metageneration
     Bucket bucket = storage.get(bucketName);
     storage.update(
@@ -38,6 +39,7 @@ public class DisableLifecycleManagement {
         BucketTargetOption.metagenerationMatch());
 
     System.out.println("Lifecycle management was disabled for bucket " + bucketName);
+    }
   }
 }
 // [END storage_disable_bucket_lifecycle_management]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/DisableRequesterPays.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DisableRequesterPays.java
@@ -29,14 +29,15 @@ public class DisableRequesterPays {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName, Storage.BucketGetOption.userProject(projectId));
-    bucket.toBuilder()
-        .setRequesterPays(false)
-        .build()
-        .update(Storage.BucketTargetOption.userProject(projectId));
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName, Storage.BucketGetOption.userProject(projectId));
+      bucket.toBuilder()
+          .setRequesterPays(false)
+          .build()
+          .update(Storage.BucketTargetOption.userProject(projectId));
 
-    System.out.println("Requester pays disabled for bucket " + bucketName);
+      System.out.println("Requester pays disabled for bucket " + bucketName);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/DisableRequesterPays.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DisableRequesterPays.java
@@ -22,14 +22,14 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class DisableRequesterPays {
-  public static void disableRequesterPays(String projectId, String bucketName) {
+  public static void disableRequesterPays(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName, Storage.BucketGetOption.userProject(projectId));
     bucket.toBuilder()
         .setRequesterPays(false)
@@ -37,6 +37,7 @@ public class DisableRequesterPays {
         .update(Storage.BucketTargetOption.userProject(projectId));
 
     System.out.println("Requester pays disabled for bucket " + bucketName);
+    }
   }
 }
 // [END storage_disable_requester_pays]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/DisableSoftDelete.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DisableSoftDelete.java
@@ -24,14 +24,14 @@ import com.google.cloud.storage.StorageOptions;
 import java.time.Duration;
 
 public class DisableSoftDelete {
-  public static void disableSoftDelete(String projectId, String bucketName) {
+  public static void disableSoftDelete(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName);
     bucket.toBuilder()
         .setSoftDeletePolicy(
@@ -43,6 +43,7 @@ public class DisableSoftDelete {
         .update();
 
     System.out.println("Soft delete for " + bucketName + " was disabled");
+    }
   }
 }
 // [END storage_disable_soft_delete]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/DisableSoftDelete.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DisableSoftDelete.java
@@ -31,18 +31,19 @@ public class DisableSoftDelete {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName);
-    bucket.toBuilder()
-        .setSoftDeletePolicy(
-            // Setting the retention duration to 0 disables Soft Delete.
-            BucketInfo.SoftDeletePolicy.newBuilder()
-                .setRetentionDuration(Duration.ofSeconds(0))
-                .build())
-        .build()
-        .update();
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
+      bucket.toBuilder()
+          .setSoftDeletePolicy(
+              // Setting the retention duration to 0 disables Soft Delete.
+              BucketInfo.SoftDeletePolicy.newBuilder()
+                  .setRetentionDuration(Duration.ofSeconds(0))
+                  .build())
+          .build()
+          .update();
 
-    System.out.println("Soft delete for " + bucketName + " was disabled");
+      System.out.println("Soft delete for " + bucketName + " was disabled");
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/DisableUniformBucketLevelAccess.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DisableUniformBucketLevelAccess.java
@@ -33,21 +33,22 @@ public class DisableUniformBucketLevelAccess {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    // first look up the bucket, so we will have its metageneration
-    Bucket bucket = storage.get(bucketName);
+      // first look up the bucket, so we will have its metageneration
+      Bucket bucket = storage.get(bucketName);
 
-    BucketInfo.IamConfiguration iamConfiguration =
-        BucketInfo.IamConfiguration.newBuilder()
-            .setIsUniformBucketLevelAccessEnabled(false)
-            .build();
+      BucketInfo.IamConfiguration iamConfiguration =
+          BucketInfo.IamConfiguration.newBuilder()
+              .setIsUniformBucketLevelAccessEnabled(false)
+              .build();
 
-    storage.update(
-        bucket.toBuilder().setIamConfiguration(iamConfiguration).build(),
-        BucketTargetOption.metagenerationMatch());
+      storage.update(
+          bucket.toBuilder().setIamConfiguration(iamConfiguration).build(),
+          BucketTargetOption.metagenerationMatch());
 
-    System.out.println("Uniform bucket-level access was disabled for " + bucketName);
+      System.out.println("Uniform bucket-level access was disabled for " + bucketName);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/DisableUniformBucketLevelAccess.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/DisableUniformBucketLevelAccess.java
@@ -22,19 +22,18 @@ import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BucketTargetOption;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
 public class DisableUniformBucketLevelAccess {
   public static void disableUniformBucketLevelAccess(String projectId, String bucketName)
-      throws StorageException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     // first look up the bucket, so we will have its metageneration
     Bucket bucket = storage.get(bucketName);
@@ -49,6 +48,7 @@ public class DisableUniformBucketLevelAccess {
         BucketTargetOption.metagenerationMatch());
 
     System.out.println("Uniform bucket-level access was disabled for " + bucketName);
+    }
   }
 }
 // [END storage_disable_uniform_bucket_level_access]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/EnableBucketVersioning.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/EnableBucketVersioning.java
@@ -29,11 +29,12 @@ public class EnableBucketVersioning {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName);
-    bucket.toBuilder().setVersioningEnabled(true).build().update();
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
+      bucket.toBuilder().setVersioningEnabled(true).build().update();
 
-    System.out.println("Versioning is now enabled for bucket " + bucketName);
+      System.out.println("Versioning is now enabled for bucket " + bucketName);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/EnableBucketVersioning.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/EnableBucketVersioning.java
@@ -22,18 +22,19 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class EnableBucketVersioning {
-  public static void enableBucketVersioning(String projectId, String bucketName) {
+  public static void enableBucketVersioning(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName);
     bucket.toBuilder().setVersioningEnabled(true).build().update();
 
     System.out.println("Versioning is now enabled for bucket " + bucketName);
+    }
   }
 }
 // [END storage_enable_versioning]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/EnableDefaultEventBasedHold.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/EnableDefaultEventBasedHold.java
@@ -32,14 +32,15 @@ public class EnableDefaultEventBasedHold {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    // first look up the bucket, so we will have its metageneration
-    Bucket bucket = storage.get(bucketName);
-    storage.update(
-        bucket.toBuilder().setDefaultEventBasedHold(true).build(),
-        BucketTargetOption.metagenerationMatch());
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      // first look up the bucket, so we will have its metageneration
+      Bucket bucket = storage.get(bucketName);
+      storage.update(
+          bucket.toBuilder().setDefaultEventBasedHold(true).build(),
+          BucketTargetOption.metagenerationMatch());
 
-    System.out.println("Default event-based hold was enabled for " + bucketName);
+      System.out.println("Default event-based hold was enabled for " + bucketName);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/EnableDefaultEventBasedHold.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/EnableDefaultEventBasedHold.java
@@ -21,19 +21,18 @@ package com.example.storage.bucket;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BucketTargetOption;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
 public class EnableDefaultEventBasedHold {
   public static void enableDefaultEventBasedHold(String projectId, String bucketName)
-      throws StorageException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     // first look up the bucket, so we will have its metageneration
     Bucket bucket = storage.get(bucketName);
     storage.update(
@@ -41,6 +40,7 @@ public class EnableDefaultEventBasedHold {
         BucketTargetOption.metagenerationMatch());
 
     System.out.println("Default event-based hold was enabled for " + bucketName);
+    }
   }
 }
 // [END storage_enable_default_event_based_hold]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/EnableLifecycleManagement.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/EnableLifecycleManagement.java
@@ -27,14 +27,15 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.common.collect.ImmutableList;
 
 public class EnableLifecycleManagement {
-  public static void enableLifecycleManagement(String projectId, String bucketName) {
+  public static void enableLifecycleManagement(String projectId, String bucketName)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName);
 
     // See the LifecycleRule documentation for additional info on what you can do with lifecycle
@@ -50,6 +51,7 @@ public class EnableLifecycleManagement {
         .update();
 
     System.out.println("Lifecycle management was enabled and configured for bucket " + bucketName);
+    }
   }
 }
 // [END storage_enable_bucket_lifecycle_management]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/EnableLifecycleManagement.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/EnableLifecycleManagement.java
@@ -35,22 +35,24 @@ public class EnableLifecycleManagement {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName);
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
 
-    // See the LifecycleRule documentation for additional info on what you can do with lifecycle
-    // management rules. This one deletes objects that are over 100 days old.
-    // https://googleapis.dev/java/google-cloud-clients/latest/com/google/cloud/storage/BucketInfo.LifecycleRule.html
-    bucket.toBuilder()
-        .setLifecycleRules(
-            ImmutableList.of(
-                new LifecycleRule(
-                    LifecycleAction.newDeleteAction(),
-                    LifecycleCondition.newBuilder().setAge(100).build())))
-        .build()
-        .update();
+      // See the LifecycleRule documentation for additional info on what you can do with lifecycle
+      // management rules. This one deletes objects that are over 100 days old.
+      // https://googleapis.dev/java/google-cloud-clients/latest/com/google/cloud/storage/BucketInfo.LifecycleRule.html
+      bucket.toBuilder()
+          .setLifecycleRules(
+              ImmutableList.of(
+                  new LifecycleRule(
+                      LifecycleAction.newDeleteAction(),
+                      LifecycleCondition.newBuilder().setAge(100).build())))
+          .build()
+          .update();
 
-    System.out.println("Lifecycle management was enabled and configured for bucket " + bucketName);
+      System.out.println(
+          "Lifecycle management was enabled and configured for bucket " + bucketName);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/EnableRequesterPays.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/EnableRequesterPays.java
@@ -29,11 +29,12 @@ public class EnableRequesterPays {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName);
-    bucket.toBuilder().setRequesterPays(true).build().update();
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
+      bucket.toBuilder().setRequesterPays(true).build().update();
 
-    System.out.println("Requester pays enabled for bucket " + bucketName);
+      System.out.println("Requester pays enabled for bucket " + bucketName);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/EnableRequesterPays.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/EnableRequesterPays.java
@@ -22,18 +22,19 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class EnableRequesterPays {
-  public static void enableRequesterPays(String projectId, String bucketName) {
+  public static void enableRequesterPays(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName);
     bucket.toBuilder().setRequesterPays(true).build().update();
 
     System.out.println("Requester pays enabled for bucket " + bucketName);
+    }
   }
 }
 // [END storage_enable_requester_pays]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/EnableUniformBucketLevelAccess.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/EnableUniformBucketLevelAccess.java
@@ -33,23 +33,26 @@ public class EnableUniformBucketLevelAccess {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    // first look up the bucket, so we will have its metageneration
-    Bucket bucket = storage.get(bucketName);
+      // first look up the bucket, so we will have its metageneration
+      Bucket bucket = storage.get(bucketName);
 
-    BucketInfo.IamConfiguration iamConfiguration =
-        BucketInfo.IamConfiguration.newBuilder().setIsUniformBucketLevelAccessEnabled(true).build();
+      BucketInfo.IamConfiguration iamConfiguration =
+          BucketInfo.IamConfiguration.newBuilder()
+              .setIsUniformBucketLevelAccessEnabled(true)
+              .build();
 
-    storage.update(
-        bucket.toBuilder()
-            .setIamConfiguration(iamConfiguration)
-            .setAcl(null)
-            .setDefaultAcl(null)
-            .build(),
-        BucketTargetOption.metagenerationMatch());
+      storage.update(
+          bucket.toBuilder()
+              .setIamConfiguration(iamConfiguration)
+              .setAcl(null)
+              .setDefaultAcl(null)
+              .build(),
+          BucketTargetOption.metagenerationMatch());
 
-    System.out.println("Uniform bucket-level access was enabled for " + bucketName);
+      System.out.println("Uniform bucket-level access was enabled for " + bucketName);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/EnableUniformBucketLevelAccess.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/EnableUniformBucketLevelAccess.java
@@ -22,19 +22,18 @@ import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BucketTargetOption;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
 public class EnableUniformBucketLevelAccess {
   public static void enableUniformBucketLevelAccess(String projectId, String bucketName)
-      throws StorageException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     // first look up the bucket, so we will have its metageneration
     Bucket bucket = storage.get(bucketName);
@@ -51,6 +50,7 @@ public class EnableUniformBucketLevelAccess {
         BucketTargetOption.metagenerationMatch());
 
     System.out.println("Uniform bucket-level access was enabled for " + bucketName);
+    }
   }
 }
 // [END storage_enable_uniform_bucket_level_access]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetBucketAutoclass.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetBucketAutoclass.java
@@ -25,14 +25,14 @@ import com.google.cloud.storage.StorageOptions;
 import java.time.OffsetDateTime;
 
 public class GetBucketAutoclass {
-  public static void getBucketAutoclass(String projectId, String bucketName) {
+  public static void getBucketAutoclass(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Autoclass autoclass = storage.get(bucketName).getAutoclass();
     String status = autoclass.getEnabled() ? "enabled" : "disabled";
     String toggleTime = autoclass.getToggleTime().toString();
@@ -50,6 +50,7 @@ public class GetBucketAutoclass {
             + terminalStorageClass.name()
             + " last updated at "
             + terminalStorageClassUpdateTime.toString());
+    }
   }
 }
 // [END storage_get_autoclass]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetBucketAutoclass.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetBucketAutoclass.java
@@ -32,24 +32,25 @@ public class GetBucketAutoclass {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Autoclass autoclass = storage.get(bucketName).getAutoclass();
-    String status = autoclass.getEnabled() ? "enabled" : "disabled";
-    String toggleTime = autoclass.getToggleTime().toString();
-    StorageClass terminalStorageClass = autoclass.getTerminalStorageClass();
-    OffsetDateTime terminalStorageClassUpdateTime = autoclass.getTerminalStorageClassUpdateTime();
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Autoclass autoclass = storage.get(bucketName).getAutoclass();
+      String status = autoclass.getEnabled() ? "enabled" : "disabled";
+      String toggleTime = autoclass.getToggleTime().toString();
+      StorageClass terminalStorageClass = autoclass.getTerminalStorageClass();
+      OffsetDateTime terminalStorageClassUpdateTime = autoclass.getTerminalStorageClassUpdateTime();
 
-    System.out.println(
-        "Autoclass is currently "
-            + status
-            + " for bucket "
-            + bucketName
-            + " and was last changed at "
-            + toggleTime
-            + ". The terminal storage class is set to be "
-            + terminalStorageClass.name()
-            + " last updated at "
-            + terminalStorageClassUpdateTime.toString());
+      System.out.println(
+          "Autoclass is currently "
+              + status
+              + " for bucket "
+              + bucketName
+              + " and was last changed at "
+              + toggleTime
+              + ". The terminal storage class is set to be "
+              + terminalStorageClass.name()
+              + " last updated at "
+              + terminalStorageClassUpdateTime.toString());
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetBucketMetadata.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetBucketMetadata.java
@@ -32,43 +32,44 @@ public class GetBucketMetadata {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    // Select all fields. Fields can be selected individually e.g. Storage.BucketField.NAME
-    Bucket bucket =
-        storage.get(bucketName, Storage.BucketGetOption.fields(Storage.BucketField.values()));
+      // Select all fields. Fields can be selected individually e.g. Storage.BucketField.NAME
+      Bucket bucket =
+          storage.get(bucketName, Storage.BucketGetOption.fields(Storage.BucketField.values()));
 
-    // Print bucket metadata
-    System.out.println("BucketName: " + bucket.getName());
-    System.out.println("DefaultEventBasedHold: " + bucket.getDefaultEventBasedHold());
-    System.out.println("DefaultKmsKeyName: " + bucket.getDefaultKmsKeyName());
-    System.out.println("Id: " + bucket.getGeneratedId());
-    System.out.println("IndexPage: " + bucket.getIndexPage());
-    System.out.println("Location: " + bucket.getLocation());
-    System.out.println("LocationType: " + bucket.getLocationType());
-    System.out.println("Metageneration: " + bucket.getMetageneration());
-    System.out.println("NotFoundPage: " + bucket.getNotFoundPage());
-    System.out.println("RetentionEffectiveTime: " + bucket.getRetentionEffectiveTime());
-    System.out.println("RetentionPeriod: " + bucket.getRetentionPeriod());
-    System.out.println("RetentionPolicyIsLocked: " + bucket.retentionPolicyIsLocked());
-    System.out.println("RequesterPays: " + bucket.requesterPays());
-    System.out.println("SelfLink: " + bucket.getSelfLink());
-    System.out.println("StorageClass: " + bucket.getStorageClass().name());
-    System.out.println("TimeCreated: " + bucket.getCreateTime());
-    System.out.println("VersioningEnabled: " + bucket.versioningEnabled());
-    System.out.println("ObjectRetention: " + bucket.getObjectRetention());
-    if (bucket.getLabels() != null) {
-      System.out.println("\n\n\nLabels:");
-      for (Map.Entry<String, String> label : bucket.getLabels().entrySet()) {
-        System.out.println(label.getKey() + "=" + label.getValue());
+      // Print bucket metadata
+      System.out.println("BucketName: " + bucket.getName());
+      System.out.println("DefaultEventBasedHold: " + bucket.getDefaultEventBasedHold());
+      System.out.println("DefaultKmsKeyName: " + bucket.getDefaultKmsKeyName());
+      System.out.println("Id: " + bucket.getGeneratedId());
+      System.out.println("IndexPage: " + bucket.getIndexPage());
+      System.out.println("Location: " + bucket.getLocation());
+      System.out.println("LocationType: " + bucket.getLocationType());
+      System.out.println("Metageneration: " + bucket.getMetageneration());
+      System.out.println("NotFoundPage: " + bucket.getNotFoundPage());
+      System.out.println("RetentionEffectiveTime: " + bucket.getRetentionEffectiveTime());
+      System.out.println("RetentionPeriod: " + bucket.getRetentionPeriod());
+      System.out.println("RetentionPolicyIsLocked: " + bucket.retentionPolicyIsLocked());
+      System.out.println("RequesterPays: " + bucket.requesterPays());
+      System.out.println("SelfLink: " + bucket.getSelfLink());
+      System.out.println("StorageClass: " + bucket.getStorageClass().name());
+      System.out.println("TimeCreated: " + bucket.getCreateTime());
+      System.out.println("VersioningEnabled: " + bucket.versioningEnabled());
+      System.out.println("ObjectRetention: " + bucket.getObjectRetention());
+      if (bucket.getLabels() != null) {
+        System.out.println("\n\n\nLabels:");
+        for (Map.Entry<String, String> label : bucket.getLabels().entrySet()) {
+          System.out.println(label.getKey() + "=" + label.getValue());
+        }
       }
-    }
-    if (bucket.getLifecycleRules() != null) {
-      System.out.println("\n\n\nLifecycle Rules:");
-      for (BucketInfo.LifecycleRule rule : bucket.getLifecycleRules()) {
-        System.out.println(rule);
+      if (bucket.getLifecycleRules() != null) {
+        System.out.println("\n\n\nLifecycle Rules:");
+        for (BucketInfo.LifecycleRule rule : bucket.getLifecycleRules()) {
+          System.out.println(rule);
+        }
       }
-    }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetBucketMetadata.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetBucketMetadata.java
@@ -25,14 +25,14 @@ import com.google.cloud.storage.StorageOptions;
 import java.util.Map;
 
 public class GetBucketMetadata {
-  public static void getBucketMetadata(String projectId, String bucketName) {
+  public static void getBucketMetadata(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     // Select all fields. Fields can be selected individually e.g. Storage.BucketField.NAME
     Bucket bucket =
@@ -68,6 +68,7 @@ public class GetBucketMetadata {
       for (BucketInfo.LifecycleRule rule : bucket.getLifecycleRules()) {
         System.out.println(rule);
       }
+    }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetBucketRpo.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetBucketRpo.java
@@ -29,11 +29,12 @@ public class GetBucketRpo {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName);
-    String rpo = bucket.getRpo().toString();
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
+      String rpo = bucket.getRpo().toString();
 
-    System.out.println("The RPO setting of bucket " + bucketName + " is " + rpo);
+      System.out.println("The RPO setting of bucket " + bucketName + " is " + rpo);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetBucketRpo.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetBucketRpo.java
@@ -22,18 +22,19 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class GetBucketRpo {
-  public static void getBucketRpo(String projectId, String bucketName) {
+  public static void getBucketRpo(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName);
     String rpo = bucket.getRpo().toString();
 
     System.out.println("The RPO setting of bucket " + bucketName + " is " + rpo);
+    }
   }
 }
 // [END storage_get_rpo]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetDefaultEventBasedHold.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetDefaultEventBasedHold.java
@@ -31,17 +31,18 @@ public class GetDefaultEventBasedHold {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket =
-        storage.get(
-            bucketName,
-            Storage.BucketGetOption.fields(Storage.BucketField.DEFAULT_EVENT_BASED_HOLD));
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket =
+          storage.get(
+              bucketName,
+              Storage.BucketGetOption.fields(Storage.BucketField.DEFAULT_EVENT_BASED_HOLD));
 
-    if (bucket.getDefaultEventBasedHold() != null && bucket.getDefaultEventBasedHold()) {
-      System.out.println("Default event-based hold is enabled for " + bucketName);
-    } else {
-      System.out.println("Default event-based hold is not enabled for " + bucketName);
-    }
+      if (bucket.getDefaultEventBasedHold() != null && bucket.getDefaultEventBasedHold()) {
+        System.out.println("Default event-based hold is enabled for " + bucketName);
+      } else {
+        System.out.println("Default event-based hold is not enabled for " + bucketName);
+      }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetDefaultEventBasedHold.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetDefaultEventBasedHold.java
@@ -20,19 +20,18 @@ package com.example.storage.bucket;
 
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
 public class GetDefaultEventBasedHold {
   public static void getDefaultEventBasedHold(String projectId, String bucketName)
-      throws StorageException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket =
         storage.get(
             bucketName,
@@ -42,6 +41,7 @@ public class GetDefaultEventBasedHold {
       System.out.println("Default event-based hold is enabled for " + bucketName);
     } else {
       System.out.println("Default event-based hold is not enabled for " + bucketName);
+    }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetPublicAccessPrevention.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetPublicAccessPrevention.java
@@ -31,21 +31,21 @@ public class GetPublicAccessPrevention {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName);
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
 
-    // Gets Bucket Metadata and prints publicAccessPrevention value (either 'inherited' or
-    // 'enforced').
-    BucketInfo.PublicAccessPrevention publicAccessPrevention =
-        bucket.getIamConfiguration().getPublicAccessPrevention();
+      // Gets Bucket Metadata and prints publicAccessPrevention value (either 'inherited' or
+      // 'enforced').
+      BucketInfo.PublicAccessPrevention publicAccessPrevention =
+          bucket.getIamConfiguration().getPublicAccessPrevention();
 
-    System.out.println(
-        "Public access prevention is set to "
-            + publicAccessPrevention.getValue()
-            + " for "
-            + bucketName);
+      System.out.println(
+          "Public access prevention is set to "
+              + publicAccessPrevention.getValue()
+              + " for "
+              + bucketName);
+    }
   }
-  }
-
 }
 // [END storage_get_public_access_prevention]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetPublicAccessPrevention.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetPublicAccessPrevention.java
@@ -23,14 +23,15 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class GetPublicAccessPrevention {
-  public static void getPublicAccessPrevention(String projectId, String bucketName) {
+  public static void getPublicAccessPrevention(String projectId, String bucketName)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName);
 
     // Gets Bucket Metadata and prints publicAccessPrevention value (either 'inherited' or
@@ -44,5 +45,7 @@ public class GetPublicAccessPrevention {
             + " for "
             + bucketName);
   }
+  }
+
 }
 // [END storage_get_public_access_prevention]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetRequesterPaysStatus.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetRequesterPaysStatus.java
@@ -20,23 +20,23 @@ package com.example.storage.bucket;
 
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
 public class GetRequesterPaysStatus {
   public static void getRequesterPaysStatus(String projectId, String bucketName)
-      throws StorageException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket =
         storage.get(bucketName, Storage.BucketGetOption.fields(Storage.BucketField.BILLING));
 
     System.out.println("Requester pays status : " + bucket.requesterPays());
+    }
   }
 }
 // [END storage_get_requester_pays_status]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetRequesterPaysStatus.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetRequesterPaysStatus.java
@@ -23,19 +23,19 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class GetRequesterPaysStatus {
-  public static void getRequesterPaysStatus(String projectId, String bucketName)
-      throws Exception {
+  public static void getRequesterPaysStatus(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket =
-        storage.get(bucketName, Storage.BucketGetOption.fields(Storage.BucketField.BILLING));
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket =
+          storage.get(bucketName, Storage.BucketGetOption.fields(Storage.BucketField.BILLING));
 
-    System.out.println("Requester pays status : " + bucket.requesterPays());
+      System.out.println("Requester pays status : " + bucket.requesterPays());
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetRetentionPolicy.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetRetentionPolicy.java
@@ -24,27 +24,27 @@ import com.google.cloud.storage.StorageOptions;
 import java.util.Date;
 
 public class GetRetentionPolicy {
-  public static void getRetentionPolicy(String projectId, String bucketName)
-      throws Exception {
+  public static void getRetentionPolicy(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket =
-        storage.get(
-            bucketName, Storage.BucketGetOption.fields(Storage.BucketField.RETENTION_POLICY));
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket =
+          storage.get(
+              bucketName, Storage.BucketGetOption.fields(Storage.BucketField.RETENTION_POLICY));
 
-    System.out.println("Retention Policy for " + bucketName);
-    System.out.println("Retention Period: " + bucket.getRetentionPeriod());
-    if (bucket.retentionPolicyIsLocked() != null && bucket.retentionPolicyIsLocked()) {
-      System.out.println("Retention Policy is locked");
-    }
-    if (bucket.getRetentionEffectiveTime() != null) {
-      System.out.println("Effective Time: " + new Date(bucket.getRetentionEffectiveTime()));
-    }
+      System.out.println("Retention Policy for " + bucketName);
+      System.out.println("Retention Period: " + bucket.getRetentionPeriod());
+      if (bucket.retentionPolicyIsLocked() != null && bucket.retentionPolicyIsLocked()) {
+        System.out.println("Retention Policy is locked");
+      }
+      if (bucket.getRetentionEffectiveTime() != null) {
+        System.out.println("Effective Time: " + new Date(bucket.getRetentionEffectiveTime()));
+      }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetRetentionPolicy.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetRetentionPolicy.java
@@ -20,20 +20,19 @@ package com.example.storage.bucket;
 
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import java.util.Date;
 
 public class GetRetentionPolicy {
   public static void getRetentionPolicy(String projectId, String bucketName)
-      throws StorageException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket =
         storage.get(
             bucketName, Storage.BucketGetOption.fields(Storage.BucketField.RETENTION_POLICY));
@@ -45,6 +44,7 @@ public class GetRetentionPolicy {
     }
     if (bucket.getRetentionEffectiveTime() != null) {
       System.out.println("Effective Time: " + new Date(bucket.getRetentionEffectiveTime()));
+    }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetSoftDeletePolicy.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetSoftDeletePolicy.java
@@ -23,14 +23,14 @@ import com.google.cloud.storage.StorageOptions;
 import java.time.Duration;
 
 public class GetSoftDeletePolicy {
-  public static void getSoftDeletePolicy(String projectId, String bucketName) {
+  public static void getSoftDeletePolicy(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     SoftDeletePolicy policy = storage.get(bucketName).getSoftDeletePolicy();
 
     if (Duration.ofSeconds(0).equals(policy.getRetentionDuration())) {
@@ -38,6 +38,7 @@ public class GetSoftDeletePolicy {
     } else {
       System.out.println("The soft delete policy for " + bucketName + " is:");
       System.out.println(policy);
+    }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetSoftDeletePolicy.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetSoftDeletePolicy.java
@@ -30,15 +30,16 @@ public class GetSoftDeletePolicy {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    SoftDeletePolicy policy = storage.get(bucketName).getSoftDeletePolicy();
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      SoftDeletePolicy policy = storage.get(bucketName).getSoftDeletePolicy();
 
-    if (Duration.ofSeconds(0).equals(policy.getRetentionDuration())) {
-      System.out.println("Soft delete is disabled for " + bucketName);
-    } else {
-      System.out.println("The soft delete policy for " + bucketName + " is:");
-      System.out.println(policy);
-    }
+      if (Duration.ofSeconds(0).equals(policy.getRetentionDuration())) {
+        System.out.println("Soft delete is disabled for " + bucketName);
+      } else {
+        System.out.println("The soft delete policy for " + bucketName + " is:");
+        System.out.println(policy);
+      }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetUniformBucketLevelAccess.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetUniformBucketLevelAccess.java
@@ -21,20 +21,19 @@ package com.example.storage.bucket;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import java.util.Date;
 
 public class GetUniformBucketLevelAccess {
   public static void getUniformBucketLevelAccess(String projectId, String bucketName)
-      throws StorageException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket =
         storage.get(
             bucketName, Storage.BucketGetOption.fields(Storage.BucketField.IAMCONFIGURATION));
@@ -48,6 +47,7 @@ public class GetUniformBucketLevelAccess {
       System.out.println("Bucket will be locked on " + lockedTime);
     } else {
       System.out.println("Uniform bucket-level access is disabled for " + bucketName);
+    }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/GetUniformBucketLevelAccess.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/GetUniformBucketLevelAccess.java
@@ -33,21 +33,22 @@ public class GetUniformBucketLevelAccess {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket =
-        storage.get(
-            bucketName, Storage.BucketGetOption.fields(Storage.BucketField.IAMCONFIGURATION));
-    BucketInfo.IamConfiguration iamConfiguration = bucket.getIamConfiguration();
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket =
+          storage.get(
+              bucketName, Storage.BucketGetOption.fields(Storage.BucketField.IAMCONFIGURATION));
+      BucketInfo.IamConfiguration iamConfiguration = bucket.getIamConfiguration();
 
-    Boolean enabled = iamConfiguration.isUniformBucketLevelAccessEnabled();
-    Date lockedTime = new Date(iamConfiguration.getUniformBucketLevelAccessLockedTime());
+      Boolean enabled = iamConfiguration.isUniformBucketLevelAccessEnabled();
+      Date lockedTime = new Date(iamConfiguration.getUniformBucketLevelAccessLockedTime());
 
-    if (enabled != null && enabled) {
-      System.out.println("Uniform bucket-level access is enabled for " + bucketName);
-      System.out.println("Bucket will be locked on " + lockedTime);
-    } else {
-      System.out.println("Uniform bucket-level access is disabled for " + bucketName);
-    }
+      if (enabled != null && enabled) {
+        System.out.println("Uniform bucket-level access is enabled for " + bucketName);
+        System.out.println("Bucket will be locked on " + lockedTime);
+      } else {
+        System.out.println("Uniform bucket-level access is disabled for " + bucketName);
+      }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/ListBucketIamMembers.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/ListBucketIamMembers.java
@@ -23,7 +23,7 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class ListBucketIamMembers {
-  public static void listBucketIamMembers(String projectId, String bucketName) {
+  public static void listBucketIamMembers(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -32,7 +32,7 @@ public class ListBucketIamMembers {
 
     // For more information please read:
     // https://cloud.google.com/storage/docs/access-control/iam
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     Policy policy =
         storage.getIamPolicy(bucketName, Storage.BucketSourceOption.requestedPolicyVersion(3));
@@ -48,6 +48,7 @@ public class ListBucketIamMembers {
         System.out.printf("Condition Description: %s\n", binding.getCondition().getDescription());
         System.out.printf("Condition Expression: %s\n", binding.getCondition().getExpression());
       }
+    }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/ListBucketIamMembers.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/ListBucketIamMembers.java
@@ -32,23 +32,24 @@ public class ListBucketIamMembers {
 
     // For more information please read:
     // https://cloud.google.com/storage/docs/access-control/iam
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    Policy policy =
-        storage.getIamPolicy(bucketName, Storage.BucketSourceOption.requestedPolicyVersion(3));
+      Policy policy =
+          storage.getIamPolicy(bucketName, Storage.BucketSourceOption.requestedPolicyVersion(3));
 
-    // Print binding information
-    for (Binding binding : policy.getBindingsList()) {
-      System.out.printf("Role: %s Members: %s\n", binding.getRole(), binding.getMembers());
+      // Print binding information
+      for (Binding binding : policy.getBindingsList()) {
+        System.out.printf("Role: %s Members: %s\n", binding.getRole(), binding.getMembers());
 
-      // Print condition if one is set
-      boolean bindingIsConditional = binding.getCondition() != null;
-      if (bindingIsConditional) {
-        System.out.printf("Condition Title: %s\n", binding.getCondition().getTitle());
-        System.out.printf("Condition Description: %s\n", binding.getCondition().getDescription());
-        System.out.printf("Condition Expression: %s\n", binding.getCondition().getExpression());
+        // Print condition if one is set
+        boolean bindingIsConditional = binding.getCondition() != null;
+        if (bindingIsConditional) {
+          System.out.printf("Condition Title: %s\n", binding.getCondition().getTitle());
+          System.out.printf("Condition Description: %s\n", binding.getCondition().getDescription());
+          System.out.printf("Condition Expression: %s\n", binding.getCondition().getExpression());
+        }
       }
-    }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/ListBuckets.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/ListBuckets.java
@@ -23,15 +23,16 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class ListBuckets {
-  public static void listBuckets(String projectId) {
+  public static void listBuckets(String projectId) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Page<Bucket> buckets = storage.list();
 
     for (Bucket bucket : buckets.iterateAll()) {
       System.out.println(bucket.getName());
+    }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/ListBuckets.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/ListBuckets.java
@@ -27,12 +27,13 @@ public class ListBuckets {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Page<Bucket> buckets = storage.list();
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Page<Bucket> buckets = storage.list();
 
-    for (Bucket bucket : buckets.iterateAll()) {
-      System.out.println(bucket.getName());
-    }
+      for (Bucket bucket : buckets.iterateAll()) {
+        System.out.println(bucket.getName());
+      }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/ListPubSubNotifications.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/ListPubSubNotifications.java
@@ -24,15 +24,16 @@ import java.util.List;
 
 public class ListPubSubNotifications {
 
-  public static void listPubSubNotifications(String bucketName) {
+  public static void listPubSubNotifications(String bucketName) throws Exception {
     // The ID to give your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().build().getService();
-    List<Notification> notificationList = storage.listNotifications(bucketName);
-    for (Notification notification : notificationList) {
-      System.out.println(
-          "Found notification " + notification.getTopic() + " for bucket " + bucketName);
+    try (Storage storage = StorageOptions.newBuilder().build().getService()) {
+      List<Notification> notificationList = storage.listNotifications(bucketName);
+      for (Notification notification : notificationList) {
+        System.out.println(
+            "Found notification " + notification.getTopic() + " for bucket " + bucketName);
+      }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/LockRetentionPolicy.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/LockRetentionPolicy.java
@@ -20,20 +20,19 @@ package com.example.storage.bucket;
 
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import java.util.Date;
 
 public class LockRetentionPolicy {
   public static void lockRetentionPolicy(String projectId, String bucketName)
-      throws StorageException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket =
         storage.get(bucketName, Storage.BucketGetOption.fields(Storage.BucketField.METAGENERATION));
     Bucket lockedBucket =
@@ -42,6 +41,7 @@ public class LockRetentionPolicy {
     System.out.println("Retention period for " + bucketName + " is now locked");
     System.out.println(
         "Retention policy effective as of " + new Date(lockedBucket.getRetentionEffectiveTime()));
+    }
   }
 }
 // [END storage_lock_retention_policy]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/LockRetentionPolicy.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/LockRetentionPolicy.java
@@ -24,23 +24,24 @@ import com.google.cloud.storage.StorageOptions;
 import java.util.Date;
 
 public class LockRetentionPolicy {
-  public static void lockRetentionPolicy(String projectId, String bucketName)
-      throws Exception {
+  public static void lockRetentionPolicy(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket =
-        storage.get(bucketName, Storage.BucketGetOption.fields(Storage.BucketField.METAGENERATION));
-    Bucket lockedBucket =
-        bucket.lockRetentionPolicy(Storage.BucketTargetOption.metagenerationMatch());
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket =
+          storage.get(
+              bucketName, Storage.BucketGetOption.fields(Storage.BucketField.METAGENERATION));
+      Bucket lockedBucket =
+          bucket.lockRetentionPolicy(Storage.BucketTargetOption.metagenerationMatch());
 
-    System.out.println("Retention period for " + bucketName + " is now locked");
-    System.out.println(
-        "Retention policy effective as of " + new Date(lockedBucket.getRetentionEffectiveTime()));
+      System.out.println("Retention period for " + bucketName + " is now locked");
+      System.out.println(
+          "Retention policy effective as of " + new Date(lockedBucket.getRetentionEffectiveTime()));
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/MakeBucketPublic.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/MakeBucketPublic.java
@@ -24,14 +24,14 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.storage.StorageRoles;
 
 public class MakeBucketPublic {
-  public static void makeBucketPublic(String projectId, String bucketName) {
+  public static void makeBucketPublic(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Policy originalPolicy = storage.getIamPolicy(bucketName);
     storage.setIamPolicy(
         bucketName,
@@ -40,6 +40,7 @@ public class MakeBucketPublic {
             .build());
 
     System.out.println("Bucket " + bucketName + " is now publicly readable");
+    }
   }
 }
 // [END storage_set_bucket_public_iam]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/MakeBucketPublic.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/MakeBucketPublic.java
@@ -31,15 +31,16 @@ public class MakeBucketPublic {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Policy originalPolicy = storage.getIamPolicy(bucketName);
-    storage.setIamPolicy(
-        bucketName,
-        originalPolicy.toBuilder()
-            .addIdentity(StorageRoles.objectViewer(), Identity.allUsers()) // All users can view
-            .build());
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Policy originalPolicy = storage.getIamPolicy(bucketName);
+      storage.setIamPolicy(
+          bucketName,
+          originalPolicy.toBuilder()
+              .addIdentity(StorageRoles.objectViewer(), Identity.allUsers()) // All users can view
+              .build());
 
-    System.out.println("Bucket " + bucketName + " is now publicly readable");
+      System.out.println("Bucket " + bucketName + " is now publicly readable");
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/PrintBucketAcl.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/PrintBucketAcl.java
@@ -30,22 +30,23 @@ public class PrintBucketAcl {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName);
-    List<Acl> bucketAcls = bucket.getAcl();
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
+      List<Acl> bucketAcls = bucket.getAcl();
 
-    for (Acl acl : bucketAcls) {
+      for (Acl acl : bucketAcls) {
 
-      // This will give you the role.
-      // See https://cloud.google.com/storage/docs/access-control/lists#permissions
-      String role = acl.getRole().name();
+        // This will give you the role.
+        // See https://cloud.google.com/storage/docs/access-control/lists#permissions
+        String role = acl.getRole().name();
 
-      // This will give you the Entity type (i.e. User, Group, Project etc.)
-      // See https://cloud.google.com/storage/docs/access-control/lists#scopes
-      String entityType = acl.getEntity().getType().name();
+        // This will give you the Entity type (i.e. User, Group, Project etc.)
+        // See https://cloud.google.com/storage/docs/access-control/lists#scopes
+        String entityType = acl.getEntity().getType().name();
 
-      System.out.printf("%s: %s \n", role, entityType);
-    }
+        System.out.printf("%s: %s \n", role, entityType);
+      }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/PrintBucketAcl.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/PrintBucketAcl.java
@@ -26,11 +26,11 @@ import java.util.List;
 
 public class PrintBucketAcl {
 
-  public static void printBucketAcl(String projectId, String bucketName) {
+  public static void printBucketAcl(String projectId, String bucketName) throws Exception {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName);
     List<Acl> bucketAcls = bucket.getAcl();
 
@@ -45,6 +45,7 @@ public class PrintBucketAcl {
       String entityType = acl.getEntity().getType().name();
 
       System.out.printf("%s: %s \n", role, entityType);
+    }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/PrintBucketAclFilterByUser.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/PrintBucketAclFilterByUser.java
@@ -26,7 +26,8 @@ import com.google.cloud.storage.StorageOptions;
 
 public class PrintBucketAclFilterByUser {
 
-  public static void printBucketAclFilterByUser(String bucketName, String userEmail) {
+  public static void printBucketAclFilterByUser(String bucketName, String userEmail)
+      throws Exception {
 
     // The ID to give your GCS bucket
     // String bucketName = "your-unique-bucket-name";
@@ -34,12 +35,13 @@ public class PrintBucketAclFilterByUser {
     // The email of the user whose acl is being retrieved.
     // String userEmail = "someuser@domain.com"
 
-    Storage storage = StorageOptions.newBuilder().build().getService();
-    Bucket bucket = storage.get(bucketName);
+    try (Storage storage = StorageOptions.newBuilder().build().getService()) {
+      Bucket bucket = storage.get(bucketName);
 
-    Acl userAcl = bucket.getAcl(new User(userEmail));
-    String userRole = userAcl.getRole().name();
-    System.out.println("User " + userEmail + " has role " + userRole);
+      Acl userAcl = bucket.getAcl(new User(userEmail));
+      String userRole = userAcl.getRole().name();
+      System.out.println("User " + userEmail + " has role " + userRole);
+    }
   }
 }
 

--- a/samples/snippets/src/main/java/com/example/storage/bucket/PrintPubSubNotification.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/PrintPubSubNotification.java
@@ -23,17 +23,19 @@ import com.google.cloud.storage.StorageOptions;
 
 public class PrintPubSubNotification {
 
-  public static void printPubSubNotification(String bucketName, String notificationId) {
+  public static void printPubSubNotification(String bucketName, String notificationId)
+      throws Exception {
     // The ID to give your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
     // The Pub/Sub topic you would like to find
     // String notificationId = "your-unique-notification-id"
 
-    Storage storage = StorageOptions.newBuilder().build().getService();
-    Notification notification = storage.getNotification(bucketName, notificationId);
-    System.out.println(
-        "Found notification " + notification.getTopic() + " for bucket " + bucketName);
+    try (Storage storage = StorageOptions.newBuilder().build().getService()) {
+      Notification notification = storage.getNotification(bucketName, notificationId);
+      System.out.println(
+          "Found notification " + notification.getTopic() + " for bucket " + bucketName);
+    }
   }
 }
 // [END storage_print_pubsub_bucket_notification]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketCors.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketCors.java
@@ -26,14 +26,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class RemoveBucketCors {
-  public static void removeBucketCors(String projectId, String bucketName) {
+  public static void removeBucketCors(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket =
         storage.get(bucketName, Storage.BucketGetOption.fields(Storage.BucketField.CORS));
 
@@ -46,6 +46,7 @@ public class RemoveBucketCors {
     // Update bucket to remove CORS.
     bucket.toBuilder().setCors(cors).build().update();
     System.out.println("Removed CORS configuration from bucket " + bucketName);
+    }
   }
 }
 // [END storage_remove_cors_configuration]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketCors.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketCors.java
@@ -33,19 +33,20 @@ public class RemoveBucketCors {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket =
-        storage.get(bucketName, Storage.BucketGetOption.fields(Storage.BucketField.CORS));
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket =
+          storage.get(bucketName, Storage.BucketGetOption.fields(Storage.BucketField.CORS));
 
-    // getCors() returns the List and copying over to an ArrayList so it's mutable.
-    List<Cors> cors = new ArrayList<>(bucket.getCors());
+      // getCors() returns the List and copying over to an ArrayList so it's mutable.
+      List<Cors> cors = new ArrayList<>(bucket.getCors());
 
-    // Clear bucket CORS configuration.
-    cors.clear();
+      // Clear bucket CORS configuration.
+      cors.clear();
 
-    // Update bucket to remove CORS.
-    bucket.toBuilder().setCors(cors).build().update();
-    System.out.println("Removed CORS configuration from bucket " + bucketName);
+      // Update bucket to remove CORS.
+      bucket.toBuilder().setCors(cors).build().update();
+      System.out.println("Removed CORS configuration from bucket " + bucketName);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketDefaultKmsKey.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketDefaultKmsKey.java
@@ -23,14 +23,15 @@ import com.google.cloud.storage.Storage.BucketTargetOption;
 import com.google.cloud.storage.StorageOptions;
 
 public class RemoveBucketDefaultKmsKey {
-  public static void removeBucketDefaultKmsKey(String projectId, String bucketName) {
+  public static void removeBucketDefaultKmsKey(String projectId, String bucketName)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     // first look up the bucket, so we will have its metageneration
     Bucket bucket = storage.get(bucketName);
     storage.update(
@@ -38,6 +39,7 @@ public class RemoveBucketDefaultKmsKey {
         BucketTargetOption.metagenerationMatch());
 
     System.out.println("Default KMS key was removed from " + bucketName);
+    }
   }
 }
 // [END storage_bucket_delete_default_kms_key]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketDefaultKmsKey.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketDefaultKmsKey.java
@@ -31,14 +31,15 @@ public class RemoveBucketDefaultKmsKey {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    // first look up the bucket, so we will have its metageneration
-    Bucket bucket = storage.get(bucketName);
-    storage.update(
-        bucket.toBuilder().setDefaultKmsKeyName(null).build(),
-        BucketTargetOption.metagenerationMatch());
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      // first look up the bucket, so we will have its metageneration
+      Bucket bucket = storage.get(bucketName);
+      storage.update(
+          bucket.toBuilder().setDefaultKmsKeyName(null).build(),
+          BucketTargetOption.metagenerationMatch());
 
-    System.out.println("Default KMS key was removed from " + bucketName);
+      System.out.println("Default KMS key was removed from " + bucketName);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketDefaultOwner.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketDefaultOwner.java
@@ -25,7 +25,8 @@ import com.google.cloud.storage.StorageOptions;
 
 public class RemoveBucketDefaultOwner {
 
-  public static void removeBucketDefaultOwner(String bucketName, String userEmail) {
+  public static void removeBucketDefaultOwner(String bucketName, String userEmail)
+      throws Exception {
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
@@ -33,15 +34,16 @@ public class RemoveBucketDefaultOwner {
     // The email of the user you wish to remove as a default owner
     // String userEmail = "someuser@domain.com"
 
-    Storage storage = StorageOptions.newBuilder().build().getService();
-    Bucket bucket = storage.get(bucketName);
-    User userToRemove = new User(userEmail);
+    try (Storage storage = StorageOptions.newBuilder().build().getService()) {
+      Bucket bucket = storage.get(bucketName);
+      User userToRemove = new User(userEmail);
 
-    boolean success = bucket.deleteDefaultAcl(userToRemove);
-    if (success) {
-      System.out.println("Removed user " + userEmail + " as an owner on " + bucketName);
-    } else {
-      System.out.println("User " + userEmail + " was not found");
+      boolean success = bucket.deleteDefaultAcl(userToRemove);
+      if (success) {
+        System.out.println("Removed user " + userEmail + " as an owner on " + bucketName);
+      } else {
+        System.out.println("User " + userEmail + " was not found");
+      }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketIamConditionalBinding.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketIamConditionalBinding.java
@@ -39,42 +39,44 @@ public class RemoveBucketIamConditionalBinding {
 
     // For more information please read:
     // https://cloud.google.com/storage/docs/access-control/iam
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    Policy originalPolicy =
-        storage.getIamPolicy(bucketName, Storage.BucketSourceOption.requestedPolicyVersion(3));
+      Policy originalPolicy =
+          storage.getIamPolicy(bucketName, Storage.BucketSourceOption.requestedPolicyVersion(3));
 
-    String role = "roles/storage.objectViewer";
+      String role = "roles/storage.objectViewer";
 
-    // getBindingsList() returns an ImmutableList and copying over to an ArrayList so it's mutable.
-    List<Binding> bindings = new ArrayList(originalPolicy.getBindingsList());
+      // getBindingsList() returns an ImmutableList and copying over to an ArrayList so it's
+      // mutable.
+      List<Binding> bindings = new ArrayList(originalPolicy.getBindingsList());
 
-    // Create a condition to compare against
-    Condition.Builder conditionBuilder = Condition.newBuilder();
-    conditionBuilder.setTitle("Title");
-    conditionBuilder.setDescription("Description");
-    conditionBuilder.setExpression(
-        "resource.name.startsWith(\"projects/_/buckets/bucket-name/objects/prefix-a-\")");
+      // Create a condition to compare against
+      Condition.Builder conditionBuilder = Condition.newBuilder();
+      conditionBuilder.setTitle("Title");
+      conditionBuilder.setDescription("Description");
+      conditionBuilder.setExpression(
+          "resource.name.startsWith(\"projects/_/buckets/bucket-name/objects/prefix-a-\")");
 
-    Iterator iterator = bindings.iterator();
-    while (iterator.hasNext()) {
-      Binding binding = (Binding) iterator.next();
-      boolean foundRole = binding.getRole().equals(role);
-      boolean conditionsEqual = conditionBuilder.build().equals(binding.getCondition());
+      Iterator iterator = bindings.iterator();
+      while (iterator.hasNext()) {
+        Binding binding = (Binding) iterator.next();
+        boolean foundRole = binding.getRole().equals(role);
+        boolean conditionsEqual = conditionBuilder.build().equals(binding.getCondition());
 
-      // Remove condition when the role and condition are equal
-      if (foundRole && conditionsEqual) {
-        iterator.remove();
-        break;
+        // Remove condition when the role and condition are equal
+        if (foundRole && conditionsEqual) {
+          iterator.remove();
+          break;
+        }
       }
-    }
 
-    // Update policy to remove conditional binding
-    Policy.Builder updatedPolicyBuilder = originalPolicy.toBuilder();
-    updatedPolicyBuilder.setBindings(bindings).setVersion(3);
-    Policy updatedPolicy = storage.setIamPolicy(bucketName, updatedPolicyBuilder.build());
+      // Update policy to remove conditional binding
+      Policy.Builder updatedPolicyBuilder = originalPolicy.toBuilder();
+      updatedPolicyBuilder.setBindings(bindings).setVersion(3);
+      Policy updatedPolicy = storage.setIamPolicy(bucketName, updatedPolicyBuilder.build());
 
-    System.out.println("Conditional Binding was removed.");
+      System.out.println("Conditional Binding was removed.");
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketIamConditionalBinding.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketIamConditionalBinding.java
@@ -29,7 +29,8 @@ import java.util.List;
 
 public class RemoveBucketIamConditionalBinding {
   /** Example of removing a conditional binding to the Bucket-level IAM */
-  public static void removeBucketIamConditionalBinding(String projectId, String bucketName) {
+  public static void removeBucketIamConditionalBinding(String projectId, String bucketName)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -38,7 +39,7 @@ public class RemoveBucketIamConditionalBinding {
 
     // For more information please read:
     // https://cloud.google.com/storage/docs/access-control/iam
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     Policy originalPolicy =
         storage.getIamPolicy(bucketName, Storage.BucketSourceOption.requestedPolicyVersion(3));
@@ -74,6 +75,7 @@ public class RemoveBucketIamConditionalBinding {
     Policy updatedPolicy = storage.setIamPolicy(bucketName, updatedPolicyBuilder.build());
 
     System.out.println("Conditional Binding was removed.");
+    }
   }
 }
 // [END storage_remove_bucket_conditional_iam_binding]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketIamMember.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketIamMember.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class RemoveBucketIamMember {
-  public static void removeBucketIamMember(String projectId, String bucketName) {
+  public static void removeBucketIamMember(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -35,7 +35,7 @@ public class RemoveBucketIamMember {
 
     // For more information please read:
     // https://cloud.google.com/storage/docs/access-control/iam
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     Policy originalPolicy =
         storage.getIamPolicy(bucketName, Storage.BucketSourceOption.requestedPolicyVersion(3));
@@ -65,6 +65,7 @@ public class RemoveBucketIamMember {
     Policy updatedPolicy = storage.setIamPolicy(bucketName, updatedPolicyBuilder.build());
 
     System.out.printf("Removed %s with role %s from %s\n", member, role, bucketName);
+  }
   }
 }
 // [END storage_remove_bucket_iam_member]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketIamMember.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketIamMember.java
@@ -35,37 +35,39 @@ public class RemoveBucketIamMember {
 
     // For more information please read:
     // https://cloud.google.com/storage/docs/access-control/iam
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    Policy originalPolicy =
-        storage.getIamPolicy(bucketName, Storage.BucketSourceOption.requestedPolicyVersion(3));
+      Policy originalPolicy =
+          storage.getIamPolicy(bucketName, Storage.BucketSourceOption.requestedPolicyVersion(3));
 
-    String role = "roles/storage.objectViewer";
-    String member = "group:example@google.com";
+      String role = "roles/storage.objectViewer";
+      String member = "group:example@google.com";
 
-    // getBindingsList() returns an ImmutableList and copying over to an ArrayList so it's mutable.
-    List<Binding> bindings = new ArrayList(originalPolicy.getBindingsList());
+      // getBindingsList() returns an ImmutableList and copying over to an ArrayList so it's
+      // mutable.
+      List<Binding> bindings = new ArrayList(originalPolicy.getBindingsList());
 
-    // Remove role-member binding without a condition.
-    for (int index = 0; index < bindings.size(); index++) {
-      Binding binding = bindings.get(index);
-      boolean foundRole = binding.getRole().equals(role);
-      boolean foundMember = binding.getMembers().contains(member);
-      boolean bindingIsNotConditional = binding.getCondition() == null;
+      // Remove role-member binding without a condition.
+      for (int index = 0; index < bindings.size(); index++) {
+        Binding binding = bindings.get(index);
+        boolean foundRole = binding.getRole().equals(role);
+        boolean foundMember = binding.getMembers().contains(member);
+        boolean bindingIsNotConditional = binding.getCondition() == null;
 
-      if (foundRole && foundMember && bindingIsNotConditional) {
-        bindings.set(index, binding.toBuilder().removeMembers(member).build());
-        break;
+        if (foundRole && foundMember && bindingIsNotConditional) {
+          bindings.set(index, binding.toBuilder().removeMembers(member).build());
+          break;
+        }
       }
+
+      // Update policy to remove member
+      Policy.Builder updatedPolicyBuilder = originalPolicy.toBuilder();
+      updatedPolicyBuilder.setBindings(bindings).setVersion(3);
+      Policy updatedPolicy = storage.setIamPolicy(bucketName, updatedPolicyBuilder.build());
+
+      System.out.printf("Removed %s with role %s from %s\n", member, role, bucketName);
     }
-
-    // Update policy to remove member
-    Policy.Builder updatedPolicyBuilder = originalPolicy.toBuilder();
-    updatedPolicyBuilder.setBindings(bindings).setVersion(3);
-    Policy updatedPolicy = storage.setIamPolicy(bucketName, updatedPolicyBuilder.build());
-
-    System.out.printf("Removed %s with role %s from %s\n", member, role, bucketName);
-  }
   }
 }
 // [END storage_remove_bucket_iam_member]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketLabel.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketLabel.java
@@ -25,7 +25,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class RemoveBucketLabel {
-  public static void removeBucketLabel(String projectId, String bucketName, String labelKey) {
+  public static void removeBucketLabel(String projectId, String bucketName, String labelKey)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -35,7 +36,7 @@ public class RemoveBucketLabel {
     // The key of the label to remove from the bucket
     // String labelKey = "label-key-to-remove";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     Map<String, String> labelsToRemove = new HashMap<>();
     labelsToRemove.put(labelKey, null);
@@ -51,6 +52,7 @@ public class RemoveBucketLabel {
     bucket.toBuilder().setLabels(labels).build().update();
 
     System.out.println("Removed label " + labelKey + " from bucket " + bucketName);
+  }
   }
 }
 // [END storage_remove_bucket_label]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketLabel.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketLabel.java
@@ -36,23 +36,24 @@ public class RemoveBucketLabel {
     // The key of the label to remove from the bucket
     // String labelKey = "label-key-to-remove";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    Map<String, String> labelsToRemove = new HashMap<>();
-    labelsToRemove.put(labelKey, null);
+      Map<String, String> labelsToRemove = new HashMap<>();
+      labelsToRemove.put(labelKey, null);
 
-    Bucket bucket = storage.get(bucketName);
-    Map<String, String> labels;
-    if (bucket.getLabels() == null) {
-      labels = new HashMap<>();
-    } else {
-      labels = new HashMap(bucket.getLabels());
+      Bucket bucket = storage.get(bucketName);
+      Map<String, String> labels;
+      if (bucket.getLabels() == null) {
+        labels = new HashMap<>();
+      } else {
+        labels = new HashMap(bucket.getLabels());
+      }
+      labels.putAll(labelsToRemove);
+      bucket.toBuilder().setLabels(labels).build().update();
+
+      System.out.println("Removed label " + labelKey + " from bucket " + bucketName);
     }
-    labels.putAll(labelsToRemove);
-    bucket.toBuilder().setLabels(labels).build().update();
-
-    System.out.println("Removed label " + labelKey + " from bucket " + bucketName);
-  }
   }
 }
 // [END storage_remove_bucket_label]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketOwner.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketOwner.java
@@ -37,16 +37,17 @@ public class RemoveBucketOwner {
     // Email of the user you wish to remove as an owner
     // String userEmail = "someuser@domain.com"
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName);
-    User ownerToRemove = new User(userEmail);
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
+      User ownerToRemove = new User(userEmail);
 
-    boolean success = bucket.deleteAcl(ownerToRemove);
-    if (success) {
-      System.out.println("Removed user " + userEmail + " as an owner on " + bucketName);
-    } else {
-      System.out.println("User " + userEmail + " was not found");
-    }
+      boolean success = bucket.deleteAcl(ownerToRemove);
+      if (success) {
+        System.out.println("Removed user " + userEmail + " as an owner on " + bucketName);
+      } else {
+        System.out.println("User " + userEmail + " was not found");
+      }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketOwner.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/RemoveBucketOwner.java
@@ -25,7 +25,8 @@ import com.google.cloud.storage.StorageOptions;
 
 public class RemoveBucketOwner {
 
-  public static void removeBucketOwner(String projectId, String bucketName, String userEmail) {
+  public static void removeBucketOwner(String projectId, String bucketName, String userEmail)
+      throws Exception {
 
     // The ID of your GCP project
     // String projectId = "your-project-id";
@@ -36,7 +37,7 @@ public class RemoveBucketOwner {
     // Email of the user you wish to remove as an owner
     // String userEmail = "someuser@domain.com"
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName);
     User ownerToRemove = new User(userEmail);
 
@@ -45,6 +46,7 @@ public class RemoveBucketOwner {
       System.out.println("Removed user " + userEmail + " as an owner on " + bucketName);
     } else {
       System.out.println("User " + userEmail + " was not found");
+    }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/RemoveRetentionPolicy.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/RemoveRetentionPolicy.java
@@ -23,27 +23,27 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class RemoveRetentionPolicy {
-  public static void removeRetentionPolicy(String projectId, String bucketName)
-      throws Exception {
+  public static void removeRetentionPolicy(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    Bucket bucket =
-        storage.get(
-            bucketName, Storage.BucketGetOption.fields(Storage.BucketField.RETENTION_POLICY));
-    if (bucket.retentionPolicyIsLocked() != null && bucket.retentionPolicyIsLocked()) {
-      throw new IllegalArgumentException(
-          "Unable to remove retention policy as retention policy is locked.");
-    }
+      Bucket bucket =
+          storage.get(
+              bucketName, Storage.BucketGetOption.fields(Storage.BucketField.RETENTION_POLICY));
+      if (bucket.retentionPolicyIsLocked() != null && bucket.retentionPolicyIsLocked()) {
+        throw new IllegalArgumentException(
+            "Unable to remove retention policy as retention policy is locked.");
+      }
 
-    bucket.toBuilder().setRetentionPeriod(null).build().update();
+      bucket.toBuilder().setRetentionPeriod(null).build().update();
 
-    System.out.println("Retention policy for " + bucketName + " has been removed");
+      System.out.println("Retention policy for " + bucketName + " has been removed");
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/RemoveRetentionPolicy.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/RemoveRetentionPolicy.java
@@ -20,19 +20,18 @@ package com.example.storage.bucket;
 
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
 public class RemoveRetentionPolicy {
   public static void removeRetentionPolicy(String projectId, String bucketName)
-      throws StorageException, IllegalArgumentException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     Bucket bucket =
         storage.get(
@@ -45,6 +44,7 @@ public class RemoveRetentionPolicy {
     bucket.toBuilder().setRetentionPeriod(null).build().update();
 
     System.out.println("Retention policy for " + bucketName + " has been removed");
+    }
   }
 }
 // [END storage_remove_retention_policy]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetAsyncTurboRpo.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetAsyncTurboRpo.java
@@ -23,19 +23,20 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class SetAsyncTurboRpo {
-  public static void setAsyncTurboRpo(String projectId, String bucketName) {
+  public static void setAsyncTurboRpo(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName);
 
     bucket.toBuilder().setRpo(Rpo.ASYNC_TURBO).build().update();
 
     System.out.println("Turbo replication was enabled for " + bucketName);
+    }
   }
 }
 // [END storage_set_rpo_async_turbo]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetAsyncTurboRpo.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetAsyncTurboRpo.java
@@ -30,12 +30,13 @@ public class SetAsyncTurboRpo {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName);
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
 
-    bucket.toBuilder().setRpo(Rpo.ASYNC_TURBO).build().update();
+      bucket.toBuilder().setRpo(Rpo.ASYNC_TURBO).build().update();
 
-    System.out.println("Turbo replication was enabled for " + bucketName);
+      System.out.println("Turbo replication was enabled for " + bucketName);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetBucketDefaultKmsKey.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetBucketDefaultKmsKey.java
@@ -21,12 +21,11 @@ package com.example.storage.bucket;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BucketTargetOption;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
 public class SetBucketDefaultKmsKey {
   public static void setBucketDefaultKmsKey(String projectId, String bucketName, String kmsKeyName)
-      throws StorageException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -37,7 +36,7 @@ public class SetBucketDefaultKmsKey {
     // String kmsKeyName =
     // "projects/your-project-id/locations/us/keyRings/my_key_ring/cryptoKeys/my_key"
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     // first look up the bucket, so we will have its metageneration
     Bucket bucket = storage.get(bucketName);
 
@@ -51,6 +50,7 @@ public class SetBucketDefaultKmsKey {
             + updated.getDefaultKmsKeyName()
             + "was set to default for bucket "
             + bucketName);
+    }
   }
 }
 // [END storage_set_bucket_default_kms_key]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetBucketDefaultKmsKey.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetBucketDefaultKmsKey.java
@@ -36,20 +36,21 @@ public class SetBucketDefaultKmsKey {
     // String kmsKeyName =
     // "projects/your-project-id/locations/us/keyRings/my_key_ring/cryptoKeys/my_key"
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    // first look up the bucket, so we will have its metageneration
-    Bucket bucket = storage.get(bucketName);
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      // first look up the bucket, so we will have its metageneration
+      Bucket bucket = storage.get(bucketName);
 
-    Bucket updated =
-        storage.update(
-            bucket.toBuilder().setDefaultKmsKeyName(kmsKeyName).build(),
-            BucketTargetOption.metagenerationMatch());
+      Bucket updated =
+          storage.update(
+              bucket.toBuilder().setDefaultKmsKeyName(kmsKeyName).build(),
+              BucketTargetOption.metagenerationMatch());
 
-    System.out.println(
-        "KMS Key "
-            + updated.getDefaultKmsKeyName()
-            + "was set to default for bucket "
-            + bucketName);
+      System.out.println(
+          "KMS Key "
+              + updated.getDefaultKmsKeyName()
+              + "was set to default for bucket "
+              + bucketName);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetBucketWebsiteInfo.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetBucketWebsiteInfo.java
@@ -36,18 +36,19 @@ public class SetBucketWebsiteInfo {
     // The 404 page for a static website bucket
     // String notFoundPage = "404.html";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName);
-    bucket.toBuilder().setIndexPage(indexPage).setNotFoundPage(notFoundPage).build().update();
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
+      bucket.toBuilder().setIndexPage(indexPage).setNotFoundPage(notFoundPage).build().update();
 
-    System.out.println(
-        "Static website bucket "
-            + bucketName
-            + " is set up to use "
-            + indexPage
-            + " as the index page and "
-            + notFoundPage
-            + " as the 404 page");
+      System.out.println(
+          "Static website bucket "
+              + bucketName
+              + " is set up to use "
+              + indexPage
+              + " as the index page and "
+              + notFoundPage
+              + " as the 404 page");
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetBucketWebsiteInfo.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetBucketWebsiteInfo.java
@@ -23,7 +23,7 @@ import com.google.cloud.storage.StorageOptions;
 
 public class SetBucketWebsiteInfo {
   public static void setBucketWesbiteInfo(
-      String projectId, String bucketName, String indexPage, String notFoundPage) {
+      String projectId, String bucketName, String indexPage, String notFoundPage) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -36,7 +36,7 @@ public class SetBucketWebsiteInfo {
     // The 404 page for a static website bucket
     // String notFoundPage = "404.html";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName);
     bucket.toBuilder().setIndexPage(indexPage).setNotFoundPage(notFoundPage).build().update();
 
@@ -48,6 +48,7 @@ public class SetBucketWebsiteInfo {
             + " as the index page and "
             + notFoundPage
             + " as the 404 page");
+    }
   }
 }
 // [END storage_define_bucket_website_configuration]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetClientEndpoint.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetClientEndpoint.java
@@ -23,18 +23,19 @@ import com.google.cloud.storage.StorageOptions;
 
 public class SetClientEndpoint {
 
-  public static void setClientEndpoint(String projectId, String endpoint) {
+  public static void setClientEndpoint(String projectId, String endpoint) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The endpoint you wish to target
     // String endpoint = "https://storage.googleapis.com"
 
-    Storage storage =
-        StorageOptions.newBuilder().setProjectId(projectId).setHost(endpoint).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).setHost(endpoint)
+        .build().getService()) {
 
-    System.out.println(
-        "Storage Client initialized with endpoint " + storage.getOptions().getHost());
+      System.out.println(
+          "Storage Client initialized with endpoint " + storage.getOptions().getHost());
+    }
   }
 }
 

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetClientEndpoint.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetClientEndpoint.java
@@ -30,8 +30,12 @@ public class SetClientEndpoint {
     // The endpoint you wish to target
     // String endpoint = "https://storage.googleapis.com"
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).setHost(endpoint)
-        .build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder()
+            .setProjectId(projectId)
+            .setHost(endpoint)
+            .build()
+            .getService()) {
 
       System.out.println(
           "Storage Client initialized with endpoint " + storage.getOptions().getHost());

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetDefaultRpo.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetDefaultRpo.java
@@ -23,19 +23,20 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class SetDefaultRpo {
-  public static void setDefaultRpo(String projectId, String bucketName) {
+  public static void setDefaultRpo(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName);
 
     bucket.toBuilder().setRpo(Rpo.DEFAULT).build().update();
 
     System.out.println("Replication was set to default for " + bucketName);
+    }
   }
 }
 // [END storage_set_rpo_default]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetDefaultRpo.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetDefaultRpo.java
@@ -30,12 +30,13 @@ public class SetDefaultRpo {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName);
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
 
-    bucket.toBuilder().setRpo(Rpo.DEFAULT).build().update();
+      bucket.toBuilder().setRpo(Rpo.DEFAULT).build().update();
 
-    System.out.println("Replication was set to default for " + bucketName);
+      System.out.println("Replication was set to default for " + bucketName);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetPublicAccessPreventionEnforced.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetPublicAccessPreventionEnforced.java
@@ -31,19 +31,20 @@ public class SetPublicAccessPreventionEnforced {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName);
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
 
-    // Enforces public access prevention for the bucket
-    bucket.toBuilder()
-        .setIamConfiguration(
-            BucketInfo.IamConfiguration.newBuilder()
-                .setPublicAccessPrevention(BucketInfo.PublicAccessPrevention.ENFORCED)
-                .build())
-        .build()
-        .update();
+      // Enforces public access prevention for the bucket
+      bucket.toBuilder()
+          .setIamConfiguration(
+              BucketInfo.IamConfiguration.newBuilder()
+                  .setPublicAccessPrevention(BucketInfo.PublicAccessPrevention.ENFORCED)
+                  .build())
+          .build()
+          .update();
 
-    System.out.println("Public access prevention is set to enforced for " + bucketName);
+      System.out.println("Public access prevention is set to enforced for " + bucketName);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetPublicAccessPreventionEnforced.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetPublicAccessPreventionEnforced.java
@@ -23,14 +23,15 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class SetPublicAccessPreventionEnforced {
-  public static void setPublicAccessPreventionEnforced(String projectId, String bucketName) {
+  public static void setPublicAccessPreventionEnforced(String projectId, String bucketName)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName);
 
     // Enforces public access prevention for the bucket
@@ -43,6 +44,7 @@ public class SetPublicAccessPreventionEnforced {
         .update();
 
     System.out.println("Public access prevention is set to enforced for " + bucketName);
+    }
   }
 }
 // [END storage_set_public_access_prevention_enforced]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetPublicAccessPreventionInherited.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetPublicAccessPreventionInherited.java
@@ -31,19 +31,20 @@ public class SetPublicAccessPreventionInherited {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName);
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
 
-    // Sets public access prevention to 'inherited' for the bucket
-    bucket.toBuilder()
-        .setIamConfiguration(
-            BucketInfo.IamConfiguration.newBuilder()
-                .setPublicAccessPrevention(BucketInfo.PublicAccessPrevention.INHERITED)
-                .build())
-        .build()
-        .update();
+      // Sets public access prevention to 'inherited' for the bucket
+      bucket.toBuilder()
+          .setIamConfiguration(
+              BucketInfo.IamConfiguration.newBuilder()
+                  .setPublicAccessPrevention(BucketInfo.PublicAccessPrevention.INHERITED)
+                  .build())
+          .build()
+          .update();
 
-    System.out.println("Public access prevention is set to 'inherited' for " + bucketName);
+      System.out.println("Public access prevention is set to 'inherited' for " + bucketName);
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetPublicAccessPreventionInherited.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetPublicAccessPreventionInherited.java
@@ -23,14 +23,15 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class SetPublicAccessPreventionInherited {
-  public static void setPublicAccessPreventionInherited(String projectId, String bucketName) {
+  public static void setPublicAccessPreventionInherited(String projectId, String bucketName)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName);
 
     // Sets public access prevention to 'inherited' for the bucket
@@ -43,6 +44,7 @@ public class SetPublicAccessPreventionInherited {
         .update();
 
     System.out.println("Public access prevention is set to 'inherited' for " + bucketName);
+    }
   }
 }
 // [END storage_set_public_access_prevention_inherited]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetRetentionPolicy.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetRetentionPolicy.java
@@ -36,22 +36,23 @@ public class SetRetentionPolicy {
     // The retention period for objects in bucket
     // Long retentionPeriodSeconds = 3600L; // 1 hour in seconds
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    // first look up the bucket so we will have its metageneration
-    Bucket bucket = storage.get(bucketName);
-    Bucket bucketWithRetentionPolicy =
-        storage.update(
-            bucket.toBuilder()
-                .setRetentionPeriodDuration(Duration.ofSeconds(retentionPeriodSeconds))
-                .build(),
-            BucketTargetOption.metagenerationMatch());
+      // first look up the bucket so we will have its metageneration
+      Bucket bucket = storage.get(bucketName);
+      Bucket bucketWithRetentionPolicy =
+          storage.update(
+              bucket.toBuilder()
+                  .setRetentionPeriodDuration(Duration.ofSeconds(retentionPeriodSeconds))
+                  .build(),
+              BucketTargetOption.metagenerationMatch());
 
-    System.out.println(
-        "Retention period for "
-            + bucketName
-            + " is now "
-            + bucketWithRetentionPolicy.getRetentionPeriodDuration());
+      System.out.println(
+          "Retention period for "
+              + bucketName
+              + " is now "
+              + bucketWithRetentionPolicy.getRetentionPeriodDuration());
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetRetentionPolicy.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetRetentionPolicy.java
@@ -21,13 +21,12 @@ package com.example.storage.bucket;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Storage.BucketTargetOption;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import java.time.Duration;
 
 public class SetRetentionPolicy {
   public static void setRetentionPolicy(
-      String projectId, String bucketName, Long retentionPeriodSeconds) throws StorageException {
+      String projectId, String bucketName, Long retentionPeriodSeconds) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -37,7 +36,7 @@ public class SetRetentionPolicy {
     // The retention period for objects in bucket
     // Long retentionPeriodSeconds = 3600L; // 1 hour in seconds
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     // first look up the bucket so we will have its metageneration
     Bucket bucket = storage.get(bucketName);
@@ -53,6 +52,7 @@ public class SetRetentionPolicy {
             + bucketName
             + " is now "
             + bucketWithRetentionPolicy.getRetentionPeriodDuration());
+    }
   }
 }
 // [END storage_set_retention_policy]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetSoftDeletePolicy.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetSoftDeletePolicy.java
@@ -31,19 +31,20 @@ public class SetSoftDeletePolicy {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName);
-    bucket.toBuilder()
-        .setSoftDeletePolicy(
-            BucketInfo.SoftDeletePolicy.newBuilder()
-                .setRetentionDuration(Duration.ofDays(10))
-                .build())
-        .build()
-        .update();
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
+      bucket.toBuilder()
+          .setSoftDeletePolicy(
+              BucketInfo.SoftDeletePolicy.newBuilder()
+                  .setRetentionDuration(Duration.ofDays(10))
+                  .build())
+          .build()
+          .update();
 
-    System.out.println(
-        "Soft delete policy for " + bucketName + " was set to a 10-day retention period");
-  }
+      System.out.println(
+          "Soft delete policy for " + bucketName + " was set to a 10-day retention period");
+    }
   }
 }
 // [END storage_set_soft_delete_policy]

--- a/samples/snippets/src/main/java/com/example/storage/bucket/SetSoftDeletePolicy.java
+++ b/samples/snippets/src/main/java/com/example/storage/bucket/SetSoftDeletePolicy.java
@@ -24,14 +24,14 @@ import com.google.cloud.storage.StorageOptions;
 import java.time.Duration;
 
 public class SetSoftDeletePolicy {
-  public static void setSoftDeletePolicy(String projectId, String bucketName) {
+  public static void setSoftDeletePolicy(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName);
     bucket.toBuilder()
         .setSoftDeletePolicy(
@@ -43,6 +43,7 @@ public class SetSoftDeletePolicy {
 
     System.out.println(
         "Soft delete policy for " + bucketName + " was set to a 10-day retention period");
+  }
   }
 }
 // [END storage_set_soft_delete_policy]

--- a/samples/snippets/src/main/java/com/example/storage/hmac/ActivateHmacKey.java
+++ b/samples/snippets/src/main/java/com/example/storage/hmac/ActivateHmacKey.java
@@ -20,35 +20,35 @@ package com.example.storage.hmac;
 
 import com.google.cloud.storage.HmacKey;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import java.util.Date;
 
 public class ActivateHmacKey {
-  public static void activateHmacKey(String accessId, String projectId) throws StorageException {
+  public static void activateHmacKey(String accessId, String projectId) throws Exception {
     // The access ID of the HMAC key.
     // String accessId = "GOOG0234230X00";
 
     // The ID of the project to which the service account belongs.
     // String projectId = "project-id";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    HmacKey.HmacKeyMetadata metadata =
-        storage.getHmacKey(accessId, Storage.GetHmacKeyOption.projectId(projectId));
-    HmacKey.HmacKeyMetadata newMetadata =
-        storage.updateHmacKeyState(metadata, HmacKey.HmacKeyState.ACTIVE);
+      HmacKey.HmacKeyMetadata metadata =
+          storage.getHmacKey(accessId, Storage.GetHmacKeyOption.projectId(projectId));
+      HmacKey.HmacKeyMetadata newMetadata =
+          storage.updateHmacKeyState(metadata, HmacKey.HmacKeyState.ACTIVE);
 
-    System.out.println("The HMAC key is now active.");
-    System.out.println("The HMAC key metadata is:");
-    System.out.println("ID: " + newMetadata.getId());
-    System.out.println("Access ID: " + newMetadata.getAccessId());
-    System.out.println("Project ID: " + newMetadata.getProjectId());
-    System.out.println("Service Account Email: " + newMetadata.getServiceAccount().getEmail());
-    System.out.println("State: " + newMetadata.getState().toString());
-    System.out.println("Time Created: " + new Date(newMetadata.getCreateTime()).toString());
-    System.out.println("Time Updated: " + new Date(newMetadata.getUpdateTime()).toString());
-    System.out.println("ETag: " + newMetadata.getEtag());
+      System.out.println("The HMAC key is now active.");
+      System.out.println("The HMAC key metadata is:");
+      System.out.println("ID: " + newMetadata.getId());
+      System.out.println("Access ID: " + newMetadata.getAccessId());
+      System.out.println("Project ID: " + newMetadata.getProjectId());
+      System.out.println("Service Account Email: " + newMetadata.getServiceAccount().getEmail());
+      System.out.println("State: " + newMetadata.getState().toString());
+      System.out.println("Time Created: " + new Date(newMetadata.getCreateTime()).toString());
+      System.out.println("Time Updated: " + new Date(newMetadata.getUpdateTime()).toString());
+      System.out.println("ETag: " + newMetadata.getEtag());
+    }
   }
 }
 // [END storage_activate_hmac_key]

--- a/samples/snippets/src/main/java/com/example/storage/hmac/ActivateHmacKey.java
+++ b/samples/snippets/src/main/java/com/example/storage/hmac/ActivateHmacKey.java
@@ -31,7 +31,8 @@ public class ActivateHmacKey {
     // The ID of the project to which the service account belongs.
     // String projectId = "project-id";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
       HmacKey.HmacKeyMetadata metadata =
           storage.getHmacKey(accessId, Storage.GetHmacKeyOption.projectId(projectId));

--- a/samples/snippets/src/main/java/com/example/storage/hmac/CreateHmacKey.java
+++ b/samples/snippets/src/main/java/com/example/storage/hmac/CreateHmacKey.java
@@ -25,8 +25,7 @@ import com.google.cloud.storage.StorageOptions;
 import java.util.Date;
 
 public class CreateHmacKey {
-  public static void createHmacKey(String serviceAccountEmail, String projectId)
-      throws Exception {
+  public static void createHmacKey(String serviceAccountEmail, String projectId) throws Exception {
 
     // The service account email for which the new HMAC key will be created.
     // String serviceAccountEmail = "service-account@iam.gserviceaccount.com";
@@ -34,26 +33,28 @@ public class CreateHmacKey {
     // The ID of the project to which the service account belongs.
     // String projectId = "project-id";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()){
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    ServiceAccount account = ServiceAccount.of(serviceAccountEmail);
-    HmacKey hmacKey =
-        storage.createHmacKey(account, Storage.CreateHmacKeyOption.projectId(projectId));
+      ServiceAccount account = ServiceAccount.of(serviceAccountEmail);
+      HmacKey hmacKey =
+          storage.createHmacKey(account, Storage.CreateHmacKeyOption.projectId(projectId));
 
-    String secret = hmacKey.getSecretKey();
-    HmacKey.HmacKeyMetadata metadata = hmacKey.getMetadata();
+      String secret = hmacKey.getSecretKey();
+      HmacKey.HmacKeyMetadata metadata = hmacKey.getMetadata();
 
-    System.out.println("The Base64 encoded secret is: " + secret);
-    System.out.println("Do not lose that secret, there is no API to recover it.");
-    System.out.println("The HMAC key metadata is:");
-    System.out.println("ID: " + metadata.getId());
-    System.out.println("Access ID: " + metadata.getAccessId());
-    System.out.println("Project ID: " + metadata.getProjectId());
-    System.out.println("Service Account Email: " + metadata.getServiceAccount().getEmail());
-    System.out.println("State: " + metadata.getState().toString());
-    System.out.println("Time Created: " + new Date(metadata.getCreateTime()).toString());
-    System.out.println("Time Updated: " + new Date(metadata.getUpdateTime()).toString());
-    System.out.println("ETag: " + metadata.getEtag());
-  }}
+      System.out.println("The Base64 encoded secret is: " + secret);
+      System.out.println("Do not lose that secret, there is no API to recover it.");
+      System.out.println("The HMAC key metadata is:");
+      System.out.println("ID: " + metadata.getId());
+      System.out.println("Access ID: " + metadata.getAccessId());
+      System.out.println("Project ID: " + metadata.getProjectId());
+      System.out.println("Service Account Email: " + metadata.getServiceAccount().getEmail());
+      System.out.println("State: " + metadata.getState().toString());
+      System.out.println("Time Created: " + new Date(metadata.getCreateTime()).toString());
+      System.out.println("Time Updated: " + new Date(metadata.getUpdateTime()).toString());
+      System.out.println("ETag: " + metadata.getEtag());
+    }
+  }
 }
 // [END storage_create_hmac_key]

--- a/samples/snippets/src/main/java/com/example/storage/hmac/CreateHmacKey.java
+++ b/samples/snippets/src/main/java/com/example/storage/hmac/CreateHmacKey.java
@@ -21,13 +21,12 @@ package com.example.storage.hmac;
 import com.google.cloud.storage.HmacKey;
 import com.google.cloud.storage.ServiceAccount;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import java.util.Date;
 
 public class CreateHmacKey {
   public static void createHmacKey(String serviceAccountEmail, String projectId)
-      throws StorageException {
+      throws Exception {
 
     // The service account email for which the new HMAC key will be created.
     // String serviceAccountEmail = "service-account@iam.gserviceaccount.com";
@@ -35,7 +34,7 @@ public class CreateHmacKey {
     // The ID of the project to which the service account belongs.
     // String projectId = "project-id";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()){
 
     ServiceAccount account = ServiceAccount.of(serviceAccountEmail);
     HmacKey hmacKey =
@@ -55,6 +54,6 @@ public class CreateHmacKey {
     System.out.println("Time Created: " + new Date(metadata.getCreateTime()).toString());
     System.out.println("Time Updated: " + new Date(metadata.getUpdateTime()).toString());
     System.out.println("ETag: " + metadata.getEtag());
-  }
+  }}
 }
 // [END storage_create_hmac_key]

--- a/samples/snippets/src/main/java/com/example/storage/hmac/DeactivateHmacKey.java
+++ b/samples/snippets/src/main/java/com/example/storage/hmac/DeactivateHmacKey.java
@@ -20,35 +20,34 @@ package com.example.storage.hmac;
 
 import com.google.cloud.storage.HmacKey;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import java.util.Date;
 
 public class DeactivateHmacKey {
-  public static void deactivateHmacKey(String accessId, String projectId) throws StorageException {
+  public static void deactivateHmacKey(String accessId, String projectId) throws Exception {
     // The access ID of the HMAC key.
     // String accessId = "GOOG0234230X00";
 
     // The ID of the project to which the service account belongs.
     // String projectId = "project-id";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    HmacKey.HmacKeyMetadata metadata =
-        storage.getHmacKey(accessId, Storage.GetHmacKeyOption.projectId(projectId));
-    HmacKey.HmacKeyMetadata newMetadata =
-        storage.updateHmacKeyState(metadata, HmacKey.HmacKeyState.INACTIVE);
+      HmacKey.HmacKeyMetadata metadata =
+          storage.getHmacKey(accessId, Storage.GetHmacKeyOption.projectId(projectId));
+      HmacKey.HmacKeyMetadata newMetadata =
+          storage.updateHmacKeyState(metadata, HmacKey.HmacKeyState.INACTIVE);
 
-    System.out.println("The HMAC key is now inactive.");
-    System.out.println("The HMAC key metadata is:");
-    System.out.println("ID: " + newMetadata.getId());
-    System.out.println("Access ID: " + newMetadata.getAccessId());
-    System.out.println("Project ID: " + newMetadata.getProjectId());
-    System.out.println("Service Account Email: " + newMetadata.getServiceAccount().getEmail());
-    System.out.println("State: " + newMetadata.getState().toString());
-    System.out.println("Time Created: " + new Date(newMetadata.getCreateTime()).toString());
-    System.out.println("Time Updated: " + new Date(newMetadata.getUpdateTime()).toString());
-    System.out.println("ETag: " + newMetadata.getEtag());
-  }
+      System.out.println("The HMAC key is now inactive.");
+      System.out.println("The HMAC key metadata is:");
+      System.out.println("ID: " + newMetadata.getId());
+      System.out.println("Access ID: " + newMetadata.getAccessId());
+      System.out.println("Project ID: " + newMetadata.getProjectId());
+      System.out.println("Service Account Email: " + newMetadata.getServiceAccount().getEmail());
+      System.out.println("State: " + newMetadata.getState().toString());
+      System.out.println("Time Created: " + new Date(newMetadata.getCreateTime()).toString());
+      System.out.println("Time Updated: " + new Date(newMetadata.getUpdateTime()).toString());
+      System.out.println("ETag: " + newMetadata.getEtag());
+    }}
 }
 // [END storage_deactivate_hmac_key]

--- a/samples/snippets/src/main/java/com/example/storage/hmac/DeactivateHmacKey.java
+++ b/samples/snippets/src/main/java/com/example/storage/hmac/DeactivateHmacKey.java
@@ -31,7 +31,8 @@ public class DeactivateHmacKey {
     // The ID of the project to which the service account belongs.
     // String projectId = "project-id";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
       HmacKey.HmacKeyMetadata metadata =
           storage.getHmacKey(accessId, Storage.GetHmacKeyOption.projectId(projectId));
@@ -48,6 +49,7 @@ public class DeactivateHmacKey {
       System.out.println("Time Created: " + new Date(newMetadata.getCreateTime()).toString());
       System.out.println("Time Updated: " + new Date(newMetadata.getUpdateTime()).toString());
       System.out.println("ETag: " + newMetadata.getEtag());
-    }}
+    }
+  }
 }
 // [END storage_deactivate_hmac_key]

--- a/samples/snippets/src/main/java/com/example/storage/hmac/DeleteHmacKey.java
+++ b/samples/snippets/src/main/java/com/example/storage/hmac/DeleteHmacKey.java
@@ -20,11 +20,10 @@ package com.example.storage.hmac;
 
 import com.google.cloud.storage.HmacKey;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
 public class DeleteHmacKey {
-  public static void deleteHmacKey(String accessId, String projectId) throws StorageException {
+  public static void deleteHmacKey(String accessId, String projectId) throws Exception {
 
     // The access ID of the HMAC key.
     // String accessId = "GOOG0234230X00";
@@ -32,15 +31,15 @@ public class DeleteHmacKey {
     // The ID of the project to which the service account belongs.
     // String projectId = "project-id";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    HmacKey.HmacKeyMetadata metadata =
-        storage.getHmacKey(accessId, Storage.GetHmacKeyOption.projectId(projectId));
-    storage.deleteHmacKey(metadata);
+      HmacKey.HmacKeyMetadata metadata =
+          storage.getHmacKey(accessId, Storage.GetHmacKeyOption.projectId(projectId));
+      storage.deleteHmacKey(metadata);
 
-    System.out.println(
-        "The key is deleted, though it will still appear in "
-            + "getHmacKeys() results if called with showDeletedKey.");
-  }
+      System.out.println(
+          "The key is deleted, though it will still appear in "
+              + "getHmacKeys() results if called with showDeletedKey.");
+    }}
 }
 // [END storage_delete_hmac_key]

--- a/samples/snippets/src/main/java/com/example/storage/hmac/DeleteHmacKey.java
+++ b/samples/snippets/src/main/java/com/example/storage/hmac/DeleteHmacKey.java
@@ -31,7 +31,8 @@ public class DeleteHmacKey {
     // The ID of the project to which the service account belongs.
     // String projectId = "project-id";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
       HmacKey.HmacKeyMetadata metadata =
           storage.getHmacKey(accessId, Storage.GetHmacKeyOption.projectId(projectId));
@@ -40,6 +41,7 @@ public class DeleteHmacKey {
       System.out.println(
           "The key is deleted, though it will still appear in "
               + "getHmacKeys() results if called with showDeletedKey.");
-    }}
+    }
+  }
 }
 // [END storage_delete_hmac_key]

--- a/samples/snippets/src/main/java/com/example/storage/hmac/GetHmacKey.java
+++ b/samples/snippets/src/main/java/com/example/storage/hmac/GetHmacKey.java
@@ -20,32 +20,31 @@ package com.example.storage.hmac;
 
 import com.google.cloud.storage.HmacKey;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import java.util.Date;
 
 public class GetHmacKey {
-  public static void getHmacKey(String accessId, String projectId) throws StorageException {
+  public static void getHmacKey(String accessId, String projectId) throws Exception {
     // The access ID of the HMAC key.
     // String accessId = "GOOG0234230X00";
 
     // The ID of the project to which the service account belongs.
     // String projectId = "project-id";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    HmacKey.HmacKeyMetadata metadata =
-        storage.getHmacKey(accessId, Storage.GetHmacKeyOption.projectId(projectId));
+      HmacKey.HmacKeyMetadata metadata =
+          storage.getHmacKey(accessId, Storage.GetHmacKeyOption.projectId(projectId));
 
-    System.out.println("The HMAC key metadata is:");
-    System.out.println("ID: " + metadata.getId());
-    System.out.println("Access ID: " + metadata.getAccessId());
-    System.out.println("Project ID: " + metadata.getProjectId());
-    System.out.println("Service Account Email: " + metadata.getServiceAccount().getEmail());
-    System.out.println("State: " + metadata.getState().toString());
-    System.out.println("Time Created: " + new Date(metadata.getCreateTime()).toString());
-    System.out.println("Time Updated: " + new Date(metadata.getUpdateTime()).toString());
-    System.out.println("ETag: " + metadata.getEtag());
-  }
+      System.out.println("The HMAC key metadata is:");
+      System.out.println("ID: " + metadata.getId());
+      System.out.println("Access ID: " + metadata.getAccessId());
+      System.out.println("Project ID: " + metadata.getProjectId());
+      System.out.println("Service Account Email: " + metadata.getServiceAccount().getEmail());
+      System.out.println("State: " + metadata.getState().toString());
+      System.out.println("Time Created: " + new Date(metadata.getCreateTime()).toString());
+      System.out.println("Time Updated: " + new Date(metadata.getUpdateTime()).toString());
+      System.out.println("ETag: " + metadata.getEtag());
+    }}
 }
 // [END storage_get_hmac_key]

--- a/samples/snippets/src/main/java/com/example/storage/hmac/GetHmacKey.java
+++ b/samples/snippets/src/main/java/com/example/storage/hmac/GetHmacKey.java
@@ -31,7 +31,8 @@ public class GetHmacKey {
     // The ID of the project to which the service account belongs.
     // String projectId = "project-id";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
       HmacKey.HmacKeyMetadata metadata =
           storage.getHmacKey(accessId, Storage.GetHmacKeyOption.projectId(projectId));
@@ -45,6 +46,7 @@ public class GetHmacKey {
       System.out.println("Time Created: " + new Date(metadata.getCreateTime()).toString());
       System.out.println("Time Updated: " + new Date(metadata.getUpdateTime()).toString());
       System.out.println("ETag: " + metadata.getEtag());
-    }}
+    }
+  }
 }
 // [END storage_get_hmac_key]

--- a/samples/snippets/src/main/java/com/example/storage/hmac/ListHmacKeys.java
+++ b/samples/snippets/src/main/java/com/example/storage/hmac/ListHmacKeys.java
@@ -21,23 +21,22 @@ package com.example.storage.hmac;
 import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.HmacKey;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
 public class ListHmacKeys {
-  public static void listHmacKeys(String projectId) throws StorageException {
+  public static void listHmacKeys(String projectId) throws Exception {
     // The ID of the project to which the service account belongs.
     // String projectId = "project-id";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    Page<HmacKey.HmacKeyMetadata> page =
-        storage.listHmacKeys(Storage.ListHmacKeysOption.projectId(projectId));
+      Page<HmacKey.HmacKeyMetadata> page =
+          storage.listHmacKeys(Storage.ListHmacKeysOption.projectId(projectId));
 
-    for (HmacKey.HmacKeyMetadata metadata : page.iterateAll()) {
-      System.out.println("Service Account Email: " + metadata.getServiceAccount().getEmail());
-      System.out.println("Access ID: " + metadata.getAccessId());
-    }
-  }
+      for (HmacKey.HmacKeyMetadata metadata : page.iterateAll()) {
+        System.out.println("Service Account Email: " + metadata.getServiceAccount().getEmail());
+        System.out.println("Access ID: " + metadata.getAccessId());
+      }
+    }}
 }
 // [END storage_list_hmac_keys]

--- a/samples/snippets/src/main/java/com/example/storage/hmac/ListHmacKeys.java
+++ b/samples/snippets/src/main/java/com/example/storage/hmac/ListHmacKeys.java
@@ -28,7 +28,8 @@ public class ListHmacKeys {
     // The ID of the project to which the service account belongs.
     // String projectId = "project-id";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
       Page<HmacKey.HmacKeyMetadata> page =
           storage.listHmacKeys(Storage.ListHmacKeysOption.projectId(projectId));
@@ -37,6 +38,7 @@ public class ListHmacKeys {
         System.out.println("Service Account Email: " + metadata.getServiceAccount().getEmail());
         System.out.println("Access ID: " + metadata.getAccessId());
       }
-    }}
+    }
+  }
 }
 // [END storage_list_hmac_keys]

--- a/samples/snippets/src/main/java/com/example/storage/object/AddBlobOwner.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/AddBlobOwner.java
@@ -42,7 +42,8 @@ public class AddBlobOwner {
     // The name of the blob/file that you wish to modify permissions on
     // String blobName = "your-blob-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
       Blob blob = storage.get(BlobId.of(bucketName, blobName));
       Acl newOwner = Acl.of(new User(userEmail), Role.OWNER);
 
@@ -54,6 +55,7 @@ public class AddBlobOwner {
               + blobName
               + " in bucket "
               + bucketName);
-    }}
+    }
+  }
 }
 // [END storage_add_file_owner]

--- a/samples/snippets/src/main/java/com/example/storage/object/AddBlobOwner.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/AddBlobOwner.java
@@ -29,7 +29,7 @@ import com.google.cloud.storage.StorageOptions;
 public class AddBlobOwner {
 
   public static void addBlobOwner(
-      String projectId, String bucketName, String userEmail, String blobName) {
+      String projectId, String bucketName, String userEmail, String blobName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -42,18 +42,18 @@ public class AddBlobOwner {
     // The name of the blob/file that you wish to modify permissions on
     // String blobName = "your-blob-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
-    Blob blob = storage.get(BlobId.of(bucketName, blobName));
-    Acl newOwner = Acl.of(new User(userEmail), Role.OWNER);
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Blob blob = storage.get(BlobId.of(bucketName, blobName));
+      Acl newOwner = Acl.of(new User(userEmail), Role.OWNER);
 
-    blob.createAcl(newOwner);
-    System.out.println(
-        "Added user "
-            + userEmail
-            + " as an owner on blob "
-            + blobName
-            + " in bucket "
-            + bucketName);
-  }
+      blob.createAcl(newOwner);
+      System.out.println(
+          "Added user "
+              + userEmail
+              + " as an owner on blob "
+              + blobName
+              + " in bucket "
+              + bucketName);
+    }}
 }
 // [END storage_add_file_owner]

--- a/samples/snippets/src/main/java/com/example/storage/object/AtomicMoveObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/AtomicMoveObject.java
@@ -27,7 +27,8 @@ import com.google.cloud.storage.StorageOptions;
 public final class AtomicMoveObject {
 
   public static void moveObject(
-      String projectId, String bucketName, String sourceObjectName, String targetObjectName) {
+      String projectId, String bucketName, String sourceObjectName, String targetObjectName)
+      throws Exception {
 
     // The ID of your GCP project
     // String projectId = "your-project-id";
@@ -41,7 +42,7 @@ public final class AtomicMoveObject {
     // The ID of your GCS object
     // String targetObjectName = "your-new-object-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     BlobId source = BlobId.of(bucketName, sourceObjectName);
     BlobId target = BlobId.of(bucketName, targetObjectName);
 
@@ -76,5 +77,5 @@ public final class AtomicMoveObject {
             + " to "
             + movedBlob.getBlobId().toGsUtilUriWithGeneration());
   }
-}
+}}
 // [END storage_move_object]

--- a/samples/snippets/src/main/java/com/example/storage/object/BatchSetObjectMetadata.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/BatchSetObjectMetadata.java
@@ -32,8 +32,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class BatchSetObjectMetadata {
-  public static void batchSetObjectMetadata(
-      String projectId, String bucketName, String pathPrefix) throws Exception {
+  public static void batchSetObjectMetadata(String projectId, String bucketName, String pathPrefix)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -44,54 +44,56 @@ public class BatchSetObjectMetadata {
     // updated
     // String pathPrefix = "yourPath/";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Map<String, String> newMetadata = new HashMap<>();
-    newMetadata.put("keyToAddOrUpdate", "value");
-    Page<Blob> blobs =
-        storage.list(
-            bucketName,
-            Storage.BlobListOption.prefix(pathPrefix),
-            Storage.BlobListOption.delimiter("/"));
-    StorageBatch batchRequest = storage.batch();
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Map<String, String> newMetadata = new HashMap<>();
+      newMetadata.put("keyToAddOrUpdate", "value");
+      Page<Blob> blobs =
+          storage.list(
+              bucketName,
+              Storage.BlobListOption.prefix(pathPrefix),
+              Storage.BlobListOption.delimiter("/"));
+      StorageBatch batchRequest = storage.batch();
 
-    // Add all blobs with the given prefix to the batch request
-    List<StorageBatchResult<Blob>> batchResults =
-        blobs
-            .streamAll()
-            .map(blob -> batchRequest.update(blob.toBuilder().setMetadata(newMetadata).build()))
-            .collect(Collectors.toList());
+      // Add all blobs with the given prefix to the batch request
+      List<StorageBatchResult<Blob>> batchResults =
+          blobs
+              .streamAll()
+              .map(blob -> batchRequest.update(blob.toBuilder().setMetadata(newMetadata).build()))
+              .collect(Collectors.toList());
 
-    // Execute the batch request
-    batchRequest.submit();
-    List<StorageException> failures =
-        batchResults.stream()
-            .map(
-                r -> {
-                  try {
-                    BlobInfo blob = r.get();
-                    return null;
-                  } catch (StorageException e) {
-                    return e;
-                  }
-                })
-            .filter(Objects::nonNull)
-            .collect(Collectors.toList());
+      // Execute the batch request
+      batchRequest.submit();
+      List<StorageException> failures =
+          batchResults.stream()
+              .map(
+                  r -> {
+                    try {
+                      BlobInfo blob = r.get();
+                      return null;
+                    } catch (StorageException e) {
+                      return e;
+                    }
+                  })
+              .filter(Objects::nonNull)
+              .collect(Collectors.toList());
 
-    System.out.println(
-        (batchResults.size() - failures.size())
-            + " blobs in bucket "
-            + bucketName
-            + " with prefix '"
-            + pathPrefix
-            + "' had their metadata updated successfully.");
+      System.out.println(
+          (batchResults.size() - failures.size())
+              + " blobs in bucket "
+              + bucketName
+              + " with prefix '"
+              + pathPrefix
+              + "' had their metadata updated successfully.");
 
-    if (!failures.isEmpty()) {
-      System.out.println("While processing, there were " + failures.size() + " failures");
+      if (!failures.isEmpty()) {
+        System.out.println("While processing, there were " + failures.size() + " failures");
 
-      for (StorageException failure : failures) {
-        failure.printStackTrace(System.out);
+        for (StorageException failure : failures) {
+          failure.printStackTrace(System.out);
+        }
       }
     }
   }
-}}
+}
 // [END storage_batch_request]

--- a/samples/snippets/src/main/java/com/example/storage/object/BatchSetObjectMetadata.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/BatchSetObjectMetadata.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 
 public class BatchSetObjectMetadata {
   public static void batchSetObjectMetadata(
-      String projectId, String bucketName, String pathPrefix) {
+      String projectId, String bucketName, String pathPrefix) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -44,7 +44,7 @@ public class BatchSetObjectMetadata {
     // updated
     // String pathPrefix = "yourPath/";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Map<String, String> newMetadata = new HashMap<>();
     newMetadata.put("keyToAddOrUpdate", "value");
     Page<Blob> blobs =
@@ -93,5 +93,5 @@ public class BatchSetObjectMetadata {
       }
     }
   }
-}
+}}
 // [END storage_batch_request]

--- a/samples/snippets/src/main/java/com/example/storage/object/ChangeObjectCsekToKms.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ChangeObjectCsekToKms.java
@@ -28,7 +28,8 @@ public class ChangeObjectCsekToKms {
       String bucketName,
       String objectName,
       String decryptionKey,
-      String kmsKeyName) throws Exception {
+      String kmsKeyName)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -46,36 +47,38 @@ public class ChangeObjectCsekToKms {
     // String kmsKeyName =
     // "projects/your-project-id/locations/global/keyRings/your-key-ring/cryptoKeys/your-key";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    BlobId blobId = BlobId.of(bucketName, objectName);
-    Blob blob = storage.get(blobId);
-    if (blob == null) {
-      System.out.println("The object " + objectName + " wasn't found in " + bucketName);
-      return;
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      BlobId blobId = BlobId.of(bucketName, objectName);
+      Blob blob = storage.get(blobId);
+      if (blob == null) {
+        System.out.println("The object " + objectName + " wasn't found in " + bucketName);
+        return;
+      }
+
+      // Optional: set a generation-match precondition to avoid potential race
+      // conditions and data corruptions. The request to upload returns a 412 error if
+      // the object's generation number does not match your precondition.
+      Storage.BlobSourceOption precondition =
+          Storage.BlobSourceOption.generationMatch(blob.getGeneration());
+
+      Storage.CopyRequest request =
+          Storage.CopyRequest.newBuilder()
+              .setSource(blobId)
+              .setSourceOptions(Storage.BlobSourceOption.decryptionKey(decryptionKey), precondition)
+              .setTarget(blobId, Storage.BlobTargetOption.kmsKeyName(kmsKeyName))
+              .build();
+      storage.copy(request);
+
+      System.out.println(
+          "Object "
+              + objectName
+              + " in bucket "
+              + bucketName
+              + " is now managed by the KMS key "
+              + kmsKeyName
+              + " instead of a customer-supplied encryption key");
     }
-
-    // Optional: set a generation-match precondition to avoid potential race
-    // conditions and data corruptions. The request to upload returns a 412 error if
-    // the object's generation number does not match your precondition.
-    Storage.BlobSourceOption precondition =
-        Storage.BlobSourceOption.generationMatch(blob.getGeneration());
-
-    Storage.CopyRequest request =
-        Storage.CopyRequest.newBuilder()
-            .setSource(blobId)
-            .setSourceOptions(Storage.BlobSourceOption.decryptionKey(decryptionKey), precondition)
-            .setTarget(blobId, Storage.BlobTargetOption.kmsKeyName(kmsKeyName))
-            .build();
-    storage.copy(request);
-
-    System.out.println(
-        "Object "
-            + objectName
-            + " in bucket "
-            + bucketName
-            + " is now managed by the KMS key "
-            + kmsKeyName
-            + " instead of a customer-supplied encryption key");
   }
-}}
+}
 // [END storage_object_csek_to_cmek]

--- a/samples/snippets/src/main/java/com/example/storage/object/ChangeObjectCsekToKms.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ChangeObjectCsekToKms.java
@@ -28,7 +28,7 @@ public class ChangeObjectCsekToKms {
       String bucketName,
       String objectName,
       String decryptionKey,
-      String kmsKeyName) {
+      String kmsKeyName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -46,7 +46,7 @@ public class ChangeObjectCsekToKms {
     // String kmsKeyName =
     // "projects/your-project-id/locations/global/keyRings/your-key-ring/cryptoKeys/your-key";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     BlobId blobId = BlobId.of(bucketName, objectName);
     Blob blob = storage.get(blobId);
     if (blob == null) {
@@ -77,5 +77,5 @@ public class ChangeObjectCsekToKms {
             + kmsKeyName
             + " instead of a customer-supplied encryption key");
   }
-}
+}}
 // [END storage_object_csek_to_cmek]

--- a/samples/snippets/src/main/java/com/example/storage/object/ChangeObjectStorageClass.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ChangeObjectStorageClass.java
@@ -36,44 +36,46 @@ public class ChangeObjectStorageClass {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    BlobId blobId = BlobId.of(bucketName, objectName);
-    Blob sourceBlob = storage.get(blobId);
-    if (sourceBlob == null) {
-      System.out.println("The object " + objectName + " wasn't found in " + bucketName);
-      return;
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      BlobId blobId = BlobId.of(bucketName, objectName);
+      Blob sourceBlob = storage.get(blobId);
+      if (sourceBlob == null) {
+        System.out.println("The object " + objectName + " wasn't found in " + bucketName);
+        return;
+      }
+
+      // See the StorageClass documentation for other valid storage classes:
+      // https://googleapis.dev/java/google-cloud-clients/latest/com/google/cloud/storage/StorageClass.html
+      StorageClass storageClass = StorageClass.COLDLINE;
+
+      // You can't change an object's storage class directly, the only way is to rewrite the object
+      // with the desired storage class
+
+      BlobInfo targetBlob = BlobInfo.newBuilder(blobId).setStorageClass(storageClass).build();
+
+      // Optional: set a generation-match precondition to avoid potential race
+      // conditions and data corruptions. The request to upload returns a 412 error if
+      // the object's generation number does not match your precondition.
+      Storage.BlobSourceOption precondition =
+          Storage.BlobSourceOption.generationMatch(sourceBlob.getGeneration());
+
+      Storage.CopyRequest request =
+          Storage.CopyRequest.newBuilder()
+              .setSource(blobId)
+              .setSourceOptions(precondition) // delete this line to run without preconditions
+              .setTarget(targetBlob)
+              .build();
+      Blob updatedBlob = storage.copy(request).getResult();
+
+      System.out.println(
+          "Object "
+              + objectName
+              + " in bucket "
+              + bucketName
+              + " had its storage class set to "
+              + updatedBlob.getStorageClass().name());
     }
-
-    // See the StorageClass documentation for other valid storage classes:
-    // https://googleapis.dev/java/google-cloud-clients/latest/com/google/cloud/storage/StorageClass.html
-    StorageClass storageClass = StorageClass.COLDLINE;
-
-    // You can't change an object's storage class directly, the only way is to rewrite the object
-    // with the desired storage class
-
-    BlobInfo targetBlob = BlobInfo.newBuilder(blobId).setStorageClass(storageClass).build();
-
-    // Optional: set a generation-match precondition to avoid potential race
-    // conditions and data corruptions. The request to upload returns a 412 error if
-    // the object's generation number does not match your precondition.
-    Storage.BlobSourceOption precondition =
-        Storage.BlobSourceOption.generationMatch(sourceBlob.getGeneration());
-
-    Storage.CopyRequest request =
-        Storage.CopyRequest.newBuilder()
-            .setSource(blobId)
-            .setSourceOptions(precondition) // delete this line to run without preconditions
-            .setTarget(targetBlob)
-            .build();
-    Blob updatedBlob = storage.copy(request).getResult();
-
-    System.out.println(
-        "Object "
-            + objectName
-            + " in bucket "
-            + bucketName
-            + " had its storage class set to "
-            + updatedBlob.getStorageClass().name());
   }
-}}
+}
 // [END storage_change_file_storage_class]

--- a/samples/snippets/src/main/java/com/example/storage/object/ChangeObjectStorageClass.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ChangeObjectStorageClass.java
@@ -26,7 +26,7 @@ import com.google.cloud.storage.StorageOptions;
 
 public class ChangeObjectStorageClass {
   public static void changeObjectStorageClass(
-      String projectId, String bucketName, String objectName) {
+      String projectId, String bucketName, String objectName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -36,7 +36,7 @@ public class ChangeObjectStorageClass {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     BlobId blobId = BlobId.of(bucketName, objectName);
     Blob sourceBlob = storage.get(blobId);
     if (sourceBlob == null) {
@@ -75,5 +75,5 @@ public class ChangeObjectStorageClass {
             + " had its storage class set to "
             + updatedBlob.getStorageClass().name());
   }
-}
+}}
 // [END storage_change_file_storage_class]

--- a/samples/snippets/src/main/java/com/example/storage/object/ComposeObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ComposeObject.java
@@ -28,7 +28,7 @@ public class ComposeObject {
       String firstObjectName,
       String secondObjectName,
       String targetObjectName,
-      String projectId) {
+      String projectId) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -44,7 +44,7 @@ public class ComposeObject {
     // The ID to give the new composite object
     // String targetObjectName = "new-composite-object-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     // Optional: set a generation-match precondition to avoid potential race
     // conditions and data corruptions. The request returns a 412 error if the
@@ -82,5 +82,5 @@ public class ComposeObject {
             + " and "
             + secondObjectName);
   }
-}
+}}
 // [END storage_compose_file]

--- a/samples/snippets/src/main/java/com/example/storage/object/CopyDeleteObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/CopyDeleteObject.java
@@ -30,7 +30,7 @@ public class CopyDeleteObject {
       String sourceBucketName,
       String sourceObjectName,
       String targetBucketName,
-      String targetObjectName) {
+      String targetObjectName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -46,7 +46,7 @@ public class CopyDeleteObject {
     // The ID of your GCS object
     // String targetObjectName = "your-new-object-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     BlobId source = BlobId.of(sourceBucketName, sourceObjectName);
     BlobId target = BlobId.of(targetBucketName, targetObjectName);
 
@@ -84,5 +84,5 @@ public class CopyDeleteObject {
             + " in bucket "
             + copiedObject.getBucket());
   }
-}
+}}
 // [END storage_move_file]

--- a/samples/snippets/src/main/java/com/example/storage/object/CopyOldVersionOfObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/CopyOldVersionOfObject.java
@@ -27,7 +27,7 @@ public class CopyOldVersionOfObject {
       String bucketName,
       String objectToCopy,
       long generationToCopy,
-      String newObjectName) {
+      String newObjectName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -43,7 +43,7 @@ public class CopyOldVersionOfObject {
     // What to name the new object with the old data from objectToCopy
     // String newObjectName = "your-new-object";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     // Optional: set a generation-match precondition to avoid potential race
     // conditions and data corruptions. The request returns a 412 error if the
@@ -79,5 +79,5 @@ public class CopyOldVersionOfObject {
             + " was copied to "
             + newObjectName);
   }
-}
+}}
 // [END storage_copy_file_archived_generation]

--- a/samples/snippets/src/main/java/com/example/storage/object/DeleteObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/DeleteObject.java
@@ -23,7 +23,8 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class DeleteObject {
-  public static void deleteObject(String projectId, String bucketName, String objectName) {
+  public static void deleteObject(String projectId, String bucketName, String objectName)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -33,7 +34,7 @@ public class DeleteObject {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Blob blob = storage.get(bucketName, objectName);
     if (blob == null) {
       System.out.println("The object " + objectName + " wasn't found in " + bucketName);
@@ -53,5 +54,5 @@ public class DeleteObject {
 
     System.out.println("Object " + objectName + " was permanently deleted from " + bucketName);
   }
-}
+}}
 // [END storage_delete_file]

--- a/samples/snippets/src/main/java/com/example/storage/object/DeleteObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/DeleteObject.java
@@ -34,25 +34,28 @@ public class DeleteObject {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Blob blob = storage.get(bucketName, objectName);
-    if (blob == null) {
-      System.out.println("The object " + objectName + " wasn't found in " + bucketName);
-      return;
-    }
-    BlobId idWithGeneration = blob.getBlobId();
-    // Deletes the blob specified by its id. When the generation is present and non-null it will be
-    // specified in the request.
-    // If versioning is enabled on the bucket and the generation is present in the delete request,
-    // only the version of the object with the matching generation will be deleted.
-    // If instead you want to delete the current version, the generation should be dropped by
-    // performing the following.
-    // BlobId idWithoutGeneration =
-    //    BlobId.of(idWithGeneration.getBucket(), idWithGeneration.getName());
-    // storage.delete(idWithoutGeneration);
-    storage.delete(idWithGeneration);
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Blob blob = storage.get(bucketName, objectName);
+      if (blob == null) {
+        System.out.println("The object " + objectName + " wasn't found in " + bucketName);
+        return;
+      }
+      BlobId idWithGeneration = blob.getBlobId();
+      // Deletes the blob specified by its id. When the generation is present and non-null it will
+      // be
+      // specified in the request.
+      // If versioning is enabled on the bucket and the generation is present in the delete request,
+      // only the version of the object with the matching generation will be deleted.
+      // If instead you want to delete the current version, the generation should be dropped by
+      // performing the following.
+      // BlobId idWithoutGeneration =
+      //    BlobId.of(idWithGeneration.getBucket(), idWithGeneration.getName());
+      // storage.delete(idWithoutGeneration);
+      storage.delete(idWithGeneration);
 
-    System.out.println("Object " + objectName + " was permanently deleted from " + bucketName);
+      System.out.println("Object " + objectName + " was permanently deleted from " + bucketName);
+    }
   }
-}}
+}
 // [END storage_delete_file]

--- a/samples/snippets/src/main/java/com/example/storage/object/DeleteOldVersionOfObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/DeleteOldVersionOfObject.java
@@ -23,7 +23,8 @@ import com.google.cloud.storage.StorageOptions;
 
 public class DeleteOldVersionOfObject {
   public static void deleteOldVersionOfObject(
-      String projectId, String bucketName, String objectName, long generationToDelete) {
+      String projectId, String bucketName, String objectName, long generationToDelete)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -36,7 +37,7 @@ public class DeleteOldVersionOfObject {
     // The generation of objectName to delete
     // long generationToDelete = 1579287380533984;
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     storage.delete(BlobId.of(bucketName, objectName, generationToDelete));
 
     System.out.println(
@@ -47,5 +48,5 @@ public class DeleteOldVersionOfObject {
             + " was deleted from "
             + bucketName);
   }
-}
+}}
 // [END storage_delete_file_archived_generation]

--- a/samples/snippets/src/main/java/com/example/storage/object/DeleteOldVersionOfObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/DeleteOldVersionOfObject.java
@@ -37,16 +37,18 @@ public class DeleteOldVersionOfObject {
     // The generation of objectName to delete
     // long generationToDelete = 1579287380533984;
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    storage.delete(BlobId.of(bucketName, objectName, generationToDelete));
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      storage.delete(BlobId.of(bucketName, objectName, generationToDelete));
 
-    System.out.println(
-        "Generation "
-            + generationToDelete
-            + " of object "
-            + objectName
-            + " was deleted from "
-            + bucketName);
+      System.out.println(
+          "Generation "
+              + generationToDelete
+              + " of object "
+              + objectName
+              + " was deleted from "
+              + bucketName);
+    }
   }
-}}
+}
 // [END storage_delete_file_archived_generation]

--- a/samples/snippets/src/main/java/com/example/storage/object/DownloadByteRange.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/DownloadByteRange.java
@@ -23,7 +23,6 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.io.ByteStreams;
-import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
@@ -37,7 +36,7 @@ public class DownloadByteRange {
       long startByte,
       long endBytes,
       String destFileName)
-      throws IOException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -56,7 +55,7 @@ public class DownloadByteRange {
     // The path to which the file should be downloaded
     // String destFileName = '/local/path/to/file.txt';
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     BlobId blobId = BlobId.of(bucketName, blobName);
     try (ReadChannel from = storage.reader(blobId);
         FileChannel to = FileChannel.open(Paths.get(destFileName), StandardOpenOption.WRITE)) {
@@ -70,5 +69,5 @@ public class DownloadByteRange {
           blobId.toGsUtilUri(), destFileName, startByte, endBytes);
     }
   }
-}
+}}
 // [END storage_download_byte_range]

--- a/samples/snippets/src/main/java/com/example/storage/object/DownloadByteRange.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/DownloadByteRange.java
@@ -55,19 +55,21 @@ public class DownloadByteRange {
     // The path to which the file should be downloaded
     // String destFileName = '/local/path/to/file.txt';
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    BlobId blobId = BlobId.of(bucketName, blobName);
-    try (ReadChannel from = storage.reader(blobId);
-        FileChannel to = FileChannel.open(Paths.get(destFileName), StandardOpenOption.WRITE)) {
-      from.seek(startByte);
-      from.limit(endBytes);
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      BlobId blobId = BlobId.of(bucketName, blobName);
+      try (ReadChannel from = storage.reader(blobId);
+          FileChannel to = FileChannel.open(Paths.get(destFileName), StandardOpenOption.WRITE)) {
+        from.seek(startByte);
+        from.limit(endBytes);
 
-      ByteStreams.copy(from, to);
+        ByteStreams.copy(from, to);
 
-      System.out.printf(
-          "%s downloaded to %s from byte %d to byte %d%n",
-          blobId.toGsUtilUri(), destFileName, startByte, endBytes);
+        System.out.printf(
+            "%s downloaded to %s from byte %d to byte %d%n",
+            blobId.toGsUtilUri(), destFileName, startByte, endBytes);
+      }
     }
   }
-}}
+}
 // [END storage_download_byte_range]

--- a/samples/snippets/src/main/java/com/example/storage/object/DownloadEncryptedObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/DownloadEncryptedObject.java
@@ -21,7 +21,6 @@ package com.example.storage.object;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
-import java.io.IOException;
 import java.nio.file.Path;
 
 public class DownloadEncryptedObject {
@@ -31,7 +30,7 @@ public class DownloadEncryptedObject {
       String objectName,
       Path destFilePath,
       String decryptionKey)
-      throws IOException {
+      throws Exception {
 
     // The ID of your GCP project
     // String projectId = "your-project-id";
@@ -49,7 +48,7 @@ public class DownloadEncryptedObject {
     // the object
     // String decryptionKey = "TIbv/fjexq+VmtXzAlc63J4z5kFmWJ6NdAPQulQBT7g=";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     Blob blob = storage.get(bucketName, objectName);
     blob.downloadTo(destFilePath, Blob.BlobSourceOption.decryptionKey(decryptionKey));
@@ -63,5 +62,5 @@ public class DownloadEncryptedObject {
             + destFilePath
             + " using customer-supplied encryption key");
   }
-}
+}}
 // [END storage_download_encrypted_file]

--- a/samples/snippets/src/main/java/com/example/storage/object/DownloadEncryptedObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/DownloadEncryptedObject.java
@@ -48,19 +48,21 @@ public class DownloadEncryptedObject {
     // the object
     // String decryptionKey = "TIbv/fjexq+VmtXzAlc63J4z5kFmWJ6NdAPQulQBT7g=";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    Blob blob = storage.get(bucketName, objectName);
-    blob.downloadTo(destFilePath, Blob.BlobSourceOption.decryptionKey(decryptionKey));
+      Blob blob = storage.get(bucketName, objectName);
+      blob.downloadTo(destFilePath, Blob.BlobSourceOption.decryptionKey(decryptionKey));
 
-    System.out.println(
-        "Downloaded object "
-            + objectName
-            + " from bucket name "
-            + bucketName
-            + " to "
-            + destFilePath
-            + " using customer-supplied encryption key");
+      System.out.println(
+          "Downloaded object "
+              + objectName
+              + " from bucket name "
+              + bucketName
+              + " to "
+              + destFilePath
+              + " using customer-supplied encryption key");
+    }
   }
-}}
+}
 // [END storage_download_encrypted_file]

--- a/samples/snippets/src/main/java/com/example/storage/object/DownloadObjectIntoMemory.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/DownloadObjectIntoMemory.java
@@ -24,7 +24,7 @@ import java.nio.charset.StandardCharsets;
 
 public class DownloadObjectIntoMemory {
   public static void downloadObjectIntoMemory(
-      String projectId, String bucketName, String objectName) {
+      String projectId, String bucketName, String objectName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -34,7 +34,7 @@ public class DownloadObjectIntoMemory {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     byte[] content = storage.readAllBytes(bucketName, objectName);
     System.out.println(
         "The contents of "
@@ -44,5 +44,5 @@ public class DownloadObjectIntoMemory {
             + " are: "
             + new String(content, StandardCharsets.UTF_8));
   }
-}
+}}
 // [END storage_file_download_into_memory]

--- a/samples/snippets/src/main/java/com/example/storage/object/DownloadObjectIntoMemory.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/DownloadObjectIntoMemory.java
@@ -34,15 +34,17 @@ public class DownloadObjectIntoMemory {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    byte[] content = storage.readAllBytes(bucketName, objectName);
-    System.out.println(
-        "The contents of "
-            + objectName
-            + " from bucket name "
-            + bucketName
-            + " are: "
-            + new String(content, StandardCharsets.UTF_8));
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      byte[] content = storage.readAllBytes(bucketName, objectName);
+      System.out.println(
+          "The contents of "
+              + objectName
+              + " from bucket name "
+              + bucketName
+              + " are: "
+              + new String(content, StandardCharsets.UTF_8));
+    }
   }
-}}
+}
 // [END storage_file_download_into_memory]

--- a/samples/snippets/src/main/java/com/example/storage/object/DownloadPublicObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/DownloadPublicObject.java
@@ -25,7 +25,7 @@ import java.nio.file.Path;
 
 public class DownloadPublicObject {
   public static void downloadPublicObject(
-      String bucketName, String publicObjectName, Path destFilePath) {
+      String bucketName, String publicObjectName, Path destFilePath) throws Exception {
     // The name of the bucket to access
     // String bucketName = "my-bucket";
 
@@ -36,17 +36,17 @@ public class DownloadPublicObject {
     // Path destFilePath = Paths.get("/local/path/to/file.txt");
 
     // Instantiate an anonymous Google Cloud Storage client, which can only access public files
-    Storage storage = StorageOptions.getUnauthenticatedInstance().getService();
+    try (Storage storage = StorageOptions.getUnauthenticatedInstance().getService()) {
 
-    storage.downloadTo(BlobId.of(bucketName, publicObjectName), destFilePath);
+      storage.downloadTo(BlobId.of(bucketName, publicObjectName), destFilePath);
 
-    System.out.println(
-        "Downloaded public object "
-            + publicObjectName
-            + " from bucket name "
-            + bucketName
-            + " to "
-            + destFilePath);
-  }
+      System.out.println(
+          "Downloaded public object "
+              + publicObjectName
+              + " from bucket name "
+              + bucketName
+              + " to "
+              + destFilePath);
+    }}
 }
 // [END storage_download_public_file]

--- a/samples/snippets/src/main/java/com/example/storage/object/DownloadPublicObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/DownloadPublicObject.java
@@ -47,6 +47,7 @@ public class DownloadPublicObject {
               + bucketName
               + " to "
               + destFilePath);
-    }}
+    }
+  }
 }
 // [END storage_download_public_file]

--- a/samples/snippets/src/main/java/com/example/storage/object/DownloadRequesterPaysObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/DownloadRequesterPaysObject.java
@@ -26,7 +26,7 @@ import java.nio.file.Path;
 
 public class DownloadRequesterPaysObject {
   public static void downloadRequesterPaysObject(
-      String projectId, String bucketName, String objectName, Path destFilePath) {
+      String projectId, String bucketName, String objectName, Path destFilePath) throws Exception {
     // The project ID to bill
     // String projectId = "my-billable-project-id";
 
@@ -39,7 +39,7 @@ public class DownloadRequesterPaysObject {
     // The path to which the file should be downloaded
     // Path destFilePath = Paths.get("/local/path/to/file.txt");
 
-    Storage storage = StorageOptions.getDefaultInstance().getService();
+    try (Storage storage = StorageOptions.getDefaultInstance().getService()) {
     Blob blob =
         storage.get(
             BlobId.of(bucketName, objectName), Storage.BlobGetOption.userProject(projectId));
@@ -47,6 +47,7 @@ public class DownloadRequesterPaysObject {
 
     System.out.println(
         "Object " + objectName + " downloaded to " + destFilePath + " and billed to " + projectId);
+  }
   }
 }
 // [END storage_download_file_requester_pays]

--- a/samples/snippets/src/main/java/com/example/storage/object/DownloadRequesterPaysObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/DownloadRequesterPaysObject.java
@@ -40,14 +40,19 @@ public class DownloadRequesterPaysObject {
     // Path destFilePath = Paths.get("/local/path/to/file.txt");
 
     try (Storage storage = StorageOptions.getDefaultInstance().getService()) {
-    Blob blob =
-        storage.get(
-            BlobId.of(bucketName, objectName), Storage.BlobGetOption.userProject(projectId));
-    blob.downloadTo(destFilePath, Blob.BlobSourceOption.userProject(projectId));
+      Blob blob =
+          storage.get(
+              BlobId.of(bucketName, objectName), Storage.BlobGetOption.userProject(projectId));
+      blob.downloadTo(destFilePath, Blob.BlobSourceOption.userProject(projectId));
 
-    System.out.println(
-        "Object " + objectName + " downloaded to " + destFilePath + " and billed to " + projectId);
-  }
+      System.out.println(
+          "Object "
+              + objectName
+              + " downloaded to "
+              + destFilePath
+              + " and billed to "
+              + projectId);
+    }
   }
 }
 // [END storage_download_file_requester_pays]

--- a/samples/snippets/src/main/java/com/example/storage/object/GenerateV4GetObjectSignedUrl.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/GenerateV4GetObjectSignedUrl.java
@@ -42,18 +42,20 @@ public class GenerateV4GetObjectSignedUrl {
     // String bucketName = "my-bucket";
     // String objectName = "my-object";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    // Define resource
-    BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, objectName)).build();
+      // Define resource
+      BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, objectName)).build();
 
-    URL url =
-        storage.signUrl(blobInfo, 15, TimeUnit.MINUTES, Storage.SignUrlOption.withV4Signature());
+      URL url =
+          storage.signUrl(blobInfo, 15, TimeUnit.MINUTES, Storage.SignUrlOption.withV4Signature());
 
-    System.out.println("Generated GET signed URL:");
-    System.out.println(url);
-    System.out.println("You can use this URL with any user agent, for example:");
-    System.out.println("curl '" + url + "'");
+      System.out.println("Generated GET signed URL:");
+      System.out.println(url);
+      System.out.println("You can use this URL with any user agent, for example:");
+      System.out.println("curl '" + url + "'");
+    }
   }
-}}
+}
 // [END storage_generate_signed_url_v4]

--- a/samples/snippets/src/main/java/com/example/storage/object/GenerateV4GetObjectSignedUrl.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/GenerateV4GetObjectSignedUrl.java
@@ -21,7 +21,6 @@ package com.example.storage.object;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
@@ -38,12 +37,12 @@ public class GenerateV4GetObjectSignedUrl {
    * details.
    */
   public static void generateV4GetObjectSignedUrl(
-      String projectId, String bucketName, String objectName) throws StorageException {
+      String projectId, String bucketName, String objectName) throws Exception {
     // String projectId = "my-project-id";
     // String bucketName = "my-bucket";
     // String objectName = "my-object";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     // Define resource
     BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, objectName)).build();
@@ -56,5 +55,5 @@ public class GenerateV4GetObjectSignedUrl {
     System.out.println("You can use this URL with any user agent, for example:");
     System.out.println("curl '" + url + "'");
   }
-}
+}}
 // [END storage_generate_signed_url_v4]

--- a/samples/snippets/src/main/java/com/example/storage/object/GenerateV4PutObjectSignedUrl.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/GenerateV4PutObjectSignedUrl.java
@@ -22,7 +22,6 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.HttpMethod;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import java.net.URL;
 import java.util.HashMap;
@@ -41,12 +40,12 @@ public class GenerateV4PutObjectSignedUrl {
    * details.
    */
   public static void generateV4PutObjectSignedUrl(
-      String projectId, String bucketName, String objectName) throws StorageException {
+      String projectId, String bucketName, String objectName) throws Exception {
     // String projectId = "my-project-id";
     // String bucketName = "my-bucket";
     // String objectName = "my-object";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     // Define Resource
     BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, objectName)).build();
@@ -72,5 +71,5 @@ public class GenerateV4PutObjectSignedUrl {
             + url
             + "'");
   }
-}
+}}
 // [END storage_generate_upload_signed_url_v4]

--- a/samples/snippets/src/main/java/com/example/storage/object/GenerateV4PutObjectSignedUrl.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/GenerateV4PutObjectSignedUrl.java
@@ -45,31 +45,33 @@ public class GenerateV4PutObjectSignedUrl {
     // String bucketName = "my-bucket";
     // String objectName = "my-object";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    // Define Resource
-    BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, objectName)).build();
+      // Define Resource
+      BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, objectName)).build();
 
-    // Generate Signed URL
-    Map<String, String> extensionHeaders = new HashMap<>();
-    extensionHeaders.put("Content-Type", "application/octet-stream");
+      // Generate Signed URL
+      Map<String, String> extensionHeaders = new HashMap<>();
+      extensionHeaders.put("Content-Type", "application/octet-stream");
 
-    URL url =
-        storage.signUrl(
-            blobInfo,
-            15,
-            TimeUnit.MINUTES,
-            Storage.SignUrlOption.httpMethod(HttpMethod.PUT),
-            Storage.SignUrlOption.withExtHeaders(extensionHeaders),
-            Storage.SignUrlOption.withV4Signature());
+      URL url =
+          storage.signUrl(
+              blobInfo,
+              15,
+              TimeUnit.MINUTES,
+              Storage.SignUrlOption.httpMethod(HttpMethod.PUT),
+              Storage.SignUrlOption.withExtHeaders(extensionHeaders),
+              Storage.SignUrlOption.withV4Signature());
 
-    System.out.println("Generated PUT signed URL:");
-    System.out.println(url);
-    System.out.println("You can use this URL with any user agent, for example:");
-    System.out.println(
-        "curl -X PUT -H 'Content-Type: application/octet-stream' --upload-file my-file '"
-            + url
-            + "'");
+      System.out.println("Generated PUT signed URL:");
+      System.out.println(url);
+      System.out.println("You can use this URL with any user agent, for example:");
+      System.out.println(
+          "curl -X PUT -H 'Content-Type: application/octet-stream' --upload-file my-file '"
+              + url
+              + "'");
+    }
   }
-}}
+}
 // [END storage_generate_upload_signed_url_v4]

--- a/samples/snippets/src/main/java/com/example/storage/object/GetObjectMetadata.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/GetObjectMetadata.java
@@ -36,52 +36,56 @@ public class GetObjectMetadata {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    // Select all fields
-    // Fields can be selected individually e.g. Storage.BlobField.CACHE_CONTROL
-    Blob blob =
-        storage.get(bucketName, blobName, Storage.BlobGetOption.fields(Storage.BlobField.values()));
+      // Select all fields
+      // Fields can be selected individually e.g. Storage.BlobField.CACHE_CONTROL
+      Blob blob =
+          storage.get(
+              bucketName, blobName, Storage.BlobGetOption.fields(Storage.BlobField.values()));
 
-    // Print blob metadata
-    System.out.println("Bucket: " + blob.getBucket());
-    System.out.println("CacheControl: " + blob.getCacheControl());
-    System.out.println("ComponentCount: " + blob.getComponentCount());
-    System.out.println("ContentDisposition: " + blob.getContentDisposition());
-    System.out.println("ContentEncoding: " + blob.getContentEncoding());
-    System.out.println("ContentLanguage: " + blob.getContentLanguage());
-    System.out.println("ContentType: " + blob.getContentType());
-    System.out.println("CustomTime: " + blob.getCustomTime());
-    System.out.println("Crc32c: " + blob.getCrc32c());
-    System.out.println("Crc32cHexString: " + blob.getCrc32cToHexString());
-    System.out.println("ETag: " + blob.getEtag());
-    System.out.println("Generation: " + blob.getGeneration());
-    System.out.println("Id: " + blob.getBlobId());
-    System.out.println("KmsKeyName: " + blob.getKmsKeyName());
-    System.out.println("Md5Hash: " + blob.getMd5());
-    System.out.println("Md5HexString: " + blob.getMd5ToHexString());
-    System.out.println("MediaLink: " + blob.getMediaLink());
-    System.out.println("Metageneration: " + blob.getMetageneration());
-    System.out.println("Name: " + blob.getName());
-    System.out.println("Size: " + blob.getSize());
-    System.out.println("StorageClass: " + blob.getStorageClass());
-    System.out.println("TimeCreated: " + new Date(blob.getCreateTime()));
-    System.out.println("Last Metadata Update: " + new Date(blob.getUpdateTime()));
-    System.out.println("Object Retention Policy: " + blob.getRetention());
-    Boolean temporaryHoldIsEnabled = (blob.getTemporaryHold() != null && blob.getTemporaryHold());
-    System.out.println("temporaryHold: " + (temporaryHoldIsEnabled ? "enabled" : "disabled"));
-    Boolean eventBasedHoldIsEnabled =
-        (blob.getEventBasedHold() != null && blob.getEventBasedHold());
-    System.out.println("eventBasedHold: " + (eventBasedHoldIsEnabled ? "enabled" : "disabled"));
-    if (blob.getRetentionExpirationTime() != null) {
-      System.out.println("retentionExpirationTime: " + new Date(blob.getRetentionExpirationTime()));
-    }
-    if (blob.getMetadata() != null) {
-      System.out.println("\n\n\nUser metadata:");
-      for (Map.Entry<String, String> userMetadata : blob.getMetadata().entrySet()) {
-        System.out.println(userMetadata.getKey() + "=" + userMetadata.getValue());
+      // Print blob metadata
+      System.out.println("Bucket: " + blob.getBucket());
+      System.out.println("CacheControl: " + blob.getCacheControl());
+      System.out.println("ComponentCount: " + blob.getComponentCount());
+      System.out.println("ContentDisposition: " + blob.getContentDisposition());
+      System.out.println("ContentEncoding: " + blob.getContentEncoding());
+      System.out.println("ContentLanguage: " + blob.getContentLanguage());
+      System.out.println("ContentType: " + blob.getContentType());
+      System.out.println("CustomTime: " + blob.getCustomTime());
+      System.out.println("Crc32c: " + blob.getCrc32c());
+      System.out.println("Crc32cHexString: " + blob.getCrc32cToHexString());
+      System.out.println("ETag: " + blob.getEtag());
+      System.out.println("Generation: " + blob.getGeneration());
+      System.out.println("Id: " + blob.getBlobId());
+      System.out.println("KmsKeyName: " + blob.getKmsKeyName());
+      System.out.println("Md5Hash: " + blob.getMd5());
+      System.out.println("Md5HexString: " + blob.getMd5ToHexString());
+      System.out.println("MediaLink: " + blob.getMediaLink());
+      System.out.println("Metageneration: " + blob.getMetageneration());
+      System.out.println("Name: " + blob.getName());
+      System.out.println("Size: " + blob.getSize());
+      System.out.println("StorageClass: " + blob.getStorageClass());
+      System.out.println("TimeCreated: " + new Date(blob.getCreateTime()));
+      System.out.println("Last Metadata Update: " + new Date(blob.getUpdateTime()));
+      System.out.println("Object Retention Policy: " + blob.getRetention());
+      Boolean temporaryHoldIsEnabled = (blob.getTemporaryHold() != null && blob.getTemporaryHold());
+      System.out.println("temporaryHold: " + (temporaryHoldIsEnabled ? "enabled" : "disabled"));
+      Boolean eventBasedHoldIsEnabled =
+          (blob.getEventBasedHold() != null && blob.getEventBasedHold());
+      System.out.println("eventBasedHold: " + (eventBasedHoldIsEnabled ? "enabled" : "disabled"));
+      if (blob.getRetentionExpirationTime() != null) {
+        System.out.println(
+            "retentionExpirationTime: " + new Date(blob.getRetentionExpirationTime()));
+      }
+      if (blob.getMetadata() != null) {
+        System.out.println("\n\n\nUser metadata:");
+        for (Map.Entry<String, String> userMetadata : blob.getMetadata().entrySet()) {
+          System.out.println(userMetadata.getKey() + "=" + userMetadata.getValue());
+        }
       }
     }
   }
-}}
+}
 // [END storage_get_metadata]

--- a/samples/snippets/src/main/java/com/example/storage/object/GetObjectMetadata.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/GetObjectMetadata.java
@@ -20,14 +20,13 @@ package com.example.storage.object;
 
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import java.util.Date;
 import java.util.Map;
 
 public class GetObjectMetadata {
   public static void getObjectMetadata(String projectId, String bucketName, String blobName)
-      throws StorageException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -37,7 +36,7 @@ public class GetObjectMetadata {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     // Select all fields
     // Fields can be selected individually e.g. Storage.BlobField.CACHE_CONTROL
@@ -84,5 +83,5 @@ public class GetObjectMetadata {
       }
     }
   }
-}
+}}
 // [END storage_get_metadata]

--- a/samples/snippets/src/main/java/com/example/storage/object/ListObjects.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ListObjects.java
@@ -23,19 +23,19 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class ListObjects {
-  public static void listObjects(String projectId, String bucketName) {
+  public static void listObjects(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Page<Blob> blobs = storage.list(bucketName);
 
     for (Blob blob : blobs.iterateAll()) {
       System.out.println(blob.getName());
     }
   }
-}
+}}
 // [END storage_list_files]

--- a/samples/snippets/src/main/java/com/example/storage/object/ListObjects.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ListObjects.java
@@ -30,12 +30,14 @@ public class ListObjects {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Page<Blob> blobs = storage.list(bucketName);
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Page<Blob> blobs = storage.list(bucketName);
 
-    for (Blob blob : blobs.iterateAll()) {
-      System.out.println(blob.getName());
+      for (Blob blob : blobs.iterateAll()) {
+        System.out.println(blob.getName());
+      }
     }
   }
-}}
+}
 // [END storage_list_files]

--- a/samples/snippets/src/main/java/com/example/storage/object/ListObjectsWithOldVersions.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ListObjectsWithOldVersions.java
@@ -31,13 +31,15 @@ public class ListObjectsWithOldVersions {
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Bucket bucket = storage.get(bucketName);
-    Page<Blob> blobs = bucket.list(Storage.BlobListOption.versions(true));
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Bucket bucket = storage.get(bucketName);
+      Page<Blob> blobs = bucket.list(Storage.BlobListOption.versions(true));
 
-    for (Blob blob : blobs.iterateAll()) {
-      System.out.println(blob.getName() + "," + blob.getGeneration());
+      for (Blob blob : blobs.iterateAll()) {
+        System.out.println(blob.getName() + "," + blob.getGeneration());
+      }
     }
   }
-}}
+}
 // [END storage_list_file_archived_generations]

--- a/samples/snippets/src/main/java/com/example/storage/object/ListObjectsWithOldVersions.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ListObjectsWithOldVersions.java
@@ -24,13 +24,14 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class ListObjectsWithOldVersions {
-  public static void listObjectsWithOldVersions(String projectId, String bucketName) {
+  public static void listObjectsWithOldVersions(String projectId, String bucketName)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Bucket bucket = storage.get(bucketName);
     Page<Blob> blobs = bucket.list(Storage.BlobListOption.versions(true));
 
@@ -38,5 +39,5 @@ public class ListObjectsWithOldVersions {
       System.out.println(blob.getName() + "," + blob.getGeneration());
     }
   }
-}
+}}
 // [END storage_list_file_archived_generations]

--- a/samples/snippets/src/main/java/com/example/storage/object/ListObjectsWithPrefix.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ListObjectsWithPrefix.java
@@ -34,36 +34,39 @@ public class ListObjectsWithPrefix {
     // The directory prefix to search for
     // String directoryPrefix = "myDirectory/"
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    /**
-     * Using the Storage.BlobListOption.currentDirectory() option here causes the results to display
-     * in a "directory-like" mode, showing what objects are in the directory you've specified, as
-     * well as what other directories exist in that directory. For example, given these blobs:
-     *
-     * <p>a/1.txt a/b/2.txt a/b/3.txt
-     *
-     * <p>If you specify prefix = "a/" and don't use Storage.BlobListOption.currentDirectory(),
-     * you'll get back:
-     *
-     * <p>a/1.txt a/b/2.txt a/b/3.txt
-     *
-     * <p>However, if you specify prefix = "a/" and do use
-     * Storage.BlobListOption.currentDirectory(), you'll get back:
-     *
-     * <p>a/1.txt a/b/
-     *
-     * <p>Because a/1.txt is the only file in the a/ directory and a/b/ is a directory inside the
-     * /a/ directory.
-     */
-    Page<Blob> blobs =
-        storage.list(
-            bucketName,
-            Storage.BlobListOption.prefix(directoryPrefix),
-            Storage.BlobListOption.currentDirectory());
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      /**
+       * Using the Storage.BlobListOption.currentDirectory() option here causes the results to
+       * display in a "directory-like" mode, showing what objects are in the directory you've
+       * specified, as well as what other directories exist in that directory. For example, given
+       * these blobs:
+       *
+       * <p>a/1.txt a/b/2.txt a/b/3.txt
+       *
+       * <p>If you specify prefix = "a/" and don't use Storage.BlobListOption.currentDirectory(),
+       * you'll get back:
+       *
+       * <p>a/1.txt a/b/2.txt a/b/3.txt
+       *
+       * <p>However, if you specify prefix = "a/" and do use
+       * Storage.BlobListOption.currentDirectory(), you'll get back:
+       *
+       * <p>a/1.txt a/b/
+       *
+       * <p>Because a/1.txt is the only file in the a/ directory and a/b/ is a directory inside the
+       * /a/ directory.
+       */
+      Page<Blob> blobs =
+          storage.list(
+              bucketName,
+              Storage.BlobListOption.prefix(directoryPrefix),
+              Storage.BlobListOption.currentDirectory());
 
-    for (Blob blob : blobs.iterateAll()) {
-      System.out.println(blob.getName());
+      for (Blob blob : blobs.iterateAll()) {
+        System.out.println(blob.getName());
+      }
     }
   }
-}}
+}
 // [END storage_list_files_with_prefix]

--- a/samples/snippets/src/main/java/com/example/storage/object/ListObjectsWithPrefix.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ListObjectsWithPrefix.java
@@ -24,7 +24,7 @@ import com.google.cloud.storage.StorageOptions;
 
 public class ListObjectsWithPrefix {
   public static void listObjectsWithPrefix(
-      String projectId, String bucketName, String directoryPrefix) {
+      String projectId, String bucketName, String directoryPrefix) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -34,7 +34,7 @@ public class ListObjectsWithPrefix {
     // The directory prefix to search for
     // String directoryPrefix = "myDirectory/"
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     /**
      * Using the Storage.BlobListOption.currentDirectory() option here causes the results to display
      * in a "directory-like" mode, showing what objects are in the directory you've specified, as
@@ -65,5 +65,5 @@ public class ListObjectsWithPrefix {
       System.out.println(blob.getName());
     }
   }
-}
+}}
 // [END storage_list_files_with_prefix]

--- a/samples/snippets/src/main/java/com/example/storage/object/ListSoftDeletedObjects.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ListSoftDeletedObjects.java
@@ -30,12 +30,14 @@ public class ListSoftDeletedObjects {
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Page<Blob> blobs = storage.list(bucketName, Storage.BlobListOption.softDeleted(true));
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Page<Blob> blobs = storage.list(bucketName, Storage.BlobListOption.softDeleted(true));
 
-    for (Blob blob : blobs.iterateAll()) {
-      System.out.println(blob.getName());
+      for (Blob blob : blobs.iterateAll()) {
+        System.out.println(blob.getName());
+      }
     }
   }
-}}
+}
 // [END storage_list_soft_deleted_objects]

--- a/samples/snippets/src/main/java/com/example/storage/object/ListSoftDeletedObjects.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ListSoftDeletedObjects.java
@@ -23,19 +23,19 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class ListSoftDeletedObjects {
-  public static void listSoftDeletedObjects(String projectId, String bucketName) {
+  public static void listSoftDeletedObjects(String projectId, String bucketName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
     // The ID of your GCS bucket
     // String bucketName = "your-unique-bucket-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Page<Blob> blobs = storage.list(bucketName, Storage.BlobListOption.softDeleted(true));
 
     for (Blob blob : blobs.iterateAll()) {
       System.out.println(blob.getName());
     }
   }
-}
+}}
 // [END storage_list_soft_deleted_objects]

--- a/samples/snippets/src/main/java/com/example/storage/object/ListSoftDeletedVersionsOfObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ListSoftDeletedVersionsOfObject.java
@@ -25,7 +25,7 @@ import com.google.cloud.storage.StorageOptions;
 public class ListSoftDeletedVersionsOfObject {
 
   public static void listSoftDeletedVersionOfObject(
-      String projectId, String bucketName, String objectName) {
+      String projectId, String bucketName, String objectName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -35,7 +35,7 @@ public class ListSoftDeletedVersionsOfObject {
     // The name of your GCS object
     // String objectName = "your-object-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Page<Blob> blobs =
         storage.list(
             bucketName,
@@ -47,5 +47,5 @@ public class ListSoftDeletedVersionsOfObject {
       System.out.println(blob.getName());
     }
   }
-}
+}}
 // [END storage_list_soft_deleted_object_versions]

--- a/samples/snippets/src/main/java/com/example/storage/object/ListSoftDeletedVersionsOfObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ListSoftDeletedVersionsOfObject.java
@@ -35,17 +35,19 @@ public class ListSoftDeletedVersionsOfObject {
     // The name of your GCS object
     // String objectName = "your-object-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Page<Blob> blobs =
-        storage.list(
-            bucketName,
-            Storage.BlobListOption.softDeleted(true),
-            // See https://cloud.google.com/storage/docs/json_api/v1/objects/list#matchGlob
-            Storage.BlobListOption.matchGlob(objectName));
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Page<Blob> blobs =
+          storage.list(
+              bucketName,
+              Storage.BlobListOption.softDeleted(true),
+              // See https://cloud.google.com/storage/docs/json_api/v1/objects/list#matchGlob
+              Storage.BlobListOption.matchGlob(objectName));
 
-    for (Blob blob : blobs.iterateAll()) {
-      System.out.println(blob.getName());
+      for (Blob blob : blobs.iterateAll()) {
+        System.out.println(blob.getName());
+      }
     }
   }
-}}
+}
 // [END storage_list_soft_deleted_object_versions]

--- a/samples/snippets/src/main/java/com/example/storage/object/MakeObjectPublic.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/MakeObjectPublic.java
@@ -23,16 +23,17 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 public class MakeObjectPublic {
-  public static void makeObjectPublic(String projectId, String bucketName, String objectName) {
+  public static void makeObjectPublic(String projectId, String bucketName, String objectName)
+      throws Exception {
     // String projectId = "your-project-id";
     // String bucketName = "your-bucket-name";
     // String objectName = "your-object-name";
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     BlobId blobId = BlobId.of(bucketName, objectName);
     storage.createAcl(blobId, Acl.of(Acl.User.ofAllUsers(), Acl.Role.READER));
 
     System.out.println(
         "Object " + objectName + " in bucket " + bucketName + " was made publicly readable");
   }
-}
+}}
 // [END storage_make_public]

--- a/samples/snippets/src/main/java/com/example/storage/object/MakeObjectPublic.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/MakeObjectPublic.java
@@ -28,12 +28,14 @@ public class MakeObjectPublic {
     // String projectId = "your-project-id";
     // String bucketName = "your-bucket-name";
     // String objectName = "your-object-name";
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    BlobId blobId = BlobId.of(bucketName, objectName);
-    storage.createAcl(blobId, Acl.of(Acl.User.ofAllUsers(), Acl.Role.READER));
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      BlobId blobId = BlobId.of(bucketName, objectName);
+      storage.createAcl(blobId, Acl.of(Acl.User.ofAllUsers(), Acl.Role.READER));
 
-    System.out.println(
-        "Object " + objectName + " in bucket " + bucketName + " was made publicly readable");
+      System.out.println(
+          "Object " + objectName + " in bucket " + bucketName + " was made publicly readable");
+    }
   }
-}}
+}
 // [END storage_make_public]

--- a/samples/snippets/src/main/java/com/example/storage/object/PrintBlobAcl.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/PrintBlobAcl.java
@@ -51,6 +51,7 @@ public class PrintBlobAcl {
 
         System.out.printf("%s: %s %n", role, entityType);
       }
-    }}
+    }
+  }
 }
 // [END storage_print_file_acl]

--- a/samples/snippets/src/main/java/com/example/storage/object/PrintBlobAcl.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/PrintBlobAcl.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 public class PrintBlobAcl {
 
-  public static void printBlobAcl(String bucketName, String blobName) {
+  public static void printBlobAcl(String bucketName, String blobName) throws Exception {
 
     // The ID to give your GCS bucket
     // String bucketName = "your-unique-bucket-name";
@@ -35,22 +35,22 @@ public class PrintBlobAcl {
     // The name of the blob/file that you wish to view Acls of
     // String blobName = "your-blob-name";
 
-    Storage storage = StorageOptions.newBuilder().build().getService();
-    Blob blob = storage.get(BlobId.of(bucketName, blobName));
-    List<Acl> blobAcls = blob.getAcl();
+    try (Storage storage = StorageOptions.newBuilder().build().getService()) {
+      Blob blob = storage.get(BlobId.of(bucketName, blobName));
+      List<Acl> blobAcls = blob.getAcl();
 
-    for (Acl acl : blobAcls) {
+      for (Acl acl : blobAcls) {
 
-      // This will give you the role.
-      // See https://cloud.google.com/storage/docs/access-control/lists#permissions
-      String role = acl.getRole().name();
+        // This will give you the role.
+        // See https://cloud.google.com/storage/docs/access-control/lists#permissions
+        String role = acl.getRole().name();
 
-      // This will give you the Entity type (i.e. User, Group, Project etc.)
-      // See https://cloud.google.com/storage/docs/access-control/lists#scopes
-      String entityType = acl.getEntity().getType().name();
+        // This will give you the Entity type (i.e. User, Group, Project etc.)
+        // See https://cloud.google.com/storage/docs/access-control/lists#scopes
+        String entityType = acl.getEntity().getType().name();
 
-      System.out.printf("%s: %s %n", role, entityType);
-    }
-  }
+        System.out.printf("%s: %s %n", role, entityType);
+      }
+    }}
 }
 // [END storage_print_file_acl]

--- a/samples/snippets/src/main/java/com/example/storage/object/ReleaseEventBasedHold.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ReleaseEventBasedHold.java
@@ -21,12 +21,11 @@ package com.example.storage.object;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
 public class ReleaseEventBasedHold {
   public static void releaseEventBasedHold(String projectId, String bucketName, String objectName)
-      throws StorageException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -36,7 +35,7 @@ public class ReleaseEventBasedHold {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     BlobId blobId = BlobId.of(bucketName, objectName);
     Blob blob = storage.get(blobId);
     if (blob == null) {
@@ -53,5 +52,5 @@ public class ReleaseEventBasedHold {
 
     System.out.println("Event-based hold was released for " + objectName);
   }
-}
+}}
 // [END storage_release_event_based_hold]

--- a/samples/snippets/src/main/java/com/example/storage/object/ReleaseEventBasedHold.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ReleaseEventBasedHold.java
@@ -35,22 +35,24 @@ public class ReleaseEventBasedHold {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    BlobId blobId = BlobId.of(bucketName, objectName);
-    Blob blob = storage.get(blobId);
-    if (blob == null) {
-      System.out.println("The object " + objectName + " was not found in " + bucketName);
-      return;
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      BlobId blobId = BlobId.of(bucketName, objectName);
+      Blob blob = storage.get(blobId);
+      if (blob == null) {
+        System.out.println("The object " + objectName + " was not found in " + bucketName);
+        return;
+      }
+
+      // Optional: set a generation-match precondition to avoid potential race
+      // conditions and data corruptions. The request to upload returns a 412 error if
+      // the object's generation number does not match your precondition.
+      Storage.BlobTargetOption precondition = Storage.BlobTargetOption.generationMatch();
+
+      blob.toBuilder().setEventBasedHold(false).build().update(precondition);
+
+      System.out.println("Event-based hold was released for " + objectName);
     }
-
-    // Optional: set a generation-match precondition to avoid potential race
-    // conditions and data corruptions. The request to upload returns a 412 error if
-    // the object's generation number does not match your precondition.
-    Storage.BlobTargetOption precondition = Storage.BlobTargetOption.generationMatch();
-
-    blob.toBuilder().setEventBasedHold(false).build().update(precondition);
-
-    System.out.println("Event-based hold was released for " + objectName);
   }
-}}
+}
 // [END storage_release_event_based_hold]

--- a/samples/snippets/src/main/java/com/example/storage/object/ReleaseTemporaryHold.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ReleaseTemporaryHold.java
@@ -35,23 +35,25 @@ public class ReleaseTemporaryHold {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
-    BlobId blobId = BlobId.of(bucketName, objectName);
-    Blob blob = storage.get(blobId);
-    if (blob == null) {
-      System.out.println("The object " + objectName + " was not found in " + bucketName);
-      return;
+      BlobId blobId = BlobId.of(bucketName, objectName);
+      Blob blob = storage.get(blobId);
+      if (blob == null) {
+        System.out.println("The object " + objectName + " was not found in " + bucketName);
+        return;
+      }
+
+      // Optional: set a generation-match precondition to avoid potential race
+      // conditions and data corruptions. The request to upload returns a 412 error if
+      // the object's generation number does not match your precondition.
+      Storage.BlobTargetOption precondition = Storage.BlobTargetOption.generationMatch();
+
+      blob.toBuilder().setTemporaryHold(false).build().update(precondition);
+
+      System.out.println("Temporary hold was released for " + objectName);
     }
-
-    // Optional: set a generation-match precondition to avoid potential race
-    // conditions and data corruptions. The request to upload returns a 412 error if
-    // the object's generation number does not match your precondition.
-    Storage.BlobTargetOption precondition = Storage.BlobTargetOption.generationMatch();
-
-    blob.toBuilder().setTemporaryHold(false).build().update(precondition);
-
-    System.out.println("Temporary hold was released for " + objectName);
   }
-}}
+}
 // [END storage_release_temporary_hold]

--- a/samples/snippets/src/main/java/com/example/storage/object/ReleaseTemporaryHold.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/ReleaseTemporaryHold.java
@@ -21,12 +21,11 @@ package com.example.storage.object;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
 public class ReleaseTemporaryHold {
   public static void releaseTemporaryHold(String projectId, String bucketName, String objectName)
-      throws StorageException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -36,7 +35,7 @@ public class ReleaseTemporaryHold {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
 
     BlobId blobId = BlobId.of(bucketName, objectName);
     Blob blob = storage.get(blobId);
@@ -54,5 +53,5 @@ public class ReleaseTemporaryHold {
 
     System.out.println("Temporary hold was released for " + objectName);
   }
-}
+}}
 // [END storage_release_temporary_hold]

--- a/samples/snippets/src/main/java/com/example/storage/object/RemoveBlobOwner.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/RemoveBlobOwner.java
@@ -40,22 +40,24 @@ public class RemoveBlobOwner {
     // The name of the blob/file that you wish to modify permissions on
     // String blobName = "your-blob-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Blob blob = storage.get(BlobId.of(bucketName, blobName));
-    User ownerToRemove = new User(userEmail);
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Blob blob = storage.get(BlobId.of(bucketName, blobName));
+      User ownerToRemove = new User(userEmail);
 
-    boolean success = blob.deleteAcl(ownerToRemove);
-    if (success) {
-      System.out.println(
-          "Removed user "
-              + userEmail
-              + " as an owner on file "
-              + blobName
-              + " in bucket "
-              + bucketName);
-    } else {
-      System.out.println("User " + userEmail + " was not found");
+      boolean success = blob.deleteAcl(ownerToRemove);
+      if (success) {
+        System.out.println(
+            "Removed user "
+                + userEmail
+                + " as an owner on file "
+                + blobName
+                + " in bucket "
+                + bucketName);
+      } else {
+        System.out.println("User " + userEmail + " was not found");
+      }
     }
   }
-}}
+}
 // [END storage_remove_file_owner]

--- a/samples/snippets/src/main/java/com/example/storage/object/RemoveBlobOwner.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/RemoveBlobOwner.java
@@ -27,7 +27,7 @@ import com.google.cloud.storage.StorageOptions;
 public class RemoveBlobOwner {
 
   public static void removeBlobOwner(
-      String projectId, String bucketName, String userEmail, String blobName) {
+      String projectId, String bucketName, String userEmail, String blobName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -40,7 +40,7 @@ public class RemoveBlobOwner {
     // The name of the blob/file that you wish to modify permissions on
     // String blobName = "your-blob-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Blob blob = storage.get(BlobId.of(bucketName, blobName));
     User ownerToRemove = new User(userEmail);
 
@@ -57,5 +57,5 @@ public class RemoveBlobOwner {
       System.out.println("User " + userEmail + " was not found");
     }
   }
-}
+}}
 // [END storage_remove_file_owner]

--- a/samples/snippets/src/main/java/com/example/storage/object/RestoreSoftDeletedObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/RestoreSoftDeletedObject.java
@@ -24,7 +24,7 @@ import com.google.cloud.storage.StorageOptions;
 
 public class RestoreSoftDeletedObject {
   public static void restoreSoftDeletedObject(
-      String projectId, String bucketName, String objectName, long generation) {
+      String projectId, String bucketName, String objectName, long generation) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -34,10 +34,10 @@ public class RestoreSoftDeletedObject {
     // The name of your GCS object
     // String objectName = "your-object-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Blob blob = storage.restore(BlobId.of(bucketName, objectName, generation));
 
     System.out.println("Restored previously soft-deleted object " + blob.getName());
   }
-}
+}}
 // [END storage_restore_object]

--- a/samples/snippets/src/main/java/com/example/storage/object/RestoreSoftDeletedObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/RestoreSoftDeletedObject.java
@@ -34,10 +34,12 @@ public class RestoreSoftDeletedObject {
     // The name of your GCS object
     // String objectName = "your-object-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    Blob blob = storage.restore(BlobId.of(bucketName, objectName, generation));
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      Blob blob = storage.restore(BlobId.of(bucketName, objectName, generation));
 
-    System.out.println("Restored previously soft-deleted object " + blob.getName());
+      System.out.println("Restored previously soft-deleted object " + blob.getName());
+    }
   }
-}}
+}
 // [END storage_restore_object]

--- a/samples/snippets/src/main/java/com/example/storage/object/RotateObjectEncryptionKey.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/RotateObjectEncryptionKey.java
@@ -28,7 +28,7 @@ public class RotateObjectEncryptionKey {
       String bucketName,
       String objectName,
       String oldEncryptionKey,
-      String newEncryptionKey) {
+      String newEncryptionKey) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -47,7 +47,7 @@ public class RotateObjectEncryptionKey {
     // The new encryption key to use
     // String newEncryptionKey = "0mMWhFvQOdS4AmxRpo8SJxXn5MjFhbz7DkKBUdUIef8="
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     BlobId blobId = BlobId.of(bucketName, objectName);
     Blob blob = storage.get(blobId);
     if (blob == null) {
@@ -74,5 +74,5 @@ public class RotateObjectEncryptionKey {
     System.out.println(
         "Rotated encryption key for object " + objectName + "in bucket " + bucketName);
   }
-}
+}}
 // [END storage_rotate_encryption_key]

--- a/samples/snippets/src/main/java/com/example/storage/object/SetEventBasedHold.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/SetEventBasedHold.java
@@ -21,12 +21,11 @@ package com.example.storage.object;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
 public class SetEventBasedHold {
   public static void setEventBasedHold(String projectId, String bucketName, String objectName)
-      throws StorageException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -36,7 +35,7 @@ public class SetEventBasedHold {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     BlobId blobId = BlobId.of(bucketName, objectName);
     Blob blob = storage.get(blobId);
     if (blob == null) {
@@ -53,5 +52,5 @@ public class SetEventBasedHold {
 
     System.out.println("Event-based hold was set for " + objectName);
   }
-}
+}}
 // [END storage_set_event_based_hold]

--- a/samples/snippets/src/main/java/com/example/storage/object/SetEventBasedHold.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/SetEventBasedHold.java
@@ -35,22 +35,24 @@ public class SetEventBasedHold {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    BlobId blobId = BlobId.of(bucketName, objectName);
-    Blob blob = storage.get(blobId);
-    if (blob == null) {
-      System.out.println("The object " + objectName + " was not found in " + bucketName);
-      return;
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      BlobId blobId = BlobId.of(bucketName, objectName);
+      Blob blob = storage.get(blobId);
+      if (blob == null) {
+        System.out.println("The object " + objectName + " was not found in " + bucketName);
+        return;
+      }
+
+      // Optional: set a generation-match precondition to avoid potential race
+      // conditions and data corruptions. The request to upload returns a 412 error if
+      // the object's generation number does not match your precondition.
+      Storage.BlobTargetOption precondition = Storage.BlobTargetOption.generationMatch();
+
+      blob.toBuilder().setEventBasedHold(true).build().update(precondition);
+
+      System.out.println("Event-based hold was set for " + objectName);
     }
-
-    // Optional: set a generation-match precondition to avoid potential race
-    // conditions and data corruptions. The request to upload returns a 412 error if
-    // the object's generation number does not match your precondition.
-    Storage.BlobTargetOption precondition = Storage.BlobTargetOption.generationMatch();
-
-    blob.toBuilder().setEventBasedHold(true).build().update(precondition);
-
-    System.out.println("Event-based hold was set for " + objectName);
   }
-}}
+}
 // [END storage_set_event_based_hold]

--- a/samples/snippets/src/main/java/com/example/storage/object/SetObjectMetadata.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/SetObjectMetadata.java
@@ -27,7 +27,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class SetObjectMetadata {
-  public static void setObjectMetadata(String projectId, String bucketName, String objectName) {
+  public static void setObjectMetadata(String projectId, String bucketName, String objectName)
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -37,7 +38,7 @@ public class SetObjectMetadata {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     Map<String, String> newMetadata = new HashMap<>();
     newMetadata.put("keyToAddOrUpdate", "value");
     BlobId blobId = BlobId.of(bucketName, objectName);
@@ -60,5 +61,5 @@ public class SetObjectMetadata {
     System.out.println(
         "Updated custom metadata for object " + objectName + " in bucket " + bucketName);
   }
-}
+}}
 // [END storage_set_metadata]

--- a/samples/snippets/src/main/java/com/example/storage/object/SetObjectRetentionPolicy.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/SetObjectRetentionPolicy.java
@@ -24,12 +24,11 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo.Retention;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
 public class SetObjectRetentionPolicy {
   public static void setObjectRetentionPolicy(
-      String projectId, String bucketName, String objectName) throws StorageException {
+      String projectId, String bucketName, String objectName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -39,7 +38,7 @@ public class SetObjectRetentionPolicy {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     BlobId blobId = BlobId.of(bucketName, objectName);
     Blob blob = storage.get(blobId);
     if (blob == null) {
@@ -70,6 +69,6 @@ public class SetObjectRetentionPolicy {
     System.out.println("Retention policy for object " + objectName + " was updated to:");
     System.out.println(storage.get(blobId).getRetention().toString());
   }
-}
+}}
 
 // [END storage_set_object_retention_policy]

--- a/samples/snippets/src/main/java/com/example/storage/object/SetTemporaryHold.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/SetTemporaryHold.java
@@ -35,22 +35,24 @@ public class SetTemporaryHold {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    BlobId blobId = BlobId.of(bucketName, objectName);
-    Blob blob = storage.get(blobId);
-    if (blob == null) {
-      System.out.println("The object " + objectName + " was not found in " + bucketName);
-      return;
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      BlobId blobId = BlobId.of(bucketName, objectName);
+      Blob blob = storage.get(blobId);
+      if (blob == null) {
+        System.out.println("The object " + objectName + " was not found in " + bucketName);
+        return;
+      }
+
+      // Optional: set a generation-match precondition to avoid potential race
+      // conditions and data corruptions. The request to upload returns a 412 error if
+      // the object's generation number does not match your precondition.
+      Storage.BlobTargetOption precondition = Storage.BlobTargetOption.generationMatch();
+
+      blob.toBuilder().setTemporaryHold(true).build().update(precondition);
+
+      System.out.println("Temporary hold was set for " + objectName);
     }
-
-    // Optional: set a generation-match precondition to avoid potential race
-    // conditions and data corruptions. The request to upload returns a 412 error if
-    // the object's generation number does not match your precondition.
-    Storage.BlobTargetOption precondition = Storage.BlobTargetOption.generationMatch();
-
-    blob.toBuilder().setTemporaryHold(true).build().update(precondition);
-
-    System.out.println("Temporary hold was set for " + objectName);
   }
-}}
+}
 // [END storage_set_temporary_hold]

--- a/samples/snippets/src/main/java/com/example/storage/object/SetTemporaryHold.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/SetTemporaryHold.java
@@ -21,12 +21,11 @@ package com.example.storage.object;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 
 public class SetTemporaryHold {
   public static void setTemporaryHold(String projectId, String bucketName, String objectName)
-      throws StorageException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -36,7 +35,7 @@ public class SetTemporaryHold {
     // The ID of your GCS object
     // String objectName = "your-object-name";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     BlobId blobId = BlobId.of(bucketName, objectName);
     Blob blob = storage.get(blobId);
     if (blob == null) {
@@ -53,5 +52,5 @@ public class SetTemporaryHold {
 
     System.out.println("Temporary hold was set for " + objectName);
   }
-}
+}}
 // [END storage_set_temporary_hold]

--- a/samples/snippets/src/main/java/com/example/storage/object/StreamObjectDownload.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/StreamObjectDownload.java
@@ -23,7 +23,6 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.io.ByteStreams;
-import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -33,7 +32,7 @@ public class StreamObjectDownload {
 
   public static void streamObjectDownload(
       String projectId, String bucketName, String objectName, String targetFile)
-      throws IOException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -47,7 +46,7 @@ public class StreamObjectDownload {
     // String targetFile = "path/to/your/file";
     Path targetFilePath = Paths.get(targetFile);
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     try (ReadChannel reader = storage.reader(BlobId.of(bucketName, objectName));
         FileChannel targetFileChannel =
             FileChannel.open(targetFilePath, StandardOpenOption.WRITE)) {
@@ -64,5 +63,5 @@ public class StreamObjectDownload {
               + " using a ReadChannel.");
     }
   }
-}
+}}
 // [END storage_stream_file_download]

--- a/samples/snippets/src/main/java/com/example/storage/object/StreamObjectDownload.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/StreamObjectDownload.java
@@ -31,8 +31,7 @@ import java.nio.file.StandardOpenOption;
 public class StreamObjectDownload {
 
   public static void streamObjectDownload(
-      String projectId, String bucketName, String objectName, String targetFile)
-      throws Exception {
+      String projectId, String bucketName, String objectName, String targetFile) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -46,22 +45,24 @@ public class StreamObjectDownload {
     // String targetFile = "path/to/your/file";
     Path targetFilePath = Paths.get(targetFile);
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    try (ReadChannel reader = storage.reader(BlobId.of(bucketName, objectName));
-        FileChannel targetFileChannel =
-            FileChannel.open(targetFilePath, StandardOpenOption.WRITE)) {
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      try (ReadChannel reader = storage.reader(BlobId.of(bucketName, objectName));
+          FileChannel targetFileChannel =
+              FileChannel.open(targetFilePath, StandardOpenOption.WRITE)) {
 
-      ByteStreams.copy(reader, targetFileChannel);
+        ByteStreams.copy(reader, targetFileChannel);
 
-      System.out.println(
-          "Downloaded object "
-              + objectName
-              + " from bucket "
-              + bucketName
-              + " to "
-              + targetFile
-              + " using a ReadChannel.");
+        System.out.println(
+            "Downloaded object "
+                + objectName
+                + " from bucket "
+                + bucketName
+                + " to "
+                + targetFile
+                + " using a ReadChannel.");
+      }
     }
   }
-}}
+}
 // [END storage_stream_file_download]

--- a/samples/snippets/src/main/java/com/example/storage/object/StreamObjectUpload.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/StreamObjectUpload.java
@@ -42,16 +42,18 @@ public class StreamObjectUpload {
     // The string of contents you wish to upload
     // String contents = "Hello world!";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    BlobId blobId = BlobId.of(bucketName, objectName);
-    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
-    byte[] content = contents.getBytes(StandardCharsets.UTF_8);
-    try (WriteChannel writer = storage.writer(blobInfo)) {
-      writer.write(ByteBuffer.wrap(content));
-      System.out.println(
-          "Wrote to " + objectName + " in bucket " + bucketName + " using a WriteChannel.");
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      BlobId blobId = BlobId.of(bucketName, objectName);
+      BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+      byte[] content = contents.getBytes(StandardCharsets.UTF_8);
+      try (WriteChannel writer = storage.writer(blobInfo)) {
+        writer.write(ByteBuffer.wrap(content));
+        System.out.println(
+            "Wrote to " + objectName + " in bucket " + bucketName + " using a WriteChannel.");
+      }
     }
   }
-}}
+}
 
 // [END storage_stream_file_upload]

--- a/samples/snippets/src/main/java/com/example/storage/object/StreamObjectUpload.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/StreamObjectUpload.java
@@ -23,14 +23,13 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 public class StreamObjectUpload {
 
   public static void streamObjectUpload(
-      String projectId, String bucketName, String objectName, String contents) throws IOException {
+      String projectId, String bucketName, String objectName, String contents) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -43,7 +42,7 @@ public class StreamObjectUpload {
     // The string of contents you wish to upload
     // String contents = "Hello world!";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     BlobId blobId = BlobId.of(bucketName, objectName);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
     byte[] content = contents.getBytes(StandardCharsets.UTF_8);
@@ -53,6 +52,6 @@ public class StreamObjectUpload {
           "Wrote to " + objectName + " in bucket " + bucketName + " using a WriteChannel.");
     }
   }
-}
+}}
 
 // [END storage_stream_file_upload]

--- a/samples/snippets/src/main/java/com/example/storage/object/UploadEncryptedObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/UploadEncryptedObject.java
@@ -22,14 +22,13 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
 public class UploadEncryptedObject {
   public static void uploadEncryptedObject(
       String projectId, String bucketName, String objectName, String filePath, String encryptionKey)
-      throws IOException {
+      throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -45,7 +44,7 @@ public class UploadEncryptedObject {
     // The key to encrypt the object with
     // String encryptionKey = "TIbv/fjexq+VmtXzAlc63J4z5kFmWJ6NdAPQulQBT7g=";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     BlobId blobId = BlobId.of(bucketName, objectName);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
 
@@ -81,5 +80,5 @@ public class UploadEncryptedObject {
             + objectName
             + " with supplied encryption key");
   }
-}
+}}
 // [END storage_upload_encrypted_file]

--- a/samples/snippets/src/main/java/com/example/storage/object/UploadEncryptedObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/UploadEncryptedObject.java
@@ -44,41 +44,43 @@ public class UploadEncryptedObject {
     // The key to encrypt the object with
     // String encryptionKey = "TIbv/fjexq+VmtXzAlc63J4z5kFmWJ6NdAPQulQBT7g=";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    BlobId blobId = BlobId.of(bucketName, objectName);
-    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      BlobId blobId = BlobId.of(bucketName, objectName);
+      BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
 
-    // Optional: set a generation-match precondition to avoid potential race
-    // conditions and data corruptions. The request returns a 412 error if the
-    // preconditions are not met.
-    Storage.BlobTargetOption precondition;
-    if (storage.get(bucketName, objectName) == null) {
-      // For a target object that does not yet exist, set the DoesNotExist precondition.
-      // This will cause the request to fail if the object is created before the request runs.
-      precondition = Storage.BlobTargetOption.doesNotExist();
-    } else {
-      // If the destination already exists in your bucket, instead set a generation-match
-      // precondition. This will cause the request to fail if the existing object's generation
-      // changes before the request runs.
-      precondition =
-          Storage.BlobTargetOption.generationMatch(
-              storage.get(bucketName, objectName).getGeneration());
+      // Optional: set a generation-match precondition to avoid potential race
+      // conditions and data corruptions. The request returns a 412 error if the
+      // preconditions are not met.
+      Storage.BlobTargetOption precondition;
+      if (storage.get(bucketName, objectName) == null) {
+        // For a target object that does not yet exist, set the DoesNotExist precondition.
+        // This will cause the request to fail if the object is created before the request runs.
+        precondition = Storage.BlobTargetOption.doesNotExist();
+      } else {
+        // If the destination already exists in your bucket, instead set a generation-match
+        // precondition. This will cause the request to fail if the existing object's generation
+        // changes before the request runs.
+        precondition =
+            Storage.BlobTargetOption.generationMatch(
+                storage.get(bucketName, objectName).getGeneration());
+      }
+
+      storage.create(
+          blobInfo,
+          Files.readAllBytes(Paths.get(filePath)),
+          Storage.BlobTargetOption.encryptionKey(encryptionKey),
+          precondition);
+
+      System.out.println(
+          "File "
+              + filePath
+              + " uploaded to bucket "
+              + bucketName
+              + " as "
+              + objectName
+              + " with supplied encryption key");
     }
-
-    storage.create(
-        blobInfo,
-        Files.readAllBytes(Paths.get(filePath)),
-        Storage.BlobTargetOption.encryptionKey(encryptionKey),
-        precondition);
-
-    System.out.println(
-        "File "
-            + filePath
-            + " uploaded to bucket "
-            + bucketName
-            + " as "
-            + objectName
-            + " with supplied encryption key");
   }
-}}
+}
 // [END storage_upload_encrypted_file]

--- a/samples/snippets/src/main/java/com/example/storage/object/UploadKmsEncryptedObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/UploadKmsEncryptedObject.java
@@ -40,38 +40,40 @@ public class UploadKmsEncryptedObject {
     // The name of the KMS key to encrypt with
     // String kmsKeyName = "projects/my-project/locations/us/keyRings/my_key_ring/cryptoKeys/my_key"
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    byte[] data = "Hello, World!".getBytes(UTF_8);
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      byte[] data = "Hello, World!".getBytes(UTF_8);
 
-    BlobId blobId = BlobId.of(bucketName, objectName);
-    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("text/plain").build();
+      BlobId blobId = BlobId.of(bucketName, objectName);
+      BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setContentType("text/plain").build();
 
-    // Optional: set a generation-match precondition to avoid potential race
-    // conditions and data corruptions. The request returns a 412 error if the
-    // preconditions are not met.
-    Storage.BlobTargetOption precondition;
-    if (storage.get(bucketName, objectName) == null) {
-      // For a target object that does not yet exist, set the DoesNotExist precondition.
-      // This will cause the request to fail if the object is created before the request runs.
-      precondition = Storage.BlobTargetOption.doesNotExist();
-    } else {
-      // If the destination already exists in your bucket, instead set a generation-match
-      // precondition. This will cause the request to fail if the existing object's generation
-      // changes before the request runs.
-      precondition =
-          Storage.BlobTargetOption.generationMatch(
-              storage.get(bucketName, objectName).getGeneration());
+      // Optional: set a generation-match precondition to avoid potential race
+      // conditions and data corruptions. The request returns a 412 error if the
+      // preconditions are not met.
+      Storage.BlobTargetOption precondition;
+      if (storage.get(bucketName, objectName) == null) {
+        // For a target object that does not yet exist, set the DoesNotExist precondition.
+        // This will cause the request to fail if the object is created before the request runs.
+        precondition = Storage.BlobTargetOption.doesNotExist();
+      } else {
+        // If the destination already exists in your bucket, instead set a generation-match
+        // precondition. This will cause the request to fail if the existing object's generation
+        // changes before the request runs.
+        precondition =
+            Storage.BlobTargetOption.generationMatch(
+                storage.get(bucketName, objectName).getGeneration());
+      }
+
+      storage.create(blobInfo, data, Storage.BlobTargetOption.kmsKeyName(kmsKeyName), precondition);
+
+      System.out.println(
+          "Uploaded object "
+              + objectName
+              + " in bucket "
+              + bucketName
+              + " encrypted with "
+              + kmsKeyName);
     }
-
-    storage.create(blobInfo, data, Storage.BlobTargetOption.kmsKeyName(kmsKeyName), precondition);
-
-    System.out.println(
-        "Uploaded object "
-            + objectName
-            + " in bucket "
-            + bucketName
-            + " encrypted with "
-            + kmsKeyName);
   }
-}}
+}
 // [END storage_upload_with_kms_key]

--- a/samples/snippets/src/main/java/com/example/storage/object/UploadKmsEncryptedObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/UploadKmsEncryptedObject.java
@@ -27,7 +27,7 @@ import com.google.cloud.storage.StorageOptions;
 
 public class UploadKmsEncryptedObject {
   public static void uploadKmsEncryptedObject(
-      String projectId, String bucketName, String objectName, String kmsKeyName) {
+      String projectId, String bucketName, String objectName, String kmsKeyName) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -40,7 +40,7 @@ public class UploadKmsEncryptedObject {
     // The name of the KMS key to encrypt with
     // String kmsKeyName = "projects/my-project/locations/us/keyRings/my_key_ring/cryptoKeys/my_key"
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     byte[] data = "Hello, World!".getBytes(UTF_8);
 
     BlobId blobId = BlobId.of(bucketName, objectName);
@@ -73,5 +73,5 @@ public class UploadKmsEncryptedObject {
             + " encrypted with "
             + kmsKeyName);
   }
-}
+}}
 // [END storage_upload_with_kms_key]

--- a/samples/snippets/src/main/java/com/example/storage/object/UploadObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/UploadObject.java
@@ -39,30 +39,32 @@ public class UploadObject {
     // The path to your file to upload
     // String filePath = "path/to/your/file"
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    BlobId blobId = BlobId.of(bucketName, objectName);
-    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      BlobId blobId = BlobId.of(bucketName, objectName);
+      BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
 
-    // Optional: set a generation-match precondition to avoid potential race
-    // conditions and data corruptions. The request returns a 412 error if the
-    // preconditions are not met.
-    Storage.BlobWriteOption precondition;
-    if (storage.get(bucketName, objectName) == null) {
-      // For a target object that does not yet exist, set the DoesNotExist precondition.
-      // This will cause the request to fail if the object is created before the request runs.
-      precondition = Storage.BlobWriteOption.doesNotExist();
-    } else {
-      // If the destination already exists in your bucket, instead set a generation-match
-      // precondition. This will cause the request to fail if the existing object's generation
-      // changes before the request runs.
-      precondition =
-          Storage.BlobWriteOption.generationMatch(
-              storage.get(bucketName, objectName).getGeneration());
+      // Optional: set a generation-match precondition to avoid potential race
+      // conditions and data corruptions. The request returns a 412 error if the
+      // preconditions are not met.
+      Storage.BlobWriteOption precondition;
+      if (storage.get(bucketName, objectName) == null) {
+        // For a target object that does not yet exist, set the DoesNotExist precondition.
+        // This will cause the request to fail if the object is created before the request runs.
+        precondition = Storage.BlobWriteOption.doesNotExist();
+      } else {
+        // If the destination already exists in your bucket, instead set a generation-match
+        // precondition. This will cause the request to fail if the existing object's generation
+        // changes before the request runs.
+        precondition =
+            Storage.BlobWriteOption.generationMatch(
+                storage.get(bucketName, objectName).getGeneration());
+      }
+      storage.createFrom(blobInfo, Paths.get(filePath), precondition);
+
+      System.out.println(
+          "File " + filePath + " uploaded to bucket " + bucketName + " as " + objectName);
     }
-    storage.createFrom(blobInfo, Paths.get(filePath), precondition);
-
-    System.out.println(
-        "File " + filePath + " uploaded to bucket " + bucketName + " as " + objectName);
   }
-}}
+}
 // [END storage_upload_file]

--- a/samples/snippets/src/main/java/com/example/storage/object/UploadObject.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/UploadObject.java
@@ -22,12 +22,11 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
-import java.io.IOException;
 import java.nio.file.Paths;
 
 public class UploadObject {
   public static void uploadObject(
-      String projectId, String bucketName, String objectName, String filePath) throws IOException {
+      String projectId, String bucketName, String objectName, String filePath) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -40,7 +39,7 @@ public class UploadObject {
     // The path to your file to upload
     // String filePath = "path/to/your/file"
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     BlobId blobId = BlobId.of(bucketName, objectName);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
 
@@ -65,5 +64,5 @@ public class UploadObject {
     System.out.println(
         "File " + filePath + " uploaded to bucket " + bucketName + " as " + objectName);
   }
-}
+}}
 // [END storage_upload_file]

--- a/samples/snippets/src/main/java/com/example/storage/object/UploadObjectFromMemory.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/UploadObjectFromMemory.java
@@ -22,12 +22,11 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 public class UploadObjectFromMemory {
   public static void uploadObjectFromMemory(
-      String projectId, String bucketName, String objectName, String contents) throws IOException {
+      String projectId, String bucketName, String objectName, String contents) throws Exception {
     // The ID of your GCP project
     // String projectId = "your-project-id";
 
@@ -40,7 +39,7 @@ public class UploadObjectFromMemory {
     // The string of contents you wish to upload
     // String contents = "Hello world!";
 
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
     BlobId blobId = BlobId.of(bucketName, objectName);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
     byte[] content = contents.getBytes(StandardCharsets.UTF_8);
@@ -72,5 +71,5 @@ public class UploadObjectFromMemory {
             + " with contents "
             + contents);
   }
-}
+}}
 // [END storage_file_upload_from_memory]

--- a/samples/snippets/src/main/java/com/example/storage/object/UploadObjectFromMemory.java
+++ b/samples/snippets/src/main/java/com/example/storage/object/UploadObjectFromMemory.java
@@ -39,37 +39,39 @@ public class UploadObjectFromMemory {
     // The string of contents you wish to upload
     // String contents = "Hello world!";
 
-    try (Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
-    BlobId blobId = BlobId.of(bucketName, objectName);
-    BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
-    byte[] content = contents.getBytes(StandardCharsets.UTF_8);
+    try (Storage storage =
+        StorageOptions.newBuilder().setProjectId(projectId).build().getService()) {
+      BlobId blobId = BlobId.of(bucketName, objectName);
+      BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+      byte[] content = contents.getBytes(StandardCharsets.UTF_8);
 
-    // Optional: set a generation-match precondition to enable automatic retries, avoid potential
-    // race
-    // conditions and data corruptions. The request returns a 412 error if the
-    // preconditions are not met.
-    Storage.BlobTargetOption precondition;
-    if (storage.get(bucketName, objectName) == null) {
-      // For a target object that does not yet exist, set the DoesNotExist precondition.
-      // This will cause the request to fail if the object is created before the request runs.
-      precondition = Storage.BlobTargetOption.doesNotExist();
-    } else {
-      // If the destination already exists in your bucket, instead set a generation-match
-      // precondition. This will cause the request to fail if the existing object's generation
-      // changes before the request runs.
-      precondition =
-          Storage.BlobTargetOption.generationMatch(
-              storage.get(bucketName, objectName).getGeneration());
+      // Optional: set a generation-match precondition to enable automatic retries, avoid potential
+      // race
+      // conditions and data corruptions. The request returns a 412 error if the
+      // preconditions are not met.
+      Storage.BlobTargetOption precondition;
+      if (storage.get(bucketName, objectName) == null) {
+        // For a target object that does not yet exist, set the DoesNotExist precondition.
+        // This will cause the request to fail if the object is created before the request runs.
+        precondition = Storage.BlobTargetOption.doesNotExist();
+      } else {
+        // If the destination already exists in your bucket, instead set a generation-match
+        // precondition. This will cause the request to fail if the existing object's generation
+        // changes before the request runs.
+        precondition =
+            Storage.BlobTargetOption.generationMatch(
+                storage.get(bucketName, objectName).getGeneration());
+      }
+      storage.create(blobInfo, content, precondition);
+
+      System.out.println(
+          "Object "
+              + objectName
+              + " uploaded to bucket "
+              + bucketName
+              + " with contents "
+              + contents);
     }
-    storage.create(blobInfo, content, precondition);
-
-    System.out.println(
-        "Object "
-            + objectName
-            + " uploaded to bucket "
-            + bucketName
-            + " with contents "
-            + contents);
   }
-}}
+}
 // [END storage_file_upload_from_memory]

--- a/samples/snippets/src/main/java/com/example/storage/transfermanager/AllowDivideAndConquerDownload.java
+++ b/samples/snippets/src/main/java/com/example/storage/transfermanager/AllowDivideAndConquerDownload.java
@@ -29,26 +29,26 @@ import java.util.List;
 class AllowDivideAndConquerDownload {
 
   public static void divideAndConquerDownloadAllowed(
-      List<BlobInfo> blobs, String bucketName, Path destinationDirectory) {
-    TransferManager transferManager =
-        TransferManagerConfig.newBuilder()
-            .setAllowDivideAndConquerDownload(true)
-            .build()
-            .getService();
-    ParallelDownloadConfig parallelDownloadConfig =
-        ParallelDownloadConfig.newBuilder()
-            .setBucketName(bucketName)
-            .setDownloadDirectory(destinationDirectory)
-            .build();
-    List<DownloadResult> results =
-        transferManager.downloadBlobs(blobs, parallelDownloadConfig).getDownloadResults();
+      List<BlobInfo> blobs, String bucketName, Path destinationDirectory) throws Exception {
+    TransferManagerConfig transferManagerConfig = TransferManagerConfig.newBuilder()
+        .setAllowDivideAndConquerDownload(true)
+        .build();
+    try (TransferManager transferManager = transferManagerConfig.getService()) {
+      ParallelDownloadConfig parallelDownloadConfig =
+          ParallelDownloadConfig.newBuilder()
+              .setBucketName(bucketName)
+              .setDownloadDirectory(destinationDirectory)
+              .build();
+      List<DownloadResult> results =
+          transferManager.downloadBlobs(blobs, parallelDownloadConfig).getDownloadResults();
 
-    for (DownloadResult result : results) {
-      System.out.println(
-          "Download of "
-              + result.getInput().getName()
-              + " completed with status "
-              + result.getStatus());
+      for (DownloadResult result : results) {
+        System.out.println(
+            "Download of "
+                + result.getInput().getName()
+                + " completed with status "
+                + result.getStatus());
+      }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/transfermanager/AllowDivideAndConquerDownload.java
+++ b/samples/snippets/src/main/java/com/example/storage/transfermanager/AllowDivideAndConquerDownload.java
@@ -30,9 +30,8 @@ class AllowDivideAndConquerDownload {
 
   public static void divideAndConquerDownloadAllowed(
       List<BlobInfo> blobs, String bucketName, Path destinationDirectory) throws Exception {
-    TransferManagerConfig transferManagerConfig = TransferManagerConfig.newBuilder()
-        .setAllowDivideAndConquerDownload(true)
-        .build();
+    TransferManagerConfig transferManagerConfig =
+        TransferManagerConfig.newBuilder().setAllowDivideAndConquerDownload(true).build();
     try (TransferManager transferManager = transferManagerConfig.getService()) {
       ParallelDownloadConfig parallelDownloadConfig =
           ParallelDownloadConfig.newBuilder()

--- a/samples/snippets/src/main/java/com/example/storage/transfermanager/AllowParallelCompositeUpload.java
+++ b/samples/snippets/src/main/java/com/example/storage/transfermanager/AllowParallelCompositeUpload.java
@@ -18,33 +18,33 @@
 package com.example.storage.transfermanager;
 
 // [START storage_transfer_manager_upload_chunks_concurrently]
+
 import com.google.cloud.storage.transfermanager.ParallelUploadConfig;
 import com.google.cloud.storage.transfermanager.TransferManager;
 import com.google.cloud.storage.transfermanager.TransferManagerConfig;
 import com.google.cloud.storage.transfermanager.UploadResult;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
 class AllowParallelCompositeUpload {
 
   public static void parallelCompositeUploadAllowed(String bucketName, List<Path> files)
-      throws IOException {
-    TransferManager transferManager =
-        TransferManagerConfig.newBuilder()
-            .setAllowParallelCompositeUpload(true)
-            .build()
-            .getService();
-    ParallelUploadConfig parallelUploadConfig =
-        ParallelUploadConfig.newBuilder().setBucketName(bucketName).build();
-    List<UploadResult> results =
-        transferManager.uploadFiles(files, parallelUploadConfig).getUploadResults();
-    for (UploadResult result : results) {
-      System.out.println(
-          "Upload for "
-              + result.getInput().getName()
-              + " completed with status "
-              + result.getStatus());
+      throws Exception {
+    TransferManagerConfig transferManagerConfig = TransferManagerConfig.newBuilder()
+        .setAllowParallelCompositeUpload(true)
+        .build();
+    try (TransferManager transferManager = transferManagerConfig.getService()) {
+      ParallelUploadConfig parallelUploadConfig =
+          ParallelUploadConfig.newBuilder().setBucketName(bucketName).build();
+      List<UploadResult> results =
+          transferManager.uploadFiles(files, parallelUploadConfig).getUploadResults();
+      for (UploadResult result : results) {
+        System.out.println(
+            "Upload for "
+                + result.getInput().getName()
+                + " completed with status "
+                + result.getStatus());
+      }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/transfermanager/AllowParallelCompositeUpload.java
+++ b/samples/snippets/src/main/java/com/example/storage/transfermanager/AllowParallelCompositeUpload.java
@@ -30,9 +30,8 @@ class AllowParallelCompositeUpload {
 
   public static void parallelCompositeUploadAllowed(String bucketName, List<Path> files)
       throws Exception {
-    TransferManagerConfig transferManagerConfig = TransferManagerConfig.newBuilder()
-        .setAllowParallelCompositeUpload(true)
-        .build();
+    TransferManagerConfig transferManagerConfig =
+        TransferManagerConfig.newBuilder().setAllowParallelCompositeUpload(true).build();
     try (TransferManager transferManager = transferManagerConfig.getService()) {
       ParallelUploadConfig parallelUploadConfig =
           ParallelUploadConfig.newBuilder().setBucketName(bucketName).build();

--- a/samples/snippets/src/main/java/com/example/storage/transfermanager/DownloadBucket.java
+++ b/samples/snippets/src/main/java/com/example/storage/transfermanager/DownloadBucket.java
@@ -31,30 +31,35 @@ import java.util.stream.Collectors;
 class DownloadBucket {
 
   public static void downloadBucketContents(
-      String projectId, String bucketName, Path destinationDirectory) {
-    Storage storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
-    List<BlobInfo> blobs =
-        storage
-            .list(bucketName)
-            .streamAll()
-            .map(blob -> blob.asBlobInfo())
-            .collect(Collectors.toList());
-    TransferManager transferManager = TransferManagerConfig.newBuilder().build().getService();
-    ParallelDownloadConfig parallelDownloadConfig =
-        ParallelDownloadConfig.newBuilder()
-            .setBucketName(bucketName)
-            .setDownloadDirectory(destinationDirectory)
-            .build();
+      String projectId, String bucketName, Path destinationDirectory) throws Exception {
+    StorageOptions storageOptions = StorageOptions.newBuilder().setProjectId(projectId).build();
+    List<BlobInfo> blobs;
+    try (Storage storage = storageOptions.getService()) {
+      blobs = storage
+          .list(bucketName)
+          .streamAll()
+          .map(blob -> blob.asBlobInfo())
+          .collect(Collectors.toList());
+    }
 
-    List<DownloadResult> results =
-        transferManager.downloadBlobs(blobs, parallelDownloadConfig).getDownloadResults();
+    TransferManagerConfig transferManagerConfig = TransferManagerConfig.newBuilder().build();
+    try (TransferManager transferManager = transferManagerConfig.getService()) {
+      ParallelDownloadConfig parallelDownloadConfig =
+          ParallelDownloadConfig.newBuilder()
+              .setBucketName(bucketName)
+              .setDownloadDirectory(destinationDirectory)
+              .build();
 
-    for (DownloadResult result : results) {
-      System.out.println(
-          "Download of "
-              + result.getInput().getName()
-              + " completed with status "
-              + result.getStatus());
+      List<DownloadResult> results =
+          transferManager.downloadBlobs(blobs, parallelDownloadConfig).getDownloadResults();
+
+      for (DownloadResult result : results) {
+        System.out.println(
+            "Download of "
+                + result.getInput().getName()
+                + " completed with status "
+                + result.getStatus());
+      }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/transfermanager/DownloadBucket.java
+++ b/samples/snippets/src/main/java/com/example/storage/transfermanager/DownloadBucket.java
@@ -35,11 +35,12 @@ class DownloadBucket {
     StorageOptions storageOptions = StorageOptions.newBuilder().setProjectId(projectId).build();
     List<BlobInfo> blobs;
     try (Storage storage = storageOptions.getService()) {
-      blobs = storage
-          .list(bucketName)
-          .streamAll()
-          .map(blob -> blob.asBlobInfo())
-          .collect(Collectors.toList());
+      blobs =
+          storage
+              .list(bucketName)
+              .streamAll()
+              .map(blob -> blob.asBlobInfo())
+              .collect(Collectors.toList());
     }
 
     TransferManagerConfig transferManagerConfig = TransferManagerConfig.newBuilder().build();

--- a/samples/snippets/src/main/java/com/example/storage/transfermanager/DownloadMany.java
+++ b/samples/snippets/src/main/java/com/example/storage/transfermanager/DownloadMany.java
@@ -31,8 +31,7 @@ class DownloadMany {
       String bucketName, List<BlobInfo> blobs, Path destinationDirectory) throws Exception {
 
     TransferManagerConfig transferManagerConfig = TransferManagerConfig.newBuilder().build();
-    try (TransferManager transferManager =
-        transferManagerConfig.getService()) {
+    try (TransferManager transferManager = transferManagerConfig.getService()) {
       ParallelDownloadConfig parallelDownloadConfig =
           ParallelDownloadConfig.newBuilder()
               .setBucketName(bucketName)

--- a/samples/snippets/src/main/java/com/example/storage/transfermanager/DownloadMany.java
+++ b/samples/snippets/src/main/java/com/example/storage/transfermanager/DownloadMany.java
@@ -30,8 +30,9 @@ class DownloadMany {
   public static void downloadManyBlobs(
       String bucketName, List<BlobInfo> blobs, Path destinationDirectory) throws Exception {
 
+    TransferManagerConfig transferManagerConfig = TransferManagerConfig.newBuilder().build();
     try (TransferManager transferManager =
-        TransferManagerConfig.newBuilder().build().getService()) {
+        transferManagerConfig.getService()) {
       ParallelDownloadConfig parallelDownloadConfig =
           ParallelDownloadConfig.newBuilder()
               .setBucketName(bucketName)

--- a/samples/snippets/src/main/java/com/example/storage/transfermanager/UploadDirectory.java
+++ b/samples/snippets/src/main/java/com/example/storage/transfermanager/UploadDirectory.java
@@ -17,11 +17,11 @@
 package com.example.storage.transfermanager;
 
 // [START storage_transfer_manager_upload_directory]
+
 import com.google.cloud.storage.transfermanager.ParallelUploadConfig;
 import com.google.cloud.storage.transfermanager.TransferManager;
 import com.google.cloud.storage.transfermanager.TransferManagerConfig;
 import com.google.cloud.storage.transfermanager.UploadResult;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -31,26 +31,28 @@ import java.util.stream.Stream;
 class UploadDirectory {
 
   public static void uploadDirectoryContents(String bucketName, Path sourceDirectory)
-      throws IOException {
-    TransferManager transferManager = TransferManagerConfig.newBuilder().build().getService();
-    ParallelUploadConfig parallelUploadConfig =
-        ParallelUploadConfig.newBuilder().setBucketName(bucketName).build();
+      throws Exception {
+    TransferManagerConfig transferManagerConfig = TransferManagerConfig.newBuilder().build();
+    try (TransferManager transferManager = transferManagerConfig.getService()) {
+      ParallelUploadConfig parallelUploadConfig =
+          ParallelUploadConfig.newBuilder().setBucketName(bucketName).build();
 
-    // Create a list to store the file paths
-    List<Path> filePaths = new ArrayList<>();
-    // Get all files in the directory
-    // try-with-resource to ensure pathStream is closed
-    try (Stream<Path> pathStream = Files.walk(sourceDirectory)) {
-      pathStream.filter(Files::isRegularFile).forEach(filePaths::add);
-    }
-    List<UploadResult> results =
-        transferManager.uploadFiles(filePaths, parallelUploadConfig).getUploadResults();
-    for (UploadResult result : results) {
-      System.out.println(
-          "Upload for "
-              + result.getInput().getName()
-              + " completed with status "
-              + result.getStatus());
+      // Create a list to store the file paths
+      List<Path> filePaths = new ArrayList<>();
+      // Get all files in the directory
+      // try-with-resource to ensure pathStream is closed
+      try (Stream<Path> pathStream = Files.walk(sourceDirectory)) {
+        pathStream.filter(Files::isRegularFile).forEach(filePaths::add);
+      }
+      List<UploadResult> results =
+          transferManager.uploadFiles(filePaths, parallelUploadConfig).getUploadResults();
+      for (UploadResult result : results) {
+        System.out.println(
+            "Upload for "
+                + result.getInput().getName()
+                + " completed with status "
+                + result.getStatus());
+      }
     }
   }
 }

--- a/samples/snippets/src/main/java/com/example/storage/transfermanager/UploadMany.java
+++ b/samples/snippets/src/main/java/com/example/storage/transfermanager/UploadMany.java
@@ -21,24 +21,25 @@ import com.google.cloud.storage.transfermanager.ParallelUploadConfig;
 import com.google.cloud.storage.transfermanager.TransferManager;
 import com.google.cloud.storage.transfermanager.TransferManagerConfig;
 import com.google.cloud.storage.transfermanager.UploadResult;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
 class UploadMany {
 
-  public static void uploadManyFiles(String bucketName, List<Path> files) throws IOException {
-    TransferManager transferManager = TransferManagerConfig.newBuilder().build().getService();
-    ParallelUploadConfig parallelUploadConfig =
-        ParallelUploadConfig.newBuilder().setBucketName(bucketName).build();
-    List<UploadResult> results =
-        transferManager.uploadFiles(files, parallelUploadConfig).getUploadResults();
-    for (UploadResult result : results) {
-      System.out.println(
-          "Upload for "
-              + result.getInput().getName()
-              + " completed with status "
-              + result.getStatus());
+  public static void uploadManyFiles(String bucketName, List<Path> files) throws Exception {
+    TransferManagerConfig transferManagerConfig = TransferManagerConfig.newBuilder().build();
+    try (TransferManager transferManager = transferManagerConfig.getService()) {
+      ParallelUploadConfig parallelUploadConfig =
+          ParallelUploadConfig.newBuilder().setBucketName(bucketName).build();
+      List<UploadResult> results =
+          transferManager.uploadFiles(files, parallelUploadConfig).getUploadResults();
+      for (UploadResult result : results) {
+        System.out.println(
+            "Upload for "
+                + result.getInput().getName()
+                + " completed with status "
+                + result.getStatus());
+      }
     }
   }
 }

--- a/samples/snippets/src/test/java/com/example/storage/ConfigureRetriesTest.java
+++ b/samples/snippets/src/test/java/com/example/storage/ConfigureRetriesTest.java
@@ -57,7 +57,7 @@ public final class ConfigureRetriesTest {
   }
 
   @Test
-  public void testConfigureRetries() {
+  public void testConfigureRetries() throws Exception {
     ConfigureRetries.deleteBlob(bucketName, blobName);
     assertThat(stdOut.getCapturedOutputAsUtf8String()).contains("Deletion");
     assertThat(stdOut.getCapturedOutputAsUtf8String()).contains("successfully");

--- a/samples/snippets/src/test/java/com/example/storage/ITBucketSnippets.java
+++ b/samples/snippets/src/test/java/com/example/storage/ITBucketSnippets.java
@@ -159,7 +159,7 @@ public class ITBucketSnippets {
   }
 
   @Test
-  public void testAddBucketLabel() {
+  public void testAddBucketLabel() throws Exception {
     int oldSize = storage.get(BUCKET).getLabels().size();
     AddBucketLabel.addBucketLabel(PROJECT_ID, BUCKET, "key", "value");
     assertEquals(oldSize + 1, storage.get(BUCKET).getLabels().size());
@@ -177,7 +177,7 @@ public class ITBucketSnippets {
   }
 
   @Test
-  public void testCreateBucket() {
+  public void testCreateBucket() throws Exception {
     String newBucket = RemoteStorageHelper.generateBucketName();
     CreateBucket.createBucket(PROJECT_ID, newBucket);
     try {
@@ -189,7 +189,7 @@ public class ITBucketSnippets {
   }
 
   @Test
-  public void testCreateBucketWithStorageClassAndLocation() {
+  public void testCreateBucketWithStorageClassAndLocation() throws Exception {
     String newBucket = RemoteStorageHelper.generateBucketName();
     CreateBucketWithStorageClassAndLocation.createBucketWithStorageClassAndLocation(
         PROJECT_ID, newBucket);
@@ -211,13 +211,15 @@ public class ITBucketSnippets {
     try {
       DeleteBucket.deleteBucket(PROJECT_ID, newBucket);
       assertNull(storage.get(newBucket));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     } finally {
       storage.delete(newBucket);
     }
   }
 
   @Test
-  public void testGetBucketMetadata() {
+  public void testGetBucketMetadata() throws Exception {
     Bucket bucket =
         storage.get(BUCKET, Storage.BucketGetOption.fields(Storage.BucketField.values()));
     bucket =
@@ -262,14 +264,14 @@ public class ITBucketSnippets {
   }
 
   @Test
-  public void testListBuckets() {
+  public void testListBuckets() throws Exception {
     ListBuckets.listBuckets(PROJECT_ID);
     String snippetOutput = stdOutCaptureRule.getCapturedOutputAsUtf8String();
     assertTrue(snippetOutput.contains(BUCKET));
   }
 
   @Test
-  public void testRemoveBucketLabel() {
+  public void testRemoveBucketLabel() throws Exception {
     storage.get(BUCKET).toBuilder().setLabels(ImmutableMap.of("k", "v")).build().update();
     int oldSize = storage.get(BUCKET).getLabels().size();
     RemoveBucketLabel.removeBucketLabel(PROJECT_ID, BUCKET, "k");
@@ -477,7 +479,7 @@ public class ITBucketSnippets {
   }
 
   @Test
-  public void testSetClientEndpoint() {
+  public void testSetClientEndpoint() throws Exception {
     SetClientEndpoint.setClientEndpoint(PROJECT_ID, "https://storage.googleapis.com");
     String snippetOutput = stdOutCaptureRule.getCapturedOutputAsUtf8String();
     assertTrue(snippetOutput.contains("https://storage.googleapis.com"));
@@ -645,13 +647,15 @@ public class ITBucketSnippets {
       assertEquals(5L, (long) storage.get(tempBucket).getRetentionPeriod());
       LockRetentionPolicy.lockRetentionPolicy(PROJECT_ID, tempBucket);
       assertTrue(storage.get(tempBucket).retentionPolicyIsLocked());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     } finally {
       storage.delete(tempBucket);
     }
   }
 
   @Test
-  public void testUniformBucketLevelAccess() {
+  public void testUniformBucketLevelAccess() throws Exception {
     EnableUniformBucketLevelAccess.enableUniformBucketLevelAccess(PROJECT_ID, BUCKET);
     Bucket bucket = storage.get(BUCKET);
     assertTrue(bucket.getIamConfiguration().isUniformBucketLevelAccessEnabled());
@@ -666,7 +670,7 @@ public class ITBucketSnippets {
   }
 
   @Test
-  public void testCreateBucketWithObjectRetention() {
+  public void testCreateBucketWithObjectRetention() throws Exception {
     String tempBucket = RemoteStorageHelper.generateBucketName();
 
     try {
@@ -680,7 +684,7 @@ public class ITBucketSnippets {
   }
 
   @Test
-  public void testSetSoftDeletePolicy() {
+  public void testSetSoftDeletePolicy() throws Exception {
     String tempBucket = RemoteStorageHelper.generateBucketName();
     Bucket bucket = storage.create(BucketInfo.of(tempBucket));
     try {
@@ -696,7 +700,7 @@ public class ITBucketSnippets {
   }
 
   @Test
-  public void testDisableSoftDelete() {
+  public void testDisableSoftDelete() throws Exception {
     String tempBucket = RemoteStorageHelper.generateBucketName();
     Bucket bucket = storage.create(BucketInfo.of(tempBucket));
     try {

--- a/samples/snippets/src/test/java/com/example/storage/ITHmacSnippets.java
+++ b/samples/snippets/src/test/java/com/example/storage/ITHmacSnippets.java
@@ -111,7 +111,7 @@ public class ITHmacSnippets extends TestBase {
   }
 
   @Test
-  public void testDeleteHmacKey() {
+  public void testDeleteHmacKey() throws Exception {
     HmacKey hmacKey = storage.createHmacKey(ServiceAccount.of(HMAC_KEY_TEST_SERVICE_ACCOUNT));
     HmacKeyMetadata metadata =
         storage.updateHmacKeyState(hmacKey.getMetadata(), HmacKeyState.INACTIVE);
@@ -121,7 +121,7 @@ public class ITHmacSnippets extends TestBase {
   }
 
   @Test
-  public void testListHmacKeys() {
+  public void testListHmacKeys() throws Exception {
     // Create 2 HMAC keys
     final HmacKey one =
         storage.createHmacKey(

--- a/samples/snippets/src/test/java/com/example/storage/ITObjectSnippets.java
+++ b/samples/snippets/src/test/java/com/example/storage/ITObjectSnippets.java
@@ -106,7 +106,7 @@ public class ITObjectSnippets extends TestBase {
   @Inject public KmsFixture kmsFixture;
 
   @Test
-  public void testChangeObjectStorageClass() {
+  public void testChangeObjectStorageClass() throws Exception {
     String objectName = generator.randomObjectName();
     BlobInfo gen1 = storage.create(info(objectName), CONTENT, BlobTargetOption.doesNotExist());
     Assert.assertNotEquals(StorageClass.COLDLINE, gen1.getStorageClass());
@@ -135,7 +135,7 @@ public class ITObjectSnippets extends TestBase {
   }
 
   @Test
-  public void testDeleteObject() {
+  public void testDeleteObject() throws Exception {
     String blob = generator.randomObjectName();
     storage.create(BlobInfo.newBuilder(BlobId.of(bucket.getName(), blob)).build());
     assertNotNull(storage.get(bucket.getName(), blob));
@@ -158,7 +158,7 @@ public class ITObjectSnippets extends TestBase {
   }
 
   @Test
-  public void testDownloadObjectIntoMemory() throws IOException {
+  public void testDownloadObjectIntoMemory() throws Exception {
     String objectName = generator.randomObjectName();
     storage.create(info(objectName), CONTENT, BlobTargetOption.doesNotExist());
     DownloadObjectIntoMemory.downloadObjectIntoMemory(
@@ -195,7 +195,7 @@ public class ITObjectSnippets extends TestBase {
   }
 
   @Test
-  public void testGetObjectMetadata() {
+  public void testGetObjectMetadata() throws Exception {
     String blobName = generator.randomObjectName();
     BlobId blobId = BlobId.of(bucket.getName(), blobName);
     BlobInfo blobInfo = BlobInfo.newBuilder(blobId).setMetadata(ImmutableMap.of("k", "v")).build();
@@ -236,7 +236,7 @@ public class ITObjectSnippets extends TestBase {
   }
 
   @Test
-  public void testListObjects() {
+  public void testListObjects() throws Exception {
     String name1 = generator.randomObjectName();
     storage.create(info(name1), BlobTargetOption.doesNotExist());
     ListObjects.listObjects(GOOGLE_CLOUD_PROJECT, bucket.getName());
@@ -245,7 +245,7 @@ public class ITObjectSnippets extends TestBase {
   }
 
   @Test
-  public void testListObjectsWithPrefix() {
+  public void testListObjectsWithPrefix() throws Exception {
     String prefix = generator.randomObjectName();
     storage.create(BlobInfo.newBuilder(bucket.getName(), prefix + "a/1.txt").build());
     storage.create(BlobInfo.newBuilder(bucket.getName(), prefix + "a/b/2.txt").build());
@@ -278,7 +278,7 @@ public class ITObjectSnippets extends TestBase {
   }
 
   @Test
-  public void testAtomicMoveObject() {
+  public void testAtomicMoveObject() throws Exception {
     String blob1 = generator.randomObjectName();
     String blob2 = generator.randomObjectName();
 
@@ -291,7 +291,7 @@ public class ITObjectSnippets extends TestBase {
   }
 
   @Test
-  public void testSetObjectMetadata() {
+  public void testSetObjectMetadata() throws Exception {
     String bucketName = bucket.getName();
     String name1 = generator.randomObjectName();
     BlobInfo b1Gen1 = storage.create(BlobInfo.newBuilder(bucketName, name1).build());
@@ -312,11 +312,13 @@ public class ITObjectSnippets extends TestBase {
       byte[] expected = Files.readAllBytes(file1.getPath());
       byte[] actual = storage.readAllBytes(bucket.getName(), objectName);
       assertArrayEquals(expected, actual);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
   }
 
   @Test
-  public void testUploadObjectFromMemory() throws IOException {
+  public void testUploadObjectFromMemory() throws Exception {
     String objectName = "uploadobjectfrommemorytest";
     UploadObjectFromMemory.uploadObjectFromMemory(
         GOOGLE_CLOUD_PROJECT, bucket.getName(), objectName, STRING_CONTENT);
@@ -325,7 +327,7 @@ public class ITObjectSnippets extends TestBase {
   }
 
   @Test
-  public void testObjectCSEKOperations() throws IOException {
+  public void testObjectCSEKOperations() throws Exception {
     GenerateEncryptionKey.generateEncryptionKey();
     String snippetOutput = stdOut.getCapturedOutputAsUtf8String();
     String encryptionKey = snippetOutput.split(": ")[1].trim();
@@ -408,7 +410,7 @@ public class ITObjectSnippets extends TestBase {
   }
 
   @Test
-  public void testV4SignedURLs() throws IOException {
+  public void testV4SignedURLs() throws Exception {
     String tempObject = "test-upload-signed-url-object";
     GenerateV4PutObjectSignedUrl.generateV4PutObjectSignedUrl(
         GOOGLE_CLOUD_PROJECT, bucket.getName(), tempObject);
@@ -437,7 +439,7 @@ public class ITObjectSnippets extends TestBase {
   }
 
   @Test
-  public void testMakeObjectPublic() {
+  public void testMakeObjectPublic() throws Exception {
     String aclBlob = generator.randomObjectName();
     assertNull(
         storage
@@ -448,7 +450,7 @@ public class ITObjectSnippets extends TestBase {
   }
 
   @Test
-  public void testComposeObject() {
+  public void testComposeObject() throws Exception {
     String firstObject = generator.randomObjectName();
     String secondObject = generator.randomObjectName();
     String targetObject = generator.randomObjectName();
@@ -484,7 +486,7 @@ public class ITObjectSnippets extends TestBase {
   }
 
   @Test
-  public void testUploadKMSEncryptedObject() {
+  public void testUploadKMSEncryptedObject() throws Exception {
     String blobName = generator.randomObjectName();
     UploadKmsEncryptedObject.uploadKmsEncryptedObject(
         GOOGLE_CLOUD_PROJECT, bucket.getName(), blobName, kmsFixture.getKey1().getName());
@@ -492,7 +494,7 @@ public class ITObjectSnippets extends TestBase {
   }
 
   @Test
-  public void testBatchSetObjectMetadata() {
+  public void testBatchSetObjectMetadata() throws Exception {
     String prefix = generator.randomObjectName();
     String name1 = prefix + "/1.txt";
     String name2 = prefix + "/2.txt";
@@ -511,7 +513,7 @@ public class ITObjectSnippets extends TestBase {
   }
 
   @Test
-  public void testSetObjectRetentionPolicy() {
+  public void testSetObjectRetentionPolicy() throws Exception {
     BucketInfo bucketInfo = BucketInfo.newBuilder(generator.randomBucketName()).build();
     Bucket tmpBucket = storage.create(bucketInfo, BucketTargetOption.enableObjectRetention(true));
     String tempBucket = tmpBucket.getName();

--- a/samples/snippets/src/test/java/com/example/storage/ITStorageSnippets.java
+++ b/samples/snippets/src/test/java/com/example/storage/ITStorageSnippets.java
@@ -70,7 +70,7 @@ public class ITStorageSnippets {
   }
 
   @Test
-  public void testGetServiceAccount() {
+  public void testGetServiceAccount() throws Exception {
     GetServiceAccount.getServiceAccount(PROJECT_ID);
     String snippetOutput = stdOutCaptureRule.getCapturedOutputAsUtf8String();
 

--- a/samples/snippets/src/test/java/com/example/storage/bucket/CreateBucketDualRegionTest.java
+++ b/samples/snippets/src/test/java/com/example/storage/bucket/CreateBucketDualRegionTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class CreateBucketDualRegionTest extends TestBase {
 
   @Test
-  public void testCreateBucketDualRegion() {
+  public void testCreateBucketDualRegion() throws Exception {
     assertNotNull("Unable to determine Project ID", GOOGLE_CLOUD_PROJECT);
     String newBucket = RemoteStorageHelper.generateBucketName();
     CreateBucketDualRegion.createBucketDualRegion(

--- a/samples/snippets/src/test/java/com/example/storage/bucket/PubSubNotificationTest.java
+++ b/samples/snippets/src/test/java/com/example/storage/bucket/PubSubNotificationTest.java
@@ -110,7 +110,7 @@ public class PubSubNotificationTest extends TestBase {
   }
 
   @Test
-  public void testCreateBucketPubSubNotification() {
+  public void testCreateBucketPubSubNotification() throws Exception {
     CreateBucketPubSubNotification.createBucketPubSubNotification(
         bucketName,
         topic,
@@ -122,7 +122,7 @@ public class PubSubNotificationTest extends TestBase {
   }
 
   @Test
-  public void testDeleteBucketPubSubNotification() {
+  public void testDeleteBucketPubSubNotification() throws Exception {
     Notification notification = storage.createNotification(bucketName, notificationInfo);
     DeleteBucketPubSubNotification.deleteBucketPubSubNotification(
         bucketName, notification.getNotificationId());
@@ -131,7 +131,7 @@ public class PubSubNotificationTest extends TestBase {
   }
 
   @Test
-  public void testNotificationNotFound() {
+  public void testNotificationNotFound() throws Exception {
     Notification notification = storage.createNotification(bucketName, notificationInfo);
     // Do a delete first.
     storage.deleteNotification(bucketName, notification.getNotificationId());
@@ -142,14 +142,14 @@ public class PubSubNotificationTest extends TestBase {
   }
 
   @Test
-  public void testListBucketPubSubNotification() {
+  public void testListBucketPubSubNotification() throws Exception {
     storage.createNotification(bucketName, notificationInfo);
     ListPubSubNotifications.listPubSubNotifications(bucketName);
     assertThat(stdOut.getCapturedOutputAsUtf8String()).contains(topic);
   }
 
   @Test
-  public void testPrintBucketPubSubNotification() {
+  public void testPrintBucketPubSubNotification() throws Exception {
     Notification notification = storage.createNotification(bucketName, notificationInfo);
     PrintPubSubNotification.printPubSubNotification(bucketName, notification.getNotificationId());
     assertThat(stdOut.getCapturedOutputAsUtf8String()).contains(topic);

--- a/samples/snippets/src/test/java/com/example/storage/object/AddBlobOwnerTest.java
+++ b/samples/snippets/src/test/java/com/example/storage/object/AddBlobOwnerTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 public class AddBlobOwnerTest extends TestBase {
 
   @Test
-  public void testAddBlobOwner() {
+  public void testAddBlobOwner() throws Exception {
     // Check for user email before the actual test.
     assertWithMessage("Unable to determine user email").that(IT_SERVICE_ACCOUNT_EMAIL).isNotEmpty();
 

--- a/samples/snippets/src/test/java/com/example/storage/object/DownloadBytesRangeTest.java
+++ b/samples/snippets/src/test/java/com/example/storage/object/DownloadBytesRangeTest.java
@@ -37,7 +37,7 @@ public class DownloadBytesRangeTest extends TestBase {
   @Rule public final TemporaryFolder tmp = new TemporaryFolder();
 
   @Test
-  public void testDownloadByteRange() throws IOException {
+  public void testDownloadByteRange() throws Exception {
     byte[] bytes = { // 18 elements per row
       'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
       's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',

--- a/samples/snippets/src/test/java/com/example/storage/object/DownloadBytesRangeTest.java
+++ b/samples/snippets/src/test/java/com/example/storage/object/DownloadBytesRangeTest.java
@@ -24,7 +24,6 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage.BlobTargetOption;
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;

--- a/samples/snippets/src/test/java/com/example/storage/object/PrintBlobAclTest.java
+++ b/samples/snippets/src/test/java/com/example/storage/object/PrintBlobAclTest.java
@@ -33,7 +33,7 @@ public class PrintBlobAclTest extends TestBase {
   public static final String IT_SERVICE_ACCOUNT_EMAIL = Env.IT_SERVICE_ACCOUNT_EMAIL;
 
   @Test
-  public void testPrintBlobAcls() {
+  public void testPrintBlobAcls() throws Exception {
     // Check for user email before the actual test.
     assertWithMessage("Unable to determine user email").that(IT_SERVICE_ACCOUNT_EMAIL).isNotEmpty();
 

--- a/samples/snippets/src/test/java/com/example/storage/object/RemoveBlobOwnerTest.java
+++ b/samples/snippets/src/test/java/com/example/storage/object/RemoveBlobOwnerTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 public class RemoveBlobOwnerTest extends TestBase {
 
   @Test
-  public void testRemoveBlobOwner() {
+  public void testRemoveBlobOwner() throws Exception {
     // Check for user email before the actual test.
     assertWithMessage("Unable to determine user email").that(IT_SERVICE_ACCOUNT_EMAIL).isNotEmpty();
 
@@ -50,7 +50,7 @@ public class RemoveBlobOwnerTest extends TestBase {
   }
 
   @Test
-  public void testUserNotFound() {
+  public void testUserNotFound() throws Exception {
     // Check for user email before the actual test.
     assertWithMessage("Unable to determine user email").that(IT_SERVICE_ACCOUNT_EMAIL).isNotEmpty();
 

--- a/samples/snippets/src/test/java/com/example/storage/transfermanager/ITTransferManagerSamples.java
+++ b/samples/snippets/src/test/java/com/example/storage/transfermanager/ITTransferManagerSamples.java
@@ -29,7 +29,6 @@ import com.google.cloud.storage.Storage.BlobTargetOption;
 import com.google.cloud.storage.TmpFile;
 import com.google.cloud.storage.it.TemporaryBucket;
 import com.google.common.collect.ImmutableList;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;

--- a/samples/snippets/src/test/java/com/example/storage/transfermanager/ITTransferManagerSamples.java
+++ b/samples/snippets/src/test/java/com/example/storage/transfermanager/ITTransferManagerSamples.java
@@ -119,7 +119,7 @@ public class ITTransferManagerSamples extends TestBase {
   }
 
   @Test
-  public void uploadAllowPCU() throws IOException {
+  public void uploadAllowPCU() throws Exception {
     Path baseDir = uploadDirectory.getRoot().toPath();
     try (TmpFile file1 = DataGenerator.base64Characters().tempFile(baseDir, 313 * 1024 * 1024)) {
       AllowParallelCompositeUpload.parallelCompositeUploadAllowed(


### PR DESCRIPTION
All Storage and TransferManager instances now have try-with-resource around them.

* chore: run mvn com.spotify.fmt:fmt-maven-plugin:format


The vast majority of the lines changed in here are whitespace due to additional indentation after using the try-with-resources. I did not change any logic of any of the tests or samples themselves.