### PR TITLE
fix: fix appendable upload finalization race condition

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BidiAppendableUnbufferedWritableByteChannel.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BidiAppendableUnbufferedWritableByteChannel.java
@@ -145,6 +145,7 @@ final class BidiAppendableUnbufferedWritableByteChannel implements UnbufferedWri
     // those bytes to implicitly flag as dirty.
     rewindableContent.flagDirty();
 
+    long remainingAfterPacking = Buffers.totalRemaining(srcs, srcsOffset, srcsLength);
     long bytesConsumed = 0;
     for (int i = 0, len = data.length, lastIdx = len - 1; i < len; i++) {
       ChunkSegment datum = data[i];
@@ -153,7 +154,7 @@ final class BidiAppendableUnbufferedWritableByteChannel implements UnbufferedWri
       boolean appended;
       if (i < lastIdx && !shouldFlush) {
         appended = stream.append(datum);
-      } else if (i == lastIdx && nextWriteShouldFinalize) {
+      } else if (i == lastIdx && remainingAfterPacking == 0 && nextWriteShouldFinalize) {
         appended = stream.appendAndFinalize(datum);
       } else {
         appended = stream.appendAndFlush(datum);

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/BidiUploadState.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/BidiUploadState.java
@@ -835,8 +835,7 @@ abstract class BidiUploadState {
           finishWriteOffset,
           totalSentBytes,
           confirmedBytes,
-          size
-        );
+          size);
     }
 
     protected final boolean internalOffer(BidiWriteObjectRequest e) {

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BidiAppendableUnbufferedWritableByteChannelTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BidiAppendableUnbufferedWritableByteChannelTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static com.google.cloud.storage.StorageV2ProtoUtils.fmtProto;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.grpc.GrpcCallContext;
+import com.google.cloud.storage.BidiUploadState.AppendableUploadState;
+import com.google.cloud.storage.ITAppendableUploadFakeTest.FakeStorage;
+import com.google.cloud.storage.it.ChecksummedTestContent;
+import com.google.common.collect.ImmutableList;
+import com.google.storage.v2.BidiWriteObjectResponse;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.time.OffsetDateTime;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class BidiAppendableUnbufferedWritableByteChannelTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BidiAppendableUnbufferedWritableByteChannelTest.class);
+  @Rule public final TestName testName = new TestName();
+
+  @Test
+  public void appendAndFinalizeOnlyPerformedIfAllBytesConsumed() throws IOException {
+    ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+    ChecksummedTestContent ctc = ChecksummedTestContent.gen(27);
+    AppendableUploadState state =
+        BidiUploadState.appendableNew(
+            BidiUploadTest.appendRequestNew,
+            GrpcCallContext::createDefault,
+            16,
+            SettableApiFuture.create(),
+            Crc32cValue.zero());
+    AtomicLong finishWriteOffset = new AtomicLong(-1);
+    BidiUploadStreamingStream stream = new BidiUploadStreamingStream(
+        state,
+        executor,
+        BidiUploadTestUtils.adaptOnlySend(respond -> request -> executor.submit(() -> {
+          LOGGER.info("request = {}", fmtProto(request));
+          switch ((int) request.getWriteOffset()) {
+            case 0:
+              respond.onResponse(BidiUploadTest.resourceWithSize(0));
+              break;
+            case 4:
+            case 8:
+              // do not ack any bytes until we receive 16, this simulates latency on the bytes being
+              // ack'd.
+              break;
+            case 12:
+              respond.onResponse(BidiUploadTestUtils.incremental(8));
+              break;
+            case 16:
+              respond.onResponse(BidiUploadTestUtils.incremental(12));
+              break;
+            case 20:
+              respond.onResponse(BidiUploadTestUtils.incremental(16));
+              break;
+            case 24:
+              BidiWriteObjectResponse.Builder b = BidiUploadTest.resourceFor(ctc).toBuilder();
+              b.getResourceBuilder().setFinalizeTime(Conversions.grpc().timestampCodec.encode(
+                  OffsetDateTime.now()
+              ));
+              respond.onResponse(b.build());
+              break;
+            default:
+              respond.onError(FakeStorage.unexpectedRequest(request, ImmutableList.of()));
+              break;
+          }
+          if (request.getFinishWrite()) {
+            finishWriteOffset.set(request.getWriteOffset() + request.getChecksummedData().getContent().size());
+          }
+        })),
+        3,
+        RetryContext.neverRetry()
+    );
+    ChunkSegmenter chunkSegmenter = new ChunkSegmenter(
+        Hasher.enabled(),
+        ByteStringStrategy.copy(),
+        4,
+        2
+    );
+    BidiAppendableUnbufferedWritableByteChannel channel = new BidiAppendableUnbufferedWritableByteChannel(
+        stream,
+        chunkSegmenter,
+        4,
+        0
+    );
+
+    ByteBuffer buf = ctc.asByteBuffer();
+    int written1 = channel.write(buf);
+    // fill up the outbound queue
+    assertThat(written1).isEqualTo(16);
+
+    // asynchronously bytes will be ack'd 4 at a time, eventually there will be enough space in the
+    // outbound queue to allow writeAndClose to start consuming bytes.
+    channel.nextWriteShouldFinalize();
+    int written2 = channel.writeAndClose(buf);
+    assertThat(written2).isEqualTo(11);
+    assertThat(finishWriteOffset.get()).isEqualTo(ctc.length());
+  }
+}

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BidiUploadTest.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BidiUploadTest.java
@@ -1837,7 +1837,6 @@ public final class BidiUploadTest {
         exec1.shutdownNow();
       }
     }
-
   }
 
   public static final class BidiUploadStreamingStreamResponseObserverTest {
@@ -2234,5 +2233,4 @@ public final class BidiUploadTest {
     }
     return BidiWriteObjectResponse.newBuilder().setResource(f.apply(b)).build();
   }
-
 }

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/BidiUploadTestUtils.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/BidiUploadTestUtils.java
@@ -48,8 +48,6 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.function.Function;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class BidiUploadTestUtils {
 
@@ -154,7 +152,6 @@ final class BidiUploadTestUtils {
         });
   }
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(BidiUploadTestUtils.class);
   /**
    * BidiStreamingCallable isn't functional even though it's a single abstract method.
    *
@@ -166,10 +163,10 @@ final class BidiUploadTestUtils {
    */
   static <ReqT, ResT> BidiStreamingCallable<ReqT, ResT> adapt(
       TriFunc<
-          ResponseObserver<ResT>,
-          ClientStreamReadyObserver<ReqT>,
-          ApiCallContext,
-          ClientStream<ReqT>>
+              ResponseObserver<ResT>,
+              ClientStreamReadyObserver<ReqT>,
+              ApiCallContext,
+              ClientStream<ReqT>>
           func) {
     return new BidiStreamingCallable<ReqT, ResT>() {
       @Override
@@ -177,28 +174,7 @@ final class BidiUploadTestUtils {
           ResponseObserver<ResT> respond,
           ClientStreamReadyObserver<ReqT> onReady,
           ApiCallContext context) {
-        return func.apply(new ResponseObserver<ResT>() {
-          @Override
-          public void onStart(StreamController controller) {
-            respond.onStart(controller);
-          }
-
-          @Override
-          public void onResponse(ResT response) {
-            LOGGER.info("response = {}", fmtProto(response));
-            respond.onResponse(response);
-          }
-
-          @Override
-          public void onError(Throwable t) {
-            respond.onError(t);
-          }
-
-          @Override
-          public void onComplete() {
-            respond.onComplete();
-          }
-        }, onReady, context);
+        return func.apply(respond, onReady, context);
       }
     };
   }


### PR DESCRIPTION
When finalizing an appendable upload depending on how quickly gcs is acking bytes, we could run into a case where finish_write: true was sent before all bytes had been enqueued.

Regression introduced in 2.57.0