### PR TITLE
fix: add case insensitive check for X-Goog-Content-SHA256 in SignatureInfo

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/SignatureInfo.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/SignatureInfo.java
@@ -170,7 +170,13 @@ public class SignatureInfo {
         .append(serializer.serializeHeaderNames(canonicalizedExtensionHeaders))
         .append(COMPONENT_SEPARATOR);
 
-    String userProvidedHash = canonicalizedExtensionHeaders.get("X-Goog-Content-SHA256");
+    String userProvidedHash = null;
+    for (Map.Entry<String, String> entry : canonicalizedExtensionHeaders.entrySet()) {
+      if ("X-Goog-Content-SHA256".equalsIgnoreCase(entry.getKey())) {
+        userProvidedHash = entry.getValue();
+        break;
+      }
+    }
     canonicalRequest.append(userProvidedHash == null ? "UNSIGNED-PAYLOAD" : userProvidedHash);
 
     return Hashing.sha256()


### PR DESCRIPTION
Fixes b/450079023
Based on this bug, the x-goog-content-sha256 header was not being correctly included in the V4 signature, leading to SignatureDoesNotMatch error. The issue was caused by a case-sensitive get() on the headers map, which failed to find the user-provided lowercase header.
Added a case insensitive check and a corresponding test to verify the fix
