### PR TITLE
test: switch to using 127.0.0.1 instead of localhost for Fake{,Http}Server

### DIFF
--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/FakeHttpServer.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/FakeHttpServer.java
@@ -70,7 +70,7 @@ final class FakeHttpServer implements AutoCloseable {
   static FakeHttpServer of(HttpRequestHandler server) {
     // based on
     // https://github.com/netty/netty/blob/59aa6e635b9996cf21cd946e64353270679adc73/example/src/main/java/io/netty/example/http/helloworld/HttpHelloWorldServer.java
-    InetSocketAddress address = new InetSocketAddress("localhost", 0);
+    InetSocketAddress address = new InetSocketAddress("127.0.0.1", 0);
     // Configure the server.
     EventLoopGroup bossGroup = new NioEventLoopGroup(1);
     EventLoopGroup workerGroup = new NioEventLoopGroup();

--- a/google-cloud-storage/src/test/java/com/google/cloud/storage/FakeServer.java
+++ b/google-cloud-storage/src/test/java/com/google/cloud/storage/FakeServer.java
@@ -54,7 +54,7 @@ final class FakeServer implements AutoCloseable {
   }
 
   static FakeServer of(StorageGrpc.StorageImplBase service) throws IOException {
-    InetSocketAddress address = new InetSocketAddress("localhost", 0);
+    InetSocketAddress address = new InetSocketAddress("127.0.0.1", 0);
     Server server = NettyServerBuilder.forAddress(address).addService(service).build();
     server.start();
     String endpoint = String.format(Locale.US, "%s:%d", address.getHostString(), server.getPort());


### PR DESCRIPTION
We're seeing build hangs when running some integration tests that leverage the fake servers.

Trying to see if switching to using IP address makes things more reliable.
