### PR TITLE
build: move hermetic_library_generation filtering logic into the steps rather than on.pull_request

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -15,8 +15,6 @@
 
 set -eo pipefail
 
-exit 37
-
 ## Get the directory of the build script
 scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
 ## cd to the parent directory, i.e. the root of the git repo


### PR DESCRIPTION
When filtering with on.pull_request the workflow will not report a status if it does not match. This causes contention with this workflow being declared as a required status. To sidestep this, move the matching logic into the steps of the workflow, similar to how we filter out PRs from forks.