### PR TITLE
chore: add release-please config for protobuf-4.x

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -68,7 +68,7 @@ branches:
     branch: 2.49.x
   - bumpMinorPreMajor: true
     handleGHRelease: true
-    releaseType: java-backport
+    releaseType: java-yoshi
     extraFiles:
       - README.md
       - .readme-partials.yaml


### PR DESCRIPTION
[go/cloud-java:protobuf-4.x-upgrade](http://goto.google.com/cloud-java:protobuf-4.x-upgrade)

Config in https://github.com/googleapis/java-storage/blob/protobuf-4.x-rc/release-please-config.json