### PR TITLE
chore: cleanup release-please config

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -5,25 +5,25 @@ extraFiles:
     - README.md
     - .readme-partials.yaml
 branches:
-    - releaseType: java-lts
-      branch: 1.113.14-sp
+    - branch: 1.113.14-sp
+      releaseType: java-lts
     - branch: 1.106.1-patch
     - branch: 1.111.3-patch
     - branch: java7
     - branch: 2.1.x
-    - releaseType: java-backport
-      branch: 2.6.x
-    - releaseType: java-backport
-      branch: 2.15.x
-    - releaseType: java-backport
-      branch: 2.22.x
-    - releaseType: java-backport
-      branch: 2.30.x
-    - releaseType: java-backport
-      branch: 2.38.x
-    - releaseType: java-backport
-      branch: 2.47.x
-    - releaseType: java-backport
-      branch: 2.49.x
+    - branch: 2.6.x
+      releaseType: java-backport
+    - branch: 2.15.x
+      releaseType: java-backport
+    - branch: 2.22.x
+      releaseType: java-backport
+    - branch: 2.30.x
+      releaseType: java-backport
+    - branch: 2.38.x
+      releaseType: java-backport
+    - branch: 2.47.x
+      releaseType: java-backport
+    - branch: 2.49.x
+      releaseType: java-backport
     - branch: protobuf-4.x-rc
       manifest: true


### PR DESCRIPTION
This PR cleans up the .github/release-please.yml file by removing redundant options and the bump-minor-pre-major setting for major releases.