### PR TITLE
feat: add default e2e checksum validation in the last call of resumable uploads

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSession.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableSession.java
@@ -37,11 +37,14 @@ final class JsonResumableSession {
   private final RetrierWithAlg retrier;
   private final JsonResumableWrite resumableWrite;
 
+  private final JsonResumableWriteCtx jsonResumableWriteCtx;
+
   JsonResumableSession(
       HttpClientContext context, RetrierWithAlg retrier, JsonResumableWrite resumableWrite) {
     this.context = context;
     this.retrier = retrier;
     this.resumableWrite = resumableWrite;
+    this.jsonResumableWriteCtx = new JsonResumableWriteCtx();
   }
 
   /**
@@ -55,7 +58,8 @@ final class JsonResumableSession {
   ResumableOperationResult<@Nullable StorageObject> put(
       RewindableContent content, HttpContentRange contentRange) {
     JsonResumableSessionPutTask task =
-        new JsonResumableSessionPutTask(context, resumableWrite, content, contentRange);
+        new JsonResumableSessionPutTask(
+            context, resumableWrite, content, contentRange, jsonResumableWriteCtx);
     HttpRpcContext httpRpcContext = HttpRpcContext.getInstance();
     try {
       httpRpcContext.newInvocationId();

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableWriteCtx.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/JsonResumableWriteCtx.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+final class JsonResumableWriteCtx {
+
+  private Crc32cValue.Crc32cLengthKnown cumulativeCrc32c;
+
+  JsonResumableWriteCtx() {
+    this.cumulativeCrc32c = Crc32cValue.zero();
+  }
+
+  /** Calculates the hypothetical total checksum using the provided chunk CRC. */
+  Crc32cValue.Crc32cLengthKnown peekCumulative(Crc32cValue.Crc32cLengthKnown chunkCrc) {
+    if (chunkCrc != null) {
+      return cumulativeCrc32c.concat(chunkCrc);
+    }
+    return cumulativeCrc32c;
+  }
+
+  /** Updates the persistent state using the provided chunk CRC. */
+  void commit(Crc32cValue.Crc32cLengthKnown chunkCrc) {
+    if (chunkCrc != null) {
+      this.cumulativeCrc32c = this.cumulativeCrc32c.concat(chunkCrc);
+    }
+  }
+}

--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/StorageRpc.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/StorageRpc.java
@@ -81,6 +81,7 @@ public interface StorageRpc extends ServiceRpc {
     INCLUDE_TRAILING_DELIMITER("includeTrailingDelimiter"),
     X_UPLOAD_CONTENT_LENGTH("x-upload-content-length"),
     OBJECT_FILTER("objectFilter"),
+    X_GOOG_HASH("x-goog-hash"),
     /**
      * An {@link com.google.common.collect.ImmutableMap ImmutableMap&lt;String, String>} of values
      * which will be set as additional headers on the request.


### PR DESCRIPTION
Modified the final api call of resumable uploads to include the "x-goog-hash" header for e2e checksum validation on the json path.

Fixes: b/461983980