### PR TITLE
chore: fix for failing library generation check in forks

### DIFF
--- a/.github/workflows/hermetic_library_generation.yaml
+++ b/.github/workflows/hermetic_library_generation.yaml
@@ -38,6 +38,7 @@ jobs:
         fetch-depth: 0
         token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
     - name: is applicable
+      if: env.SHOULD_RUN == 'true' 
       env:
         # set our branch names to be the names in the "origin" remote since we aren't actually checking these branches out
         base_ref: origin/${{ github.base_ref }}


### PR DESCRIPTION
Library generation test is failing for fork prs with error "Fatal: not a git repository (or any of the parent directories): .git"
Modifying to run the is_applicable step only if the repo is not a fork. 