### PR TITLE
chore: replace old partner teams with updated names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,11 +4,11 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/gcs-sdk-team is the default owner for changes in this repo
-*                       @googleapis/cloud-sdk-java-team @googleapis/gcs-sdk-team
+# The @googleapis/gcs-team is the default owner for changes in this repo
+*                       @googleapis/cloud-sdk-java-team @googleapis/gcs-team
 
 # for handwritten libraries, keep codeowner_team in .repo-metadata.json as owner
-**/*.java               @googleapis/gcs-sdk-team
+**/*.java               @googleapis/gcs-team
 
 
 # The java-samples-reviewers team is the default owner for samples changes

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -219,5 +219,5 @@ permissionRules:
     permission: admin
   - team: yoshi-java-admins
     permission: admin
-  - team: yoshi-java
+  - team: cloud-sdk-java-team
     permission: push

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -13,7 +13,7 @@
   "api_id": "storage.googleapis.com",
   "library_type": "GAPIC_COMBO",
   "requires_billing": true,
-  "codeowner_team": "@googleapis/gcs-sdk-team",
+  "codeowner_team": "@googleapis/gcs-team",
   "excluded_poms": "google-cloud-storage-bom,google-cloud-storage",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559782",
   "extra_versioned_modules": "gapic-google-cloud-storage-v2",

--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -13,7 +13,7 @@ libraries:
     repo: googleapis/java-storage
     repo_short: java-storage
     distribution_name: com.google.cloud:google-cloud-storage
-    codeowner_team: '@googleapis/gcs-sdk-team'
+    codeowner_team: '@googleapis/gcs-team'
     api_id: storage.googleapis.com
     requires_billing: true
     library_type: GAPIC_COMBO


### PR DESCRIPTION
This PR replaces @googleapis/gcs-sdk-team with @googleapis/gcs-team and @googleapis/yoshi-java with @googleapis/cloud-sdk-java-team. b/478003109