### PR TITLE
chore: modify documentation to include failure scenario

### DIFF
--- a/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
+++ b/google-cloud-storage/src/main/java/com/google/cloud/storage/Storage.java
@@ -4045,6 +4045,8 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
   /**
    * Returns the requested bucket or {@code null} if not found.
    *
+   * <p>Note: A {@link StorageException} is thrown in case of any failure.
+   *
    * <p>Accepts an optional userProject {@link BucketGetOption} option which defines the project id
    * to assign operational costs.
    *
@@ -4066,6 +4068,8 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
   /**
    * Locks bucket retention policy. Requires a local metageneration value in the request. Review
    * example below.
+   *
+   * <p>Note: A {@link StorageException} is thrown in case of any failure.
    *
    * <p>Accepts an optional userProject {@link BucketTargetOption} option which defines the project
    * id to assign operational costs.
@@ -4090,6 +4094,8 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
   /**
    * Returns the requested blob or {@code null} if not found.
    *
+   * <p>Note: A {@link StorageException} is thrown in case of any failure.
+   *
    * <p>Accepts an optional userProject {@link BlobGetOption} option which defines the project id to
    * assign operational costs.
    *
@@ -4111,6 +4117,8 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
 
   /**
    * Returns the requested blob or {@code null} if not found.
+   *
+   * <p>Note: A {@link StorageException} is thrown in case of any failure.
    *
    * <p>Accepts an optional userProject {@link BlobGetOption} option which defines the project id to
    * assign operational costs.
@@ -4148,6 +4156,8 @@ public interface Storage extends Service<StorageOptions>, AutoCloseable {
 
   /**
    * Returns the requested blob or {@code null} if not found.
+   *
+   * <p>Note: A {@link StorageException} is thrown in case of any failure.
    *
    * <p>Example of getting information on a blob.
    *


### PR DESCRIPTION
This PR updates the Javadoc for Storage.get and related methods to clarify that a StorageException is thrown for any failure.
This is to remove confusion over when the method returns null versus when it throws an exception. Specifically, while the methods return null if a resource is definitively not found (HTTP 404), they throw a StorageException for other issues such as missing permissions (HTTP 403).